### PR TITLE
Fix/dropdown not closing after block/unblock confirmation

### DIFF
--- a/frontend/src/components/user-table.tsx
+++ b/frontend/src/components/user-table.tsx
@@ -165,6 +165,10 @@ const UserRow: React.FC<UserRowProps> = ({
 }) => {
   const isBlocked = u.isBlocked || false;
 
+  //expert block/unblock modal state
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
   const { goToExpertDashboard } = useNavigateToExpertDashboard();
   const handleExpertClick = async (userdetails: any) => {
     if (userdetails) {
@@ -289,7 +293,7 @@ const UserRow: React.FC<UserRowProps> = ({
       {/* Actions */}
       <TableCell className="align-middle w-32">
         <div className="flex justify-center">
-          <DropdownMenu>
+          <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
             <DropdownMenuTrigger asChild>
               <Button size="sm" variant="outline" className="p-1">
                 <MoreVertical className="w-4 h-4" />
@@ -312,9 +316,20 @@ const UserRow: React.FC<UserRowProps> = ({
                   e.preventDefault();
                   setUserIdToBlock(u._id!);
                   setIsCurrentlyBlocked(isBlocked!);
+                  setIsOpen(false);
+                  setIsConfirmOpen(true);
                 }}
               >
-                <ConfirmationModal
+                <button className="flex justify-center items-center gap-2">
+                      <Trash className="w-4 h-4 mr-2 text-red-500" />
+                      {isBlocked ? "Unblock" : "Block"}
+                    </button>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <ConfirmationModal
+                  open={isConfirmOpen}
+                  onOpenChange={setIsConfirmOpen}
                   title={isBlocked ? "Unblock the User?" : "Block the User?"}
                   description={
                     isBlocked
@@ -324,17 +339,11 @@ const UserRow: React.FC<UserRowProps> = ({
                   confirmText={isBlocked ? "Unblock" : "Block"}
                   cancelText="Cancel"
                   type={isBlocked ? "default" : "delete"}
-                  onConfirm={handleBlock}
-                  trigger={
-                    <button className="flex justify-center items-center gap-2">
-                      <Trash className="w-4 h-4 mr-2 text-red-500" />
-                      {isBlocked ? "Unblock" : "Block"}
-                    </button>
-                  }
+                  onConfirm={() => {
+                    handleBlock()
+                    setIsConfirmOpen(false) 
+                  }}
                 />
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
         </div>
       </TableCell>
     </TableRow>

--- a/frontend/src/components/user-table.tsx
+++ b/frontend/src/components/user-table.tsx
@@ -77,7 +77,7 @@ export const UsersTable = ({
               <TableHead className="text-center w-52">Email</TableHead>
               <TableHead className="text-center w-32">State</TableHead>
               <TableHead className="text-center w-24">
-              Pending WorkLoad
+                Pending WorkLoad
               </TableHead>
               <TableHead className="text-center w-24">Incentive</TableHead>
               <TableHead className="text-center w-24">Penalty</TableHead>
@@ -321,29 +321,29 @@ const UserRow: React.FC<UserRowProps> = ({
                 }}
               >
                 <button className="flex justify-center items-center gap-2">
-                      <Trash className="w-4 h-4 mr-2 text-red-500" />
-                      {isBlocked ? "Unblock" : "Block"}
-                    </button>
+                  <Trash className="w-4 h-4 mr-2 text-red-500" />
+                  {isBlocked ? "Unblock" : "Block"}
+                </button>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
           <ConfirmationModal
-                  open={isConfirmOpen}
-                  onOpenChange={setIsConfirmOpen}
-                  title={isBlocked ? "Unblock the User?" : "Block the User?"}
-                  description={
-                    isBlocked
-                      ? "This will restore the expert’s access to the review system and allow them to participate in reviews again. Are you sure you want to unblock this user?"
-                      : "Blocking this expert will restrict their access to the review system until they are unblocked. Once blocked, they will no longer be able to review, submit answers, or perform any actions within the platform. They will also be excluded from all current and future allocations. Are you sure you want to proceed?"
-                  }
-                  confirmText={isBlocked ? "Unblock" : "Block"}
-                  cancelText="Cancel"
-                  type={isBlocked ? "default" : "delete"}
-                  onConfirm={() => {
-                    handleBlock()
-                    setIsConfirmOpen(false) 
-                  }}
-                />
+            open={isConfirmOpen}
+            onOpenChange={setIsConfirmOpen}
+            title={isBlocked ? "Unblock the User?" : "Block the User?"}
+            description={
+              isBlocked
+                ? "This will restore the expert’s access to the review system and allow them to participate in reviews again. Are you sure you want to unblock this user?"
+                : "Blocking this expert will restrict their access to the review system until they are unblocked. Once blocked, they will no longer be able to review, submit answers, or perform any actions within the platform. They will also be excluded from all current and future allocations. Are you sure you want to proceed?"
+            }
+            confirmText={isBlocked ? "Unblock" : "Block"}
+            cancelText="Cancel"
+            type={isBlocked ? "default" : "delete"}
+            onConfirm={() => {
+              handleBlock();
+              setIsConfirmOpen(false);
+            }}
+          />
         </div>
       </TableCell>
     </TableRow>


### PR DESCRIPTION
**Description**

 The action dropdown stayed open after selecting Block / Unblock.

**Changes**

- Controlled dropdown open state
- Closed dropdown on action select
- Opened confirmation modal via state
- Moved modal outside dropdown

**Before**

- Dropdown remained open after user confirmation

<img width="1863" height="704" alt="before" src="https://github.com/user-attachments/assets/2342e126-cbb1-43fc-9506-e7a5dd09f431" />


**After**

- Dropdown closes properly after user confirmation

<img width="1844" height="726" alt="after" src="https://github.com/user-attachments/assets/4db56f11-622d-4f93-8a6b-c9da3f2b3307" />
