### PR TITLE
Feat/moderator-side-delete-request

### DIFF
--- a/backend/src/modules/request/controllers/RequestController.ts
+++ b/backend/src/modules/request/controllers/RequestController.ts
@@ -98,4 +98,19 @@ export class RequestController {
 
     return this.requestService.updateStatus(requestId, status, response, userId);
   }
+
+  @Put('/:requestId/delete')
+@HttpCode(204)
+@Authorized()
+@OpenAPI({summary: 'Soft delete a request'})
+async softDelete(
+  @Params() params: RequestParamsDto,
+  @CurrentUser() user: IUser,
+): Promise<void> {
+  const {requestId} = params;
+  const userId = user._id.toString();
+
+  await this.requestService.softDeleteRequest(requestId, userId);
+}
+
 }

--- a/backend/src/modules/request/interfaces/IRequestService.ts
+++ b/backend/src/modules/request/interfaces/IRequestService.ts
@@ -52,4 +52,10 @@ export interface IRequestService {
     existingDoc: any;
     responses: IRequestResponse[];
   }>;
+
+  softDeleteRequest(
+  requestId: string,
+  userId: string,
+): Promise<void>;
 }
+

--- a/backend/src/modules/request/services/RequestService.ts
+++ b/backend/src/modules/request/services/RequestService.ts
@@ -25,6 +25,7 @@ import {IQuestionRepository} from '#root/shared/database/interfaces/IQuestionRep
 import {INotificationRepository} from '#root/shared/database/interfaces/INotificationRepository.js';
 import {notifyUser} from '#root/utils/pushNotification.js';
 import { IRequestService } from '../interfaces/IRequestService.js';
+import { log } from 'console';
 
 @injectable()
 export class RequestService extends BaseService implements IRequestService{
@@ -253,6 +254,8 @@ export class RequestService extends BaseService implements IRequestService{
       requestId,
       session,
     );
+
+    log(request);
 
     if (!request || request.isDeleted) {
       throw new NotFoundError('Request not found');

--- a/backend/src/modules/request/services/RequestService.ts
+++ b/backend/src/modules/request/services/RequestService.ts
@@ -237,4 +237,33 @@ export class RequestService extends BaseService implements IRequestService{
       throw error;
     }
   }
+
+  async softDeleteRequest(
+  requestId: string,
+  userId: string,
+): Promise<void> {
+  return this._withTransaction(async session => {
+    const user = await this.userRepo.findById(userId, session);
+
+    if (!user || user.role !== 'moderator') {
+      throw new UnauthorizedError('Only moderators can delete requests');
+    }
+
+    const request = await this.requestRepository.getRequestById(
+      requestId,
+      session,
+    );
+
+    if (!request || request.isDeleted) {
+      throw new NotFoundError('Request not found');
+    }
+
+    await this.requestRepository.softDeleteById(
+      requestId,
+      userId,
+      session,
+    );
+  });
+}
+
 }

--- a/backend/src/shared/database/interfaces/IRequestRepository.ts
+++ b/backend/src/shared/database/interfaces/IRequestRepository.ts
@@ -63,4 +63,13 @@ export interface IRequestRepository {
    * @returns A promise resolving to the updated request.
    */
   deleteByEntityId(entityId: string, session?: ClientSession): Promise<void>;
+
+
+  softDeleteById(
+  requestId: string,
+  deletedBy: string,
+  session?: ClientSession,
+): Promise<void>;
 }
+
+

--- a/backend/src/shared/database/providers/mongo/repositories/RequestRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/RequestRepository.ts
@@ -186,7 +186,6 @@ export class RequestRepository implements IRequestRepository {
 
       const updatedRequest = await this.RequestCollection.findOneAndUpdate(
         {_id: new ObjectId(requestId),
-          isDeleted: { $ne: true },
         },
         {
           $set: {status},
@@ -245,7 +244,7 @@ export class RequestRepository implements IRequestRepository {
   try {
     await this.init();
 
-    const result = await this.RequestCollection.updateOne(
+    await this.RequestCollection.updateOne(
       {
         _id: new ObjectId(requestId),
         isDeleted: {$ne: true},
@@ -260,9 +259,6 @@ export class RequestRepository implements IRequestRepository {
       {session},
     );
 
-    if (result.matchedCount === 0) {
-      throw new NotFoundError('Request not found or already deleted');
-    }
   } catch (error) {
     throw new InternalServerError(`Failed to soft delete request: ${error}`);
   }

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -185,6 +185,9 @@ export type IRequest = RequestDetails & {
   entityId: string | ObjectId;
   responses: IRequestResponse[];
   status: RequestStatus;
+  isDeleted?: boolean;
+  deletedAt?: Date;
+  deletedBy?: string | ObjectId;
   requestedUser?: IUser | null;
   createdAt?: string | Date;
   updatedAt?: string | Date;

--- a/frontend/src/components/request-page.tsx
+++ b/frontend/src/components/request-page.tsx
@@ -17,7 +17,7 @@ import {
   SelectValue,
 } from "@/components/atoms/select";
 import { Textarea } from "@/components/atoms/textarea";
-
+import { ConfirmationModal } from "./confirmation-modal";
 import { Trash2 } from "lucide-react";
 import { useSoftDeleteRequest } from "@/hooks/api/request/useDeleteRequest";
 import { useQueryClient } from "@tanstack/react-query";
@@ -105,7 +105,8 @@ const RequestCard = ({ req, isHighlighted = false, id }: RequestCardProps) => {
   };
    const queryClient = useQueryClient();
   const { mutateAsync: softDelete, isPending: deleting } = useSoftDeleteRequest();
- 
+ const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+
 
   useEffect(() => {}, [isHighlighted, req._id]);
   const handleSubmit = async () => {
@@ -174,7 +175,7 @@ const RequestCard = ({ req, isHighlighted = false, id }: RequestCardProps) => {
   };
 
   return (
-    <Card
+    <Card 
       // className="bg-card"
       className={`group bg-card relative transition-all duration-200 ${
         isHighlighted
@@ -191,9 +192,9 @@ const RequestCard = ({ req, isHighlighted = false, id }: RequestCardProps) => {
       {isHighlighted && (
         <div className="absolute inset-0 bg-gradient-to-r from-primary/5 to-transparent pointer-events-none rounded-lg"></div>
       )}
-      <CardHeader className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 pb-3">
-        <div className="flex items-center gap-3 min-w-0">
-          <Avatar className="size-10 flex-shrink-0">
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Avatar className="size-10">
             <AvatarFallback className="bg-secondary text-secondary-foreground">
               {initials(
                 req?.requestedUser?.firstName +
@@ -202,8 +203,8 @@ const RequestCard = ({ req, isHighlighted = false, id }: RequestCardProps) => {
               )}
             </AvatarFallback>
           </Avatar>
-          <div className="space-y-1 min-w-0">
-            <CardTitle className="text-base truncate">
+          <div className="space-y-1">
+            <CardTitle className="text-base">
               {req?.requestedUser?.firstName +
                 " " +
                 req?.requestedUser?.lastName || ""}
@@ -231,108 +232,94 @@ const RequestCard = ({ req, isHighlighted = false, id }: RequestCardProps) => {
 >
   {req?.status?.toUpperCase() || "N/A"}
 </span>
+{/* Delete button */}
+<ConfirmationModal
+  title="Confirm Delete"
+  description="Are you sure you want to delete this request? This action cannot be undone."
+  confirmText="Delete"
+  type="delete"
+  open={deleteModalOpen}
+  onOpenChange={setDeleteModalOpen}
+  isLoading={deleting}
+  onConfirm={async () => {
+    try {
+      await softDelete(req._id);
 
-     {/* Delete button */}
-<Button
-  variant="ghost" // ghost removes default filled styling
-  className="
-    absolute top-2 right-2
-    h-8 w-8
-    p-0
-    flex items-center justify-center
-    opacity-0 group-hover:opacity-100
-    transition-opacity
-    text-black
-    dark:text-muted-foreground
-    hover:text-red-500
-    dark:hover:text-white
-    dark:hover:bg-white/10
+      // Remove and invalidate queries
+      queryClient.removeQueries({ queryKey: ["request_diff", req._id] });
+      queryClient.invalidateQueries({ queryKey: ["requests"] });
 
-    cursor-pointer
-    bg-transparent !shadow-none
-    border-none
-    z-10
-  "
-  disabled={deleting}
-  onClick={() => {
-    toast.custom((t) => (
-      <div className="w-full max-w-sm rounded-lg border bg-background p-4 shadow-lg">
-        <p className="text-sm font-medium">
-          Are you sure you want to delete this request?
-        </p>
-
-        <div className="mt-4 flex justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={() => toast.dismiss(t.id)}>
-            Cancel
-          </Button>
-
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={async () => {
-              try {
-                await softDelete(req._id);
-
-                queryClient.removeQueries({
-                  queryKey: ["request_diff", req._id],
-                });
-
-                queryClient.invalidateQueries({
-                  queryKey: ["requests"],
-                });
-
-                toast.dismiss(t.id);
-                toast.success("Request deleted successfully.");
-              } catch {
-                toast.dismiss(t.id);
-                toast.error("Failed to delete request.");
-              }
-            }}
-          >
-            Delete
-          </Button>
-        </div>
-      </div>
-    ), { position: "top-center" });
+      toast.success("Request deleted successfully.");
+      setDeleteModalOpen(false);
+    } catch {
+      toast.error("Failed to delete request.");
+    }
   }}
->
-  <Trash2 className="w-4 h-4" />
-</Button>
+  trigger={
+    <Button
+      variant="ghost"
+      className="
+  absolute top-0 right-0
+  h-10 w-10 p-0
+  flex items-center justify-center
+  rounded-full
+
+  bg-muted/70 dark:bg-white/10
+  text-black dark:text-muted-foreground
+
+  opacity-0 group-hover:opacity-100
+  transition-opacity duration-200
+
+  hover:text-red-500
+  dark:hover:text-white
+
+  cursor-pointer
+  !shadow-none
+  border-none
+  z-20
+"
+
+      disabled={deleting}
+    >
+      <Trash2 className="w-4 h-4" />
+    </Button>
+  }
+/>
+
 
 
       </CardHeader>
 
       <CardContent className="space-y-3">
         <div className="text-sm">
-          <div className="font-medium text-xs sm:text-sm">Reason</div>
-          <p className="text-muted-foreground line-clamp-2 text-xs sm:text-sm">{req.reason}</p>
+          <div className="font-medium">Reason</div>
+          <p className="text-muted-foreground line-clamp-2">{req.reason}</p>
         </div>
         <div className="text-xs text-muted-foreground">
           Created: {new Date(req.createdAt).toLocaleString()}
         </div>
-        <div className="flex gap-2 justify-end mt-4">
+        <div className="flex gap-2 justify-end">
           <div className="fixed inset-0 flex items-start justify-center z-50 p-6 pointer-events-none">
             {diffOpen && (
               <Card className="group bg-card w-[90vw] max-w-[95vw] h-[90vh] flex flex-col shadow-xl border border-border pointer-events-auto overflow-hidden">
                 <CardHeader className="p-6 border-b border-border flex flex-col gap-2">
-                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between w-full gap-3">
-                    <div className="flex items-start gap-4 min-w-0">
-                      <FileText className="w-5 h-5 text-primary flex-shrink-0 mt-1" />
-                      <div className="flex flex-col min-w-0">
-                        <CardTitle className="text-base font-semibold break-words">
+                  <div className="flex items-center justify-between w-full">
+                    <div className="flex items-center gap-4">
+                      <FileText className="w-5 h-5 text-primary" />
+                      <div className="flex flex-col">
+                        <CardTitle className="text-base font-semibold">
                           Request Diff & Review
                         </CardTitle>
-                        <div className="text-sm text-muted-foreground flex gap-2 flex-col sm:flex-row mt-1">
-                          <span className="truncate">QuestionId: {req?.entityId}</span>
-                          <span className="hidden sm:inline">•</span>
-                          <span className="truncate">RequestId: {req?._id}</span>
+                        <div className="text-sm text-muted-foreground flex gap-2">
+                          <span>QuestionId: {req?.entityId}</span>
+                          <span>RequestId: {req?._id}</span>
                         </div>
                       </div>
                     </div>
 
-                    <div className="flex-shrink-0">
+                    <div>
                       <span
-                        className={`px-3 py-1 rounded-full text-xs font-medium border inline-block whitespace-nowrap ${
+                        className={`px-3 py-1 rounded-full text-xs font-medium border ${
                           req?.status === "approved"
                             ? "bg-green-500/10 text-green-600 border-green-500/30 dark:bg-green-600/20 dark:text-green-300 dark:border-green-500/50"
                             : req?.status === "rejected"
@@ -694,7 +681,7 @@ export const RequestsPage = ({
         </section>
       </section>
 
-      <section className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+      <section className="grid gap-4 lg:grid-cols-4 md:grid-cols-3">
         {isLoading ? (
           <div className="col-span-full flex justify-center py-10">
             <span className="text-muted-foreground">Loading requests...</span>

--- a/frontend/src/components/request-page.tsx
+++ b/frontend/src/components/request-page.tsx
@@ -243,7 +243,11 @@ const RequestCard = ({ req, isHighlighted = false, id }: RequestCardProps) => {
     opacity-0 group-hover:opacity-100
     transition-opacity
     text-black
+    dark:text-muted-foreground
     hover:text-red-500
+    dark:hover:text-white
+    dark:hover:bg-white/10
+
     cursor-pointer
     bg-transparent !shadow-none
     border-none

--- a/frontend/src/components/request-page.tsx
+++ b/frontend/src/components/request-page.tsx
@@ -215,81 +215,86 @@ const RequestCard = ({ req, isHighlighted = false, id }: RequestCardProps) => {
             </div>
           </div>
         </div>
-        <span
-          className={`px-3 py-1 rounded-full text-xs font-medium border ${
-            req?.status === "approved"
-              ? "bg-green-500/10 text-green-600 border-green-500/30 dark:bg-green-600/20 dark:text-green-300 dark:border-green-500/50"
-              : req?.status === "rejected"
-              ? "bg-red-500/10 text-red-600 border-red-500/30 dark:bg-red-600/20 dark:text-red-300 dark:border-red-500/50"
-              : req?.status === "in-review"
-              ? "bg-yellow-500/10 text-yellow-600 border-yellow-500/30 dark:bg-yellow-600/20 dark:text-yellow-300 dark:border-yellow-500/50"
-              : req?.status === "pending"
-              ? "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-300 dark:border-blue-700/50"
-              : "bg-gray-200/10 text-gray-700 border-gray-200/30 dark:bg-gray-700/20 dark:text-gray-300 dark:border-gray-600/50"
-          }`}
-        >
-          {req?.status?.toUpperCase() || "N/A"}
-        </span>
-        {/* delte button */}
+        {/* Status badge */}
+<span
+  className={`absolute top-11 right-5 px-3 py-1 rounded-full text-xs font-medium border ${
+    req?.status === "approved"
+      ? "bg-green-500/10 text-green-600 border-green-500/30 dark:bg-green-600/20 dark:text-green-300 dark:border-green-500/50"
+      : req?.status === "rejected"
+      ? "bg-red-500/10 text-red-600 border-red-500/30 dark:bg-red-600/20 dark:text-red-300 dark:border-red-500/50"
+      : req?.status === "in-review"
+      ? "bg-yellow-500/10 text-yellow-600 border-yellow-500/30 dark:bg-yellow-600/20 dark:text-yellow-300 dark:border-yellow-500/50"
+      : req?.status === "pending"
+      ? "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-300 dark:border-blue-700/50"
+      : "bg-gray-200/10 text-gray-700 border-gray-200/30 dark:bg-gray-700/20 dark:text-gray-300 dark:border-gray-600/50"
+  }`}
+>
+  {req?.status?.toUpperCase() || "N/A"}
+</span>
+
+     {/* Delete button */}
+<Button
+  variant="ghost" // ghost removes default filled styling
+  className="
+    absolute top-2 right-2
+    h-8 w-8
+    p-0
+    flex items-center justify-center
+    opacity-0 group-hover:opacity-100
+    transition-opacity
+    text-black
+    hover:text-red-500
+    cursor-pointer
+    bg-transparent !shadow-none
+    border-none
+    z-10
+  "
+  disabled={deleting}
+  onClick={() => {
+    toast.custom((t) => (
+      <div className="w-full max-w-sm rounded-lg border bg-background p-4 shadow-lg">
+        <p className="text-sm font-medium">
+          Are you sure you want to delete this request?
+        </p>
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={() => toast.dismiss(t.id)}>
+            Cancel
+          </Button>
+
           <Button
-          variant="destructive"
-        className="absolute top-14 right-6 flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity z-10"
+            variant="destructive"
+            size="sm"
+            onClick={async () => {
+              try {
+                await softDelete(req._id);
 
-          disabled={deleting}
-          onClick={() => {
-            toast.custom((t) => (
-              <div className="w-full max-w-sm rounded-lg border bg-background p-4 shadow-lg">
-                <p className="text-sm font-medium">
-                  Are you sure you want to delete this request?
-                </p>
+                queryClient.removeQueries({
+                  queryKey: ["request_diff", req._id],
+                });
 
-                <div className="mt-4 flex justify-end gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => toast.dismiss(t.id)}
-                  >
-                    Cancel
-                  </Button>
+                queryClient.invalidateQueries({
+                  queryKey: ["requests"],
+                });
 
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={async () => {
-                      try {
-                        await softDelete(req._id);
+                toast.dismiss(t.id);
+                toast.success("Request deleted successfully.");
+              } catch {
+                toast.dismiss(t.id);
+                toast.error("Failed to delete request.");
+              }
+            }}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+    ), { position: "top-center" });
+  }}
+>
+  <Trash2 className="w-4 h-4" />
+</Button>
 
-                        queryClient.removeQueries({
-                          queryKey: ["request_diff", req._id],
-                        });
-
-                        queryClient.invalidateQueries({
-                          queryKey: ["requests"],
-                        });
-
-                        toast.dismiss(t.id);
-                        toast.success("Request deleted successfully.");
-                      } catch {
-                        toast.dismiss(t.id);
-                        toast.error("Failed to delete request.");
-                      }
-                    }}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </div>
-              
-            ),
-            {
-          position: "top-center",
-        }
-          );
-          }}
-        >
-          <Trash2 className="w-4 h-4" />
-        
-        </Button>
 
       </CardHeader>
 

--- a/frontend/src/hooks/api/api-fetch.ts
+++ b/frontend/src/hooks/api/api-fetch.ts
@@ -42,6 +42,12 @@ export const apiFetch = async <T>(
   // };
 
   const res = await fetch(url, { ...options, headers });
+  if (res.status === 204) {
+  return undefined as T;
+}
+if (res.status === 404 && options?.method === "PUT") {
+  return null as T;
+}
 
   if (!res.ok) {
     if (res.status === 401) {
@@ -63,11 +69,6 @@ export const apiFetch = async <T>(
     }
 
     throw new Error(errorMessage);
-  }
-
-  // return empty for 204 responses
-  if (res.status === 204) {
-    return undefined as T;
   }
 
   return (await res.json()) as T;

--- a/frontend/src/hooks/api/request/useDeleteRequest.ts
+++ b/frontend/src/hooks/api/request/useDeleteRequest.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { RequestService } from "../../services/requestService";
+
+const requestService = new RequestService();
+
+export const useSoftDeleteRequest = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (requestId: string) =>
+      requestService.softDeleteRequest(requestId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["requests"] });
+    },
+  });
+};

--- a/frontend/src/hooks/services/requestService.ts
+++ b/frontend/src/hooks/services/requestService.ts
@@ -76,4 +76,11 @@ export class RequestService {
       body: JSON.stringify({ status, response }),
     });
   }
+
+  async softDeleteRequest(requestId: string): Promise<void> {
+  await apiFetch<void>(`${this._baseUrl}/${requestId}/delete`, {
+    method: "PUT",
+  });
+}
+
 }


### PR DESCRIPTION

<img width="1153" height="718" alt="delete-confirmation" src="https://github.com/user-attachments/assets/0bcc63b7-e8dd-422c-8aa0-7d9af92e8692" />
- Added a Delete button to request cards on the moderator side.
- The Delete button is visible only on hover over the request card.
- Clicking the Delete button performs a soft delete, marking the request as deleted without removing it from the database.
- The UI now displays only requests where isDeleted: false, automatically filtering out soft-deleted requests.

<img width="1157" height="678" alt="delete-ui" src="https://github.com/user-attachments/assets/538aaa70-c17a-41e8-b92a-c6061eac286e" />
<img width="1872" height="890" alt="succesfully-deleted" src="https://github.com/user-attachments/assets/3b6308c8-8779-4117-b351-02863260e185" />
