### PR TITLE
Fix/moderator listing expert management

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
@@ -852,7 +852,7 @@ async findAllUsers(
       await this.ensureIndexes();
       const skip = (page - 1) * limit;
 
-      const matchQuery: any = {};
+      const matchQuery: any = {role:'expert'};
 
       if (search) {
         matchQuery.$or = [


### PR DESCRIPTION
**Description**

When fetching the expert list, moderator accounts were incorrectly included in the results due to improper role filtering. This caused moderators to appear alongside experts in the expert management view.

**Before**

- Fetching experts returned both experts and moderators
- Role-based filtering was not strictly enforced

<img width="1854" height="815" alt="bfr" src="https://github.com/user-attachments/assets/dd797f12-a7cd-4dc2-a47a-3323f7cac243" />


**After**

- Fetching experts now returns only users with role: 'expert'
- Moderators are correctly excluded from expert listings

<img width="1842" height="836" alt="af" src="https://github.com/user-attachments/assets/d4fca7ea-918f-449d-9c9d-59a9dba286b7" />

