### PR TITLE
Fix/auth redirect after login

### DIFF
--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,4 +1,5 @@
 import { auth, googleProvider } from "@/config/firebase";
+import { queryClient } from "@/routes/__root";
 import type { AuthUser, ExtendedUserCredential } from "@/types";
 import {
   // getIdToken,
@@ -74,6 +75,7 @@ export const useAuthStore = create<AuthStore>()(
           set({ loading: true });
           try {
             await signOut(auth);
+            queryClient.clear();
             localStorage.removeItem("questionDrafts");
             set(
               { user: null, firebaseUser: null, loading: false },

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -38,7 +38,7 @@ export const useAuthStore = create<AuthStore>()(
           set({ firebaseUser }, undefined, "setFirebaseUser"),
 
         setUser: (user) => set({ user }, undefined, "setUser"),
-      
+
         clearUser: () => {
           localStorage.removeItem("firebase-auth-token");
           localStorage.removeItem("user-id");
@@ -82,8 +82,6 @@ export const useAuthStore = create<AuthStore>()(
               undefined,
               "logout"
             );
-
-
           } catch (err: any) {
             console.error(err);
             set({ error: err.message || "Logout failed", loading: false });


### PR DESCRIPTION
**Description**

This PR resolves an issue where logging out from one role (e.g., moderator) and immediately logging in with another role (e.g., expert) caused incorrect routing. Due to cached user data, the application briefly redirected the user to the previous role’s dashboard and then back to the login page.

**Before**

- Logging in as a moderator, logging out, and then logging in as an expert caused incorrect behavior.
- The app briefly redirected the user to the moderator dashboard and then immediately back to the login page.
- This happened due to stale cached user data being reused after logout.



https://github.com/user-attachments/assets/ebdb257a-f3f0-4b9c-9603-4c6f7ba7e295


**After**

- User-related cached data is properly cleared on logout.
- On login, the application fetches fresh user and role information.
- Users are now redirected directly to the correct dashboard based on their role, without unexpected redirects.


https://github.com/user-attachments/assets/8208d480-a247-41f0-acbc-10f6289f25a2

