### PR TITLE
Feat/consecutive approval for moderator

### DIFF
--- a/frontend/src/features/question_details/components/AnswerItem.tsx
+++ b/frontend/src/features/question_details/components/AnswerItem.tsx
@@ -33,6 +33,7 @@ interface AnswerItemProps {
   questionStatus: QuestionStatus;
   queue: ISubmission["queue"];
   rerouteQuestion?: IRerouteHistoryResponse[];
+  lastAnswerApprovalCount?: number;
 }
 
 export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
@@ -287,6 +288,7 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
         reviews={reviews}
         firstTrueIndex={firstTrueIndex}
         firstFalseOrMissingIndex={firstFalseOrMissingIndex}
+        lastAnswerApprovalCount={props.lastAnswerApprovalCount}
       />
 
       <AnswerContent answer={props.answer} />

--- a/frontend/src/features/question_details/components/AnswerItem.tsx
+++ b/frontend/src/features/question_details/components/AnswerItem.tsx
@@ -198,6 +198,8 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
         error?.message ||
         "Something went wrong";
       toast.error(message);
+    }finally{
+      setIsRejectDialogOpen(false);
     }
   };
 
@@ -283,6 +285,7 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
         filteredExperts={filteredExperts}
         selectedExperts={selectedExperts}
         handleSelectExpert={handleSelectExpert}
+        isAllocatingExperts={allocatingExperts}
         handleSubmit={handleSubmit}
         handleCancel={handleCancel}
         isRejectDialogOpen={isRejectDialogOpen}
@@ -290,6 +293,7 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
         rejectionReason={rejectionReason}
         setRejectionReason={setRejectionReason}
         handleRejectReRouteAnswer={handleRejectReRouteAnswer}
+        isRejecting={isRejecting}
         isRejected={isRejected}
         submissionData={props.submissionData}
         questionId={props.questionId}

--- a/frontend/src/features/question_details/components/AnswerItem.tsx
+++ b/frontend/src/features/question_details/components/AnswerItem.tsx
@@ -21,6 +21,7 @@ import { AnswerItemHeader } from "./answer_item/AnswerItemHeader";
 import { AnswerContent } from "./answer_item/AnswerContent";
 import { AnswerActions } from "./answer_item/AnswerActions";
 import { CommentsSection } from "@/components/comments-section";
+import { useGetReRoutedQuestionFullData } from "@/hooks/api/question/useGetReRoutedQuestionFullData";
 
 interface AnswerItemProps {
   answer: IAnswer;
@@ -46,6 +47,11 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
     props.questionId,
     props.answer._id
   );
+
+  // need to refresh after action
+  const {
+      refetch: refechrerouteSelectedQuestion,
+    } = useGetReRoutedQuestionFullData(props.questionId);
 
   const [editableAnswer, setEditableAnswer] = useState(props.answer.answer);
   const [editOpen, setEditOpen] = useState(false);
@@ -131,14 +137,16 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
         comment: comment.trim(),
         status: "pending" as ReRouteStatus,
       });
-      toast.success("You have successfully Re Routed the question");
       setSelectedExperts([]);
-      setIsModalOpen(false);
+      refechrerouteSelectedQuestion();
+      toast.success("You have successfully Re Routed the question");
     } catch (error: any) {
       console.error("Error allocating experts:", error);
       toast.error(
         error?.message || "Failed to allocate experts. Please try again."
       );
+    }finally{
+      setIsModalOpen(false);
     }
   };
 
