### PR TITLE
Fix pagination reset when applying filters on Questions Page

### DIFF
--- a/frontend/src/components/questions-page.tsx
+++ b/frontend/src/components/questions-page.tsx
@@ -174,6 +174,9 @@ export const QuestionsPage = ({
     if (next.review_level !== undefined) setReviewLevel(next.review_level);
     if (next.closedAtStart !== undefined) setClosedAtStart(next.closedAtStart);
     if (next.closedAtEnd !== undefined) setClosedAtEnd(next.closedAtEnd);
+    // Reset pagination to page 1 when filters are applied
+    setCurrentPage(1);
+    setReviewPage(1);
   };
   const [showClosedAt, setClosedAt] = useState(false);
   useEffect(() => {


### PR DESCRIPTION
## Issue Found and Fixed

When preference filters were applied, the pagination state () was not being reset to page 1. If a user was viewing page 2 before applying filters, the app would remain on page 2, which often resulted in a misleading "No questions found" message if the filtered results were fewer or different.

## Root Cause
- The onChangeFilters function did not reset pagination states.
- This caused the UI to attempt to render results from the wrong page index after filters were applied.

✅ Solution
Added logic to reset both currentPage and reviewPage to 1 whenever filters are applied:

```tsx
// Reset pagination to page 1 when filters are applied
setCurrentPage(1);
setReviewPage(1);
```

