### PR TITLE
fix:prevent expert rank from changing during search

### DIFF
--- a/frontend/src/components/user-table.tsx
+++ b/frontend/src/components/user-table.tsx
@@ -88,7 +88,7 @@
             <Table className="min-w-[800px]">
               <TableHeader className="bg-card sticky top-0 z-10">
                 <TableRow>
-                  <TableHead className="text-center w-12" onClick={() => onSort("rank")}>{isAdmin ? "#" : "Rank"}</TableHead>
+                  <TableHead className="text-center w-12" onClick={() => onSort("rank")}>{isAdmin ? "S.No" : "Rank"}</TableHead>
                   <TableHead className="w-[35%] text-center w-52">
                     Full Name
                   </TableHead>


### PR DESCRIPTION
Prevent expert rank from changing during search.
- Expert global rank is now calculated before search & filter
- Searching no longer recalculates or shifts rankPosition
- Rank remains consistent across pagination and sorting
<img width="1443" height="832" alt="normal-ranking" src="https://github.com/user-attachments/assets/82858e77-4257-4a6e-a0fd-7e2a6eefba06" />
<img width="972" height="691" alt="rank-in-search" src="https://github.com/user-attachments/assets/2ef41cbf-3519-4c8d-991e-a577ede432dd" />