@@ -173,7 +181,7 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
     const userId = lastReroutedTo.reroutedTo._id;
 
     try {
-      let result = await rejectReRoute({
+       await rejectReRoute({
         reason,
         rerouteId: rerouteId,
         questionId: questionId,
@@ -181,7 +189,7 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
         expertId: userId,
         role: "moderator",
       });
-      console.log("the result coming====", result);
+      refechrerouteSelectedQuestion();
       toast.success("You have successfully rejected the Re Route Question");
     } catch (error: any) {
       console.error("Failed to reject reroute question:", error);

--- a/frontend/src/features/question_details/components/AnswerTimeline.tsx
+++ b/frontend/src/features/question_details/components/AnswerTimeline.tsx
@@ -34,7 +34,7 @@ export const AnswerTimeline = ({
     const submission = question.submission.history.find(
       (h) => h.answer?._id === ans?._id
     );
-
+  
     return {
       lastAnswerId: answers[0]?._id, // first one will be the last one
       firstAnswerId: answers[answers?.length - 1]?._id, // last one will be the first one
@@ -96,6 +96,7 @@ export const AnswerTimeline = ({
               userRole={userRole}
               queue={queue}
               rerouteQuestion={rerouteQuestion}
+              lastAnswerApprovalCount= {answers[0].approvalCount}
             />
           </div>
         )}

--- a/frontend/src/features/question_details/components/answer_item/AnswerActions.tsx
+++ b/frontend/src/features/question_details/components/answer_item/AnswerActions.tsx
@@ -35,6 +35,7 @@ interface AnswerActionsProps {
   filteredExperts: IUser[];
   selectedExperts: string[];
   handleSelectExpert: (expertId: string) => void;
+  isAllocatingExperts?: boolean;
   handleSubmit: () => void;
   handleCancel: () => void;
   isRejectDialogOpen: boolean;
@@ -42,6 +43,7 @@ interface AnswerActionsProps {
   rejectionReason: string;
   setRejectionReason: (reason: string) => void;
   handleRejectReRouteAnswer: (reason: string) => void;
+  isRejecting?: boolean;
   isRejected: boolean|undefined;
   submissionData?: ISubmissionHistory;
   questionId: string;
@@ -75,6 +77,7 @@ export const AnswerActions = ({
   filteredExperts,
   selectedExperts,
   handleSelectExpert,
+  isAllocatingExperts,
   handleSubmit,
   handleCancel,
   isRejectDialogOpen,
@@ -82,6 +85,7 @@ export const AnswerActions = ({
   rejectionReason,
   setRejectionReason,
   handleRejectReRouteAnswer,
+  isRejecting,
   isRejected,
   submissionData,
   questionId,
@@ -133,6 +137,7 @@ export const AnswerActions = ({
             handleSubmit={handleSubmit}
             handleCancel={handleCancel}
             lastReroutedTo={lastReroutedTo}
+            isAllocatingExperts={isAllocatingExperts}
           />
 
           {lastReroutedTo?.status === "pending" && (
@@ -142,6 +147,7 @@ export const AnswerActions = ({
               rejectionReason={rejectionReason}
               setRejectionReason={setRejectionReason}
               handleRejectReRouteAnswer={handleRejectReRouteAnswer}
+              isRejecting={isRejecting}
               lastReroutedTo={lastReroutedTo}
             />
           )}

--- a/frontend/src/features/question_details/components/answer_item/AnswerActions.tsx
+++ b/frontend/src/features/question_details/components/answer_item/AnswerActions.tsx
@@ -104,6 +104,9 @@ export const AnswerActions = ({
 
   return (
     <div className="flex items-center justify-center gap-2">
+      <span className="inline-flex items-center px-2.5 py-1 rounded-md bg-background text-foreground font-medium text-xs sm:text-sm whitespace-nowrap border-l-2 border-primary pl-2.5">
+          Iteration {answer.answerIteration}
+        </span>
       {
         showAprroveButton &&(
            <ApproveAnswerDialog

--- a/frontend/src/features/question_details/components/answer_item/AnswerActions.tsx
+++ b/frontend/src/features/question_details/components/answer_item/AnswerActions.tsx
@@ -48,6 +48,7 @@ interface AnswerActionsProps {
   reviews: any[];
   firstTrueIndex?: number;
   firstFalseOrMissingIndex?: number;
+  lastAnswerApprovalCount?: number;
 }
 
 export const AnswerActions = ({
@@ -87,17 +88,21 @@ export const AnswerActions = ({
   reviews,
   firstTrueIndex,
   firstFalseOrMissingIndex,
+  lastAnswerApprovalCount,
 }: AnswerActionsProps) => {
   const showActions =
     userRole !== "expert" &&
     (questionStatus === "in-review" || questionStatus === "re-routed") &&
     lastAnswerId === answer?._id;
+  const showAprroveButton = userRole !== "expert" &&
+    (questionStatus === "in-review" || questionStatus === "re-routed") &&
+    (lastAnswerApprovalCount??0) >= 3
 
   return (
     <div className="flex items-center justify-center gap-2">
-      {showActions && (
-        <>
-          <ApproveAnswerDialog
+      {
+        showAprroveButton &&(
+           <ApproveAnswerDialog
             editOpen={editOpen}
             setEditOpen={setEditOpen}
             editableAnswer={editableAnswer}
@@ -109,7 +114,11 @@ export const AnswerActions = ({
             lastReroutedTo={lastReroutedTo}
             approvalCount={answer.approvalCount}
           />
-
+        )
+      }
+      {showActions && (
+        <>
+         
           <ReRouteDialog
             isModalOpen={isModalOpen}
             setIsModalOpen={setIsModalOpen}

--- a/frontend/src/features/question_details/components/answer_item/AnswerItemHeader.tsx
+++ b/frontend/src/features/question_details/components/answer_item/AnswerItemHeader.tsx
@@ -37,10 +37,6 @@ export const AnswerItemHeader = ({
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
       <div className="flex items-center gap-2">
-        <span className="font-medium text-foreground">
-          Iteration {answer.answerIteration}
-        </span>
-
         {answer.isFinalAnswer && (
           <Badge variant="outline" className="text-green-600 border-green-600">
             Final
@@ -66,6 +62,9 @@ export const AnswerItemHeader = ({
 
         {isMine && <UserCheck className="w-4 h-4 text-blue-600 ml-1" />}
       </div>
+       {answer?.approvalCount !== undefined && answer?.approvalCount > 0 && (
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full bg-primary/10 text-green-400 font-medium text-xs whitespace-nowrap border border-primary/20">{answer.approvalCount} Approvals</span>
+        )}
     </div>
   );
 };

--- a/frontend/src/features/question_details/components/answer_item/ApproveAnswerDialog.tsx
+++ b/frontend/src/features/question_details/components/answer_item/ApproveAnswerDialog.tsx
@@ -41,11 +41,18 @@ export const ApproveAnswerDialog = ({
       <DialogTrigger asChild>
         <button
           disabled={lastReroutedTo?.status === "pending" || approvalCount < 3}
-          className={`bg-primary text-primary-foreground flex items-center gap-2 px-2 py-2 rounded
+          className={`
+             bg-primary text-primary-foreground 
+                      flex items-center gap-2 
+                      px-3 py-1 sm:px-4 sm:py-1
+                      rounded-md
+                      text-sm
+                      whitespace-nowrap
+                      transition-all duration-200
             ${
               lastReroutedTo?.status === "pending" || approvalCount < 3
                 ? "opacity-50 cursor-not-allowed"
-                : "hover:bg-primary/90"
+                : "hover:bg-primary/90 hover:shadow-md active:scale-95"
             }
           `}
         >

--- a/frontend/src/features/question_details/components/answer_item/ReRouteDialog.tsx
+++ b/frontend/src/features/question_details/components/answer_item/ReRouteDialog.tsx
@@ -53,11 +53,18 @@ export const ReRouteDialog = ({
       <DialogTrigger asChild>
         <button
           disabled={lastReroutedTo?.status === "pending"}
-          className={`bg-primary text-primary-foreground flex items-center gap-2 px-2 py-2 rounded
+          className={`
+             bg-primary text-primary-foreground 
+                      flex items-center gap-2 
+                      px-3 py-1 sm:px-4 sm:py-1
+                      rounded-md
+                      text-sm
+                      whitespace-nowrap
+                      transition-all duration-200
             ${
               lastReroutedTo?.status === "pending"
                 ? "opacity-50 cursor-not-allowed"
-                : "hover:bg-primary/90"
+                : "hover:bg-primary/90 hover:shadow-md active:scale-95"
             }
           `}
         >

--- a/frontend/src/features/question_details/components/answer_item/ReRouteDialog.tsx
+++ b/frontend/src/features/question_details/components/answer_item/ReRouteDialog.tsx
@@ -13,7 +13,7 @@ import { ScrollArea } from "@/components/atoms/scroll-area";
 import { Textarea } from "@/components/atoms/textarea";
 import { Checkbox } from "@/components/atoms/checkbox";
 import type { IUser } from "@/types";
-import { Send, UserPlus, User, X } from "lucide-react";
+import { Send, UserPlus, User, X, Loader2 } from "lucide-react";
 
 interface ReRouteDialogProps {
   isModalOpen: boolean;
@@ -26,6 +26,7 @@ interface ReRouteDialogProps {
   filteredExperts: IUser[];
   selectedExperts: string[];
   handleSelectExpert: (expertId: string) => void;
+  isAllocatingExperts?: boolean;
   handleSubmit: () => void;
   handleCancel: () => void;
   lastReroutedTo: any;
@@ -45,6 +46,7 @@ export const ReRouteDialog = ({
   handleSubmit,
   handleCancel,
   lastReroutedTo,
+  isAllocatingExperts,
 }: ReRouteDialogProps) => {
   return (
     <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
@@ -199,14 +201,23 @@ export const ReRouteDialog = ({
             variant="outline"
             onClick={handleCancel}
             className="hidden md:block"
+            disabled={isAllocatingExperts}
           >
             Cancel
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={selectedExperts.length === 0 || !comment.trim()}
+            disabled={selectedExperts.length === 0 || !comment.trim() || isAllocatingExperts}
           >
-            {`Submit (${selectedExperts.length} selected)`}
+            {
+             isAllocatingExperts?
+             <>
+             <Loader2 className="mr-2 h-4 w-4 animate-spin"/>
+             Allocating...
+             </>
+             :
+            `Submit (${selectedExperts.length} selected)`
+            }
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/features/question_details/components/answer_item/RejectReRouteDialog.tsx
+++ b/frontend/src/features/question_details/components/answer_item/RejectReRouteDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogTrigger,
 } from "@/components/atoms/dialog";
 import { Textarea } from "@/components/atoms/textarea";
-import { XCircle } from "lucide-react";
+import { Loader2, XCircle } from "lucide-react";
 
 interface RejectReRouteDialogProps {
   isRejectDialogOpen: boolean;
@@ -18,6 +18,7 @@ interface RejectReRouteDialogProps {
   setRejectionReason: (reason: string) => void;
   handleRejectReRouteAnswer: (reason: string) => void;
   lastReroutedTo: any;
+  isRejecting?: boolean;
 }
 
 export const RejectReRouteDialog = ({
@@ -27,6 +28,7 @@ export const RejectReRouteDialog = ({
   setRejectionReason,
   handleRejectReRouteAnswer,
   lastReroutedTo,
+  isRejecting,
 }: RejectReRouteDialogProps) => {
   return (
     <Dialog open={isRejectDialogOpen} onOpenChange={setIsRejectDialogOpen}>
@@ -63,17 +65,25 @@ export const RejectReRouteDialog = ({
           <Button
             variant="outline"
             onClick={() => setIsRejectDialogOpen(false)}
+            disabled={isRejecting}
           >
             Cancel
           </Button>
           <Button
-            disabled={rejectionReason.length < 8}
+            disabled={rejectionReason.length < 8 || isRejecting}
             onClick={() => {
               handleRejectReRouteAnswer(rejectionReason);
-              setIsRejectDialogOpen(false);
             }}
-          >
-            Submit
+          > 
+          {
+            isRejecting?
+            <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin"/>
+            Submitting...
+            </>
+            :
+            "Submit"
+          }
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/features/question_details/components/answer_item/RejectReRouteDialog.tsx
+++ b/frontend/src/features/question_details/components/answer_item/RejectReRouteDialog.tsx
@@ -35,15 +35,25 @@ export const RejectReRouteDialog = ({
       <DialogTrigger asChild>
         <button
           disabled={lastReroutedTo?.status !== "pending"}
-          className={`bg-red-400 text-primary-foreground flex items-center gap-2 px-2 py-2 rounded bg-red-100 dark:bg-red-900/30 border-red-300 dark:border-red-700 shadow-red-100/50
+          className={`
+            bg-red-400 text-primary-foreground 
+                      flex items-center gap-1.5 sm:gap-2 
+                      px-2 py-1 sm:px-3 sm:py-1 
+                      rounded-md
+                      text-xs sm:text-sm
+                      dark:bg-red-900/30 
+                      border border-red-300 dark:border-red-700 
+                      shadow-sm shadow-red-100/50
+                      whitespace-nowrap
+                      transition-all duration-200
             ${
               lastReroutedTo?.status !== "pending"
                 ? "opacity-50 cursor-not-allowed"
-                : "hover:bg-red/90"
+                : "hover:bg-red-500 dark:hover:bg-red-900/50 hover:shadow-md active:scale-95"
             }
           `}
         >
-          <XCircle className="w-3 h-3" />
+          <XCircle className="w-4 h-4" />
           Reject ReRoute
         </button>
       </DialogTrigger>

--- a/frontend/src/features/question_details/components/answer_item/ViewMoreDialog.tsx
+++ b/frontend/src/features/question_details/components/answer_item/ViewMoreDialog.tsx
@@ -36,9 +36,6 @@ export const ViewMoreDialog = ({
   return (
     <Dialog>
       <div className="flex items-center gap-2 ml-auto text-right">
-        {answer?.approvalCount !== undefined && answer?.approvalCount > 0 && (
-          <p className="text-sm">Approval count: {answer.approvalCount}</p>
-        )}
         <DialogTrigger asChild>
           <Button variant="outline" size="sm" className="w-full sm:w-auto">
             <Eye className="w-4 h-4 mr-2" />


### PR DESCRIPTION
**Description**

This PR focuses on improving the approval workflow by allowing users to select any answer that has received 3 consecutive approvals, instead of restricting approvals to only the latest set of consecutive answers.

**Changes**

- Refactored approval selection logic to support choosing from any valid consecutive approvals.
- Improved state handling to update status instantly after reroute.
- Added loaders to improve UX during async operations.
- Enhance button responsiveness and hover interactions

**Before**

- Users could only approve the latest answer that had 3 consecutive approvals.
- Updated status after rerouting was not reflected without a page refresh.
- No loader was shown during reroute or allocation operations, causing perceived delays.
- Action buttons were not responsive, causing layout shifts on smaller screens.

<img width="1799" height="758" alt="bf" src="https://github.com/user-attachments/assets/6993c05d-9b92-4a55-a932-994b44fc1114" />

**After**

- Users can now select and approve any answer that has 3 consecutive approvals, not just the latest one.
- Status updates are reflected immediately after rerouting without requiring a refresh.
- Loaders are shown during reroute and allocation operations, providing better user feedback.
- Action buttons are now responsive, with improved alignment and hover interactions.


<img width="1797" height="876" alt="af" src="https://github.com/user-attachments/assets/4e58f1a4-df69-406e-9852-ade3b61a08d7" />



<img width="1824" height="856" alt="af-2" src="https://github.com/user-attachments/assets/14d23a44-1097-4f3f-9b65-1685d3a42492" />

