### PR TITLE
Fix/serial number sequence not maintained across paginated pages

### DIFF
--- a/frontend/src/components/questions-page.tsx
+++ b/frontend/src/components/questions-page.tsx
@@ -351,6 +351,7 @@ export const QuestionsPage = ({
               onViewMore={handleViewMore}
               toggleSort={toggleSort}
               sort={sort}
+              limit={reviewLimit}
             />
           )}
         </>

--- a/frontend/src/components/questions-page.tsx
+++ b/frontend/src/components/questions-page.tsx
@@ -1,7 +1,7 @@
 import { useGetAllDetailedQuestions } from "@/hooks/api/question/useGetAllDetailedQuestions";
 //import { QuestionsFilters, QuestionsTable } from "./questions-table";
-import {QuestionsTable} from '../features/question-table-page/questions-table'
-import {QuestionsFilters} from '../features/question-table-page/QuestionsFilters'
+import { QuestionsTable } from "../features/question-table-page/questions-table";
+import { QuestionsFilters } from "../features/question-table-page/QuestionsFilters";
 import { useEffect, useMemo, useState } from "react";
 import { useGetQuestionFullDataById } from "@/hooks/api/question/useGetQuestionFullData";
 import { QuestionDetails } from "./question-details";
@@ -44,8 +44,8 @@ export const QuestionsPage = ({
   const [closedAtStart, setClosedAtStart] = useState<Date | undefined>(
     undefined,
   );
-  const [consecutiveApprovals,setConsecutiveApprovals]=useState("all")
-  const [autoAllocateFilter,setAutoAllocateFilter]=useState('all')
+  const [consecutiveApprovals, setConsecutiveApprovals] = useState("all");
+  const [autoAllocateFilter, setAutoAllocateFilter] = useState("all");
   const [closedAtEnd, setClosedAtEnd] = useState<Date | undefined>(undefined);
 
   // const observerRef = useRef<IntersectionObserver | null>(null);
@@ -103,7 +103,7 @@ export const QuestionsPage = ({
       closedAtStart,
       closedAtEnd,
       consecutiveApprovals,
-      autoAllocateFilter
+      autoAllocateFilter,
     }),
     [
       status,
@@ -121,7 +121,7 @@ export const QuestionsPage = ({
       closedAtEnd,
       closedAtStart,
       consecutiveApprovals,
-      autoAllocateFilter
+      autoAllocateFilter,
     ],
   );
 
@@ -187,9 +187,8 @@ export const QuestionsPage = ({
     review_level?: ReviewLevel;
     closedAtEnd?: Date | undefined;
     closedAtStart?: Date | undefined;
-    consecutiveApprovals?:string,
-    autoAllocateFilter?:string,
-
+    consecutiveApprovals?: string;
+    autoAllocateFilter?: string;
   }) => {
     if (next.status !== undefined) setStatus(next.status);
     if (next.source !== undefined) setSource(next.source);
@@ -205,8 +204,10 @@ export const QuestionsPage = ({
     if (next.review_level !== undefined) setReviewLevel(next.review_level);
     if (next.closedAtStart !== undefined) setClosedAtStart(next.closedAtStart);
     if (next.closedAtEnd !== undefined) setClosedAtEnd(next.closedAtEnd);
-    if (next.consecutiveApprovals !== undefined) setConsecutiveApprovals(next.consecutiveApprovals);
-    if(next.autoAllocateFilter!==undefined) setAutoAllocateFilter(next.autoAllocateFilter)
+    if (next.consecutiveApprovals !== undefined)
+      setConsecutiveApprovals(next.consecutiveApprovals);
+    if (next.autoAllocateFilter !== undefined)
+      setAutoAllocateFilter(next.autoAllocateFilter);
     // Reset pagination to page 1 when filters are applied
     setCurrentPage(1);
     setReviewPage(1);
@@ -235,8 +236,8 @@ export const QuestionsPage = ({
     setEndTime(undefined);
     setClosedAtEnd(undefined);
     setClosedAtStart(undefined);
-    setConsecutiveApprovals('all')
-    setAutoAllocateFilter('all')
+    setConsecutiveApprovals("all");
+    setAutoAllocateFilter("all");
   };
 
   const handleViewMore = (questoinId: string) => {

--- a/frontend/src/features/auth/utils/validate.ts
+++ b/frontend/src/features/auth/utils/validate.ts
@@ -1,7 +1,7 @@
 export const validateEmail = (email: string, domain = "annam.ai") => {
   if (!email) return "Email is required";
-  // if (!new RegExp(`^[^\\s@]+@${domain}$`).test(email))
-  //   return `Please enter a valid email (${domain})`;
+  if (!new RegExp(`^[^\\s@]+@${domain}$`).test(email))
+    return `Please enter a valid email (${domain})`;
   return "";
 };
 

--- a/frontend/src/features/auth/utils/validate.ts
+++ b/frontend/src/features/auth/utils/validate.ts
@@ -1,7 +1,7 @@
 export const validateEmail = (email: string, domain = "annam.ai") => {
   if (!email) return "Email is required";
-  if (!new RegExp(`^[^\\s@]+@${domain}$`).test(email))
-    return `Please enter a valid email (${domain})`;
+  // if (!new RegExp(`^[^\\s@]+@${domain}$`).test(email))
+  //   return `Please enter a valid email (${domain})`;
   return "";
 };
 

--- a/frontend/src/features/questions/components/baseTable.tsx
+++ b/frontend/src/features/questions/components/baseTable.tsx
@@ -98,7 +98,9 @@ export function BaseTable<T>({
             <TableRow key={i} className="text-center hover:bg-muted/40">
               {columns.map((col) => (
                 <TableCell key={col.key as string}>
-                  {col.render ? col.render(row, (startIndex ?? 0) + i) : (row as any)[col.key]}
+                  {col.render
+                    ? col.render(row, (startIndex ?? 0) + i)
+                    : (row as any)[col.key]}
                 </TableCell>
               ))}
             </TableRow>

--- a/frontend/src/features/questions/components/baseTable.tsx
+++ b/frontend/src/features/questions/components/baseTable.tsx
@@ -23,6 +23,7 @@ type BaseTableProps<T> = {
   emptyMessage?: string;
   sort: string;
   onSort: (key: string) => void;
+  startIndex?: number;
 };
 
 export function BaseTable<T>({
@@ -32,6 +33,7 @@ export function BaseTable<T>({
   emptyMessage = "No records found",
   sort,
   onSort,
+  startIndex,
 }: BaseTableProps<T>) {
   return (
     <Table className="min-w-[800px] table-fixed">
@@ -96,7 +98,7 @@ export function BaseTable<T>({
             <TableRow key={i} className="text-center hover:bg-muted/40">
               {columns.map((col) => (
                 <TableCell key={col.key as string}>
-                  {col.render ? col.render(row, i) : (row as any)[col.key]}
+                  {col.render ? col.render(row, (startIndex ?? 0) + i) : (row as any)[col.key]}
                 </TableCell>
               ))}
             </TableRow>

--- a/frontend/src/features/questions/components/review-level/ReviewLevelsTable.tsx
+++ b/frontend/src/features/questions/components/review-level/ReviewLevelsTable.tsx
@@ -16,6 +16,8 @@ type Props = {
 
   sort: string;
   toggleSort: (key: string) => void;
+
+  limit: number;
 };
 
 export function ReviewLevelsTable({
@@ -27,6 +29,7 @@ export function ReviewLevelsTable({
   onViewMore,
   toggleSort,
   sort,
+  limit,
 }: Props) {
   return (
     <div className="ps-4 md:ps-0">
@@ -39,6 +42,7 @@ export function ReviewLevelsTable({
             isLoading={isLoading}
             onSort={toggleSort}
             sort={sort}
+            startIndex={(page - 1) * limit}
           />
         </div>
 


### PR DESCRIPTION
**Description**

Serial numbers were not maintained correctly across paginated pages in turnaround mode on the All Questions page.

**Before**

- Serial numbers restarted from 1 on each page.

<img width="1842" height="777" alt="bf" src="https://github.com/user-attachments/assets/e00f61f1-9d0f-4fec-800e-93cac60f710c" />



**After**

- Serial numbers now continue correctly across paginated pages.
<img width="1786" height="848" alt="af" src="https://github.com/user-attachments/assets/ba93a87d-c5a7-4f62-ae4e-02f13761607c" />

