### PR TITLE
fixed incomplete tags in expert history

### DIFF
--- a/frontend/src/components/ExpertHistory.tsx
+++ b/frontend/src/components/ExpertHistory.tsx
@@ -458,6 +458,13 @@ export default function UserActivityHistory({
                             )}
                           </span>
                         </Badge>
+                        {item.activityType === "reroute" && (
+                          <div className="sm:ml-auto ml-0">
+                            <Badge variant="outline" className="rounded-full bg-indigo-100 text-indigo-700 border-indigo-200 text-xs px-2 py-1">
+                              <span className="uppercase font-semibold">ReRoute</span>
+                            </Badge>
+                          </div>
+                        )}
                       </div>
                     </div>
 

--- a/frontend/src/components/ExpertHistory.tsx
+++ b/frontend/src/components/ExpertHistory.tsx
@@ -414,12 +414,12 @@ export default function UserActivityHistory({
                                 <span>ReRouted</span>
                               </>
                             )}
-                            {item.action === "accepted" || item.action ==='approved' ||item.action==='reroute_approved' && (
+                            {(item.action === "accepted" || item.action === 'approved' || item.action === 'reroute_approved') && (
                               <>
                                 <CheckCircle className="w-3 h-3 text-green-600 dark:text-green-400" />
                                 <span>Accepted</span>
                               </>
-                            )}
+                            )} 
                             {(item.action === "rejected" ||item.action==='reroute_rejected') && (
                               <>
                                 <XCircle className="w-3 h-3 text-red-600 dark:text-red-400" />
@@ -444,7 +444,7 @@ export default function UserActivityHistory({
                                 <span> Expert Rejected</span>
                               </>
                             )}
-                            {item.action === "modified" ||item.action==='reroute_modified' && (
+                            {(item.action === "modified" || item.action === 'reroute_modified') && (
                               <>
                                 <Pencil className="w-3 h-3 text-orange-700 dark:text-orange-400" />
                                 <span>Modified</span>


### PR DESCRIPTION
In expert history, the cards that are getting shown for submission and assigned questions have tags showing the status, which were being rendered incomplete because of some conditioning issue. Fixed that.