### PR TITLE
fix: adjust ranking display when expert becomes moderator

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
@@ -688,6 +688,7 @@ export class UserRepository implements IUserRepository {
       const result = await this.usersCollection.aggregate([
         
         /** ✅ Add isBlocked field default (if not exists) */
+        { $match: matchQuery },
         {
           $addFields: {
             isBlocked: { $ifNull: ["$isBlocked", false] },
@@ -794,7 +795,6 @@ export class UserRepository implements IUserRepository {
             ...selectedSort 
           } 
         },
-        { $match: matchQuery },
       
         /** Pagination */
         {


### PR DESCRIPTION
### What this PR does
- Updates the aggregation logic to handle ranking display when an expert becomes a moderator.

### Why
Previously, when an expert was promoted to moderator:
- The moderator role is expected not to have a ranking.
- The rank the user held as an expert was also disappearing, which caused confusion.

This change ensures that the system correctly reflects expected behavior: 
- The rank display will show properly