### PR TITLE
fix(expert-management): make "Rank" header clickable to reset default sort

### DIFF
--- a/frontend/src/components/user-management.tsx
+++ b/frontend/src/components/user-management.tsx
@@ -53,6 +53,10 @@ export const UserManagement = ({
     filter
   );
  const toggleSort = (key: string) => {
+  if (key === "rank") {
+    setSort("");
+    return;
+  }
   setSort((prev) => {
     if (prev === `${key}_asc`) return `${key}_desc`;
     return `${key}_asc`;

--- a/frontend/src/components/user-table.tsx
+++ b/frontend/src/components/user-table.tsx
@@ -74,7 +74,14 @@ export const UsersTable = ({
         <Table className="min-w-[800px]">
           <TableHeader className="bg-card sticky top-0 z-10">
             <TableRow>
-              <TableHead className="text-center w-12">Rank</TableHead>
+              <TableHead className="text-center w-12">
+                <button
+                  onClick={() => onSort("rank")}
+                  className="mx-auto select-none"
+                >
+                  Rank
+                </button>
+              </TableHead>
               <TableHead className="w-[35%] text-center w-52">
                 Full Name
               </TableHead>


### PR DESCRIPTION
## Summary
This PR addresses an issue in the Expert Management table where the "Rank" column header was not clickable. Users could sort by other columns (Pending Workload, Incentive, Penalty, Joined At), but had no way to return to the default ranking sort once they changed it.

## Changes
- Made the "Rank" header clickable.
- Clicking on "Rank" now triggers the default API call with an empty sort string.
- Ensures users can easily reset sorting back to the default ranking order.

## Before
- "Rank" header was static and not interactive.
- No way to return to default ranking sort after choosing another column.
## After
- "Rank" header is clickable.
- Clicking it resets sorting to the default ranking order via API call.

