### PR TITLE
fix(comment): return only required fields in API responses

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/CommentRespository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/CommentRespository.ts
@@ -134,12 +134,8 @@ export class CommentRepository implements ICommentRepository {
                 {
                   $project: {
                     _id: {$toString: '$_id'},
-                    questionId: {$toString: '$questionId'},
-                    answerId: {$toString: '$answerId'},
-                    userId: {$toString: '$userId'},
                     text: 1,
                     createdAt: 1,
-                    updatedAt: 1,
                     userName: {
                       $trim: {
                         input: {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -124,21 +124,21 @@ export interface HistoryItem {
   // If an expert is modifying, it store the modified answer id
   modifiedAnswer?: string;
   // timestamp
- 
+
   moderator?: ModeratorRerouteRepo;
   question?: QuestionEntityRerouteRepo;
- 
+
   rerouteId?: string;
   reroute?: RerouteRerouteRepo;
   text?: string;
-  
+
   details?: QuestionDetailsRerouteRepo;
   createdAt?: Date;
   priority?: Priority;
   id?: string;
- 
+
   updatedAt?:Date,
- 
+
 }
 
 export type QuestionPriority = "low" | "medium" | "high";
@@ -425,9 +425,6 @@ export interface QuestionFullDataResponse {
 
 export interface IComment {
   _id: string;
-  questionId: string;
-  answerId: string;
-  userId: string;
   userName?: string;
   text: string;
   createdAt: string;
@@ -594,7 +591,7 @@ export interface IRerouteHistoryResponse {
 export type RerouteHistoryApiResponse = IRerouteHistoryResponse[];
 type Priority = "high" | "medium" | "low";
 
- export interface ReroutedQuestionItem {
+export interface ReroutedQuestionItem {
   id: string;
   text: string;
   status: QuestionStatus;
@@ -692,7 +689,7 @@ export interface QuestionHistoryRerouteRepo {
   createdAt?: string;
   priority?: Priority;
   id?: string;
- 
+
   updatedAt?:Date,
   updatedBy?: {
     // who's submission is this
@@ -700,8 +697,8 @@ export interface QuestionHistoryRerouteRepo {
     userName: string;
     // email: string;
   };
-  
-  
+
+
 }
 
 /* =========================
@@ -788,15 +785,15 @@ export interface RerouteRerouteRepo {
 }
 export type QuestionResponse =
   | {
-      kind: "normal";
-      data: IQuestion;
-    }
+    kind: "normal";
+    data: IQuestion;
+  }
   | {
-      kind: "reroute";
-      data: QuestionRerouteRepo;
-    };
-    export interface WorkloadBalanceResponse {
-      message: string;
-      expertsInvolved: number;
-      submissionsProcessed: number;
-    }
+    kind: "reroute";
+    data: QuestionRerouteRepo;
+  };
+export interface WorkloadBalanceResponse {
+  message: string;
+  expertsInvolved: number;
+  submissionsProcessed: number;
+}


### PR DESCRIPTION
Instead of fetching the full user document, the query now retrieves only the required fields.