### PR TITLE
Fix and improve rate limiting for auth and API requests

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,10 +18,14 @@ import {currentUserChecker} from './shared/functions/currentUserChecker.js';
 import path from 'path';
 import {fileURLToPath} from 'url';
 import { initJobs } from './bootstrap/jobs/index.js';
+import { rateLimiter } from './shared/middleware/rateLimiter.js';
 
 const app = express();
 
 app.use(loggingHandler);
+
+app.set('trust proxy', 1);
+app.use('/api', rateLimiter);
 
 const {controllers, validators} = await loadAppModules(
   appConfig.module.toLowerCase(),

--- a/backend/src/modules/auth/controllers/AuthController.ts
+++ b/backend/src/modules/auth/controllers/AuthController.ts
@@ -24,6 +24,9 @@ import {
 import {AUTH_TYPES} from '#auth/types.js';
 import {OpenAPI} from 'routing-controllers-openapi';
 import {appConfig} from '#root/config/app.js';
+import { UseBefore } from 'routing-controllers';
+import { AuthRateLimiter } from '#root/shared/middleware/rateLimiter.js';
+
 
 @OpenAPI({
   tags: ['Authentication'],
@@ -90,6 +93,7 @@ export class AuthController {
   }
 
   @Post('/login')
+  @UseBefore(AuthRateLimiter)
   async login(@Body() body: LoginBody) {
     try {
       const {email, password} = body;

--- a/backend/src/shared/middleware/rateLimiter.ts
+++ b/backend/src/shared/middleware/rateLimiter.ts
@@ -2,10 +2,11 @@ import rateLimit from 'express-rate-limit';
 import {Request, Response, NextFunction} from 'express';
 
 export const rateLimiter = rateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  limit: 5, // Limit each IP to 5 requests per window
+  windowMs: 15 * 60 * 1000, // 15 minute
+  limit: 300, // Limit each IP to 300 requests per window
   standardHeaders: true, // Use `RateLimit-*` headers
   legacyHeaders: false, // Disable `X-RateLimit-*` headers
+  skip: (req) => req.method === 'OPTIONS',
   message: {error: 'Too many requests, please try again later.'},
 });
 
@@ -22,7 +23,7 @@ export function AuthRateLimiter(
   res: Response,
   next: NextFunction,
 ) {
-  if (process.env.NODE_ENV === 'production') {
+  if (['production', 'staging'].includes(process.env.NODE_ENV ?? '')) {
     return authRateLimiter(req, res, next); // delegate to express-rate-limit
   } else {
     next();


### PR DESCRIPTION
# Description
- **Auth Rate Limiter**
  - Limit: 5 requests per 15 minutes per IP.

- **General Rate Limiter**
  - Limit increased to 300 requests per 15 minutes per IP.
  - OPTIONS requests excluded to avoid preflight issues.

- **Fixes & Cleanup**
  - `AuthRateLimiter` now properly calls the rate limiter.
  - Improved readability and consistency.

# Impact
- Prevents unnecessary blocking during local development.
- Ensures frontend and preflight requests are not limited.
