### PR TITLE
Feat/collapsing sidebar

### DIFF
--- a/frontend/src/features/qa-interface-page/QA-interface.tsx
+++ b/frontend/src/features/qa-interface-page/QA-interface.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useMemo, useRef, useState,  } from "react";
-import {CheckCircle,RefreshCw,RotateCcw,Info,Loader2,Send,FileText,Bot} from "lucide-react";
+import {CheckCircle,RefreshCw,RotateCcw,Info,Loader2,Send,FileText,Bot, ChevronRight} from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/atoms/card";
 import { RadioGroup, RadioGroupItem } from "../../components/atoms/radio-group";
 import { Label } from "../../components/atoms/label";
@@ -64,6 +64,9 @@ export const QAInterface = ({
   selectQuestionType:string|null;
   onManualSelectQuestionType: (type: string | null) => void;
 }) => {
+
+  // toggle sidebar
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState<boolean>(false);
   
   const [actionType, setActionType] = useState<"allocated" | "reroute">(
     "reroute"
@@ -523,10 +526,30 @@ const handleActionChange = (value: string) => {
     <div className=" mx-auto px-4 md:px-6 bg-transparent py-4 ">
       <div className="flex flex-col space-y-6">
         <div
-          className={`grid grid-cols-1 ${
-            questions.length && !isLoadingTargetQuestion && "lg:grid-cols-2"
-          } gap-6`}
+           className={`grid grid-cols-1 ${
+            questions.length && !isLoadingTargetQuestion
+              ? isSidebarCollapsed
+                ? "lg:grid-cols-[minmax(0,_1fr)]"
+                : "lg:grid-cols-[minmax(400px,_1fr)_minmax(400px,_1fr)]"
+              : ""
+          } gap-6 transition-all duration-300 relative`}
         >
+           {isSidebarCollapsed && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsSidebarCollapsed(false)}
+              className="absolute -left-12  h-full text-center ml-2 px-2 z-10  border border-gray-200 dark:border-gray-700 shadow-sm rounded-lg bg-transparent mb-3 md:mb-0"
+              title="Expand sidebar"
+            >
+              <ChevronRight className="w-4 h-4" />
+              <span className="sr-only">Expand sidebar</span>
+            </Button>
+          )}
+        
+          <div
+            className={`transition-all duration-300 ${isSidebarCollapsed ? "hidden" : "w-full"}`}
+          >
          <QaHeader
   questions={questions}
   selectedQuestion={selectedQuestion}
@@ -542,10 +565,13 @@ const handleActionChange = (value: string) => {
   scrollRef={scrollRef}
   questionItemRefs={questionItemRefs}
   setQuestionRef={setQuestionRef}
+  isCollapsed={isSidebarCollapsed}
+  onToggleCollapse={() =>setIsSidebarCollapsed(!isSidebarCollapsed)}
 />
-
+</div>
           {selectedQuestionData &&
             selectedQuestionData?.history?.length == 0 && (
+              <div className={`transition-all duration-300 w-full`}>
               <Card className="w-full  border border-gray-200 dark:border-gray-700 shadow-sm rounded-lg bg-transparent mb-3 md:mb-0">
                 <CardHeader className="flex items-center gap-2 border-b border-gray-200 dark:border-gray-700">
                   <div className="p-2 rounded-lg bg-primary/10">
@@ -730,12 +756,14 @@ const handleActionChange = (value: string) => {
                   )}
                 </CardContent>
               </Card>
+              </div>
             )}
 
           {questions &&
             questions.length != 0 && actionType=="allocated" &&
             selectedQuestionData &&
             selectedQuestionData?.history?.length > 0 && (
+              <div className={`transition-all duration-300 w-full`}> 
               <ResponseTimeline
                 SourceUrlManager={SourceUrlManager}
                 handleReset={handleReset}
@@ -753,12 +781,14 @@ const handleActionChange = (value: string) => {
                 setSelectedQuestion={setSelectedQuestion}
                 refetchQuestions={refetch}
               />
+              </div>
             )}
             {questions &&
             questions.length != 0 && actionType=="reroute" &&
             selectedQuestionData &&selectedQuestionData?.history?.length > 0 &&
             
              (
+              <div className={`transition-all duration-300 w-full`}>
               <ReRouteResponseTimeline
                 SourceUrlManager={SourceUrlManager}
                 handleReset={handleReset}
@@ -778,6 +808,7 @@ const handleActionChange = (value: string) => {
                 setSelectedQuestion={setSelectedQuestion}
                 refetchQuestions={refetch}
               />
+              </div>
             )}
         </div>
       </div>

--- a/frontend/src/features/qa-interface-page/QA-interface.tsx
+++ b/frontend/src/features/qa-interface-page/QA-interface.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useMemo, useRef, useState,  } from "react";
-import {CheckCircle,RefreshCw,RotateCcw,Info,Loader2,Send,FileText,Bot, ChevronRight} from "lucide-react";
+import {CheckCircle,RefreshCw,RotateCcw,Info,Loader2,Send,FileText,Bot, ChevronsRight} from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/atoms/card";
 import { RadioGroup, RadioGroupItem } from "../../components/atoms/radio-group";
 import { Label } from "../../components/atoms/label";
@@ -540,10 +540,10 @@ const handleActionChange = (value: string) => {
               size="sm"
               onClick={() => setIsSidebarCollapsed(false)}
               className="absolute -left-12  h-full text-center ml-2 px-2 z-10  border border-gray-200 dark:border-gray-700 shadow-sm rounded-lg bg-transparent mb-3 md:mb-0"
-              title="Expand sidebar"
+              title="Expand Questions"
             >
-              <ChevronRight className="w-4 h-4" />
-              <span className="sr-only">Expand sidebar</span>
+              <ChevronsRight className="w-4 h-4" />
+              <span className="sr-only">Expand Questions</span>
             </Button>
           )}
         
@@ -565,7 +565,6 @@ const handleActionChange = (value: string) => {
   scrollRef={scrollRef}
   questionItemRefs={questionItemRefs}
   setQuestionRef={setQuestionRef}
-  isCollapsed={isSidebarCollapsed}
   onToggleCollapse={() =>setIsSidebarCollapsed(!isSidebarCollapsed)}
 />
 </div>

--- a/frontend/src/features/qa-interface-page/QaHeader.tsx
+++ b/frontend/src/features/qa-interface-page/QaHeader.tsx
@@ -35,7 +35,6 @@ type QaHeaderProps={
   scrollRef: React.RefObject<HTMLDivElement|null>;
   questionItemRefs: React.MutableRefObject<Record<string, HTMLDivElement>>;
   setQuestionRef: (id: string, el: HTMLDivElement | null) => void;
-  isCollapsed: boolean;
   onToggleCollapse: () => void;
 }
 export const QaHeader=({ questions,
@@ -51,7 +50,6 @@ export const QaHeader=({ questions,
   onReviewLevelChange,
   scrollRef,
   setQuestionRef,
-  isCollapsed,
   onToggleCollapse,
 }:QaHeaderProps)=>{
   return(
@@ -60,15 +58,6 @@ export const QaHeader=({ questions,
             <CardHeader className="border-b flex flex-row items-center justify-between pb-4">
               <TooltipProvider>
                 <div className="flex items-center gap-2">
-                  <Button
-                variant="outline"
-                size="sm"
-                onClick={onToggleCollapse}
-                className="h-9 px-2"
-              >
-                <ChevronLeft className="w-4 h-4" />
-                <span className="sr-only">Collapse sidebar</span>
-              </Button>
                   <CardTitle className="text-md md:text-lg font-semibold">
                     Question Queues
                   </CardTitle>
@@ -128,6 +117,17 @@ export const QaHeader=({ questions,
                 >
                   <RefreshCw className="w-4 h-4" />
                   <span className="sr-only">Refresh</span>
+                </Button>
+
+                 <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onToggleCollapse}
+                  className="h-9 px-2 ml-2"
+                  title="Collapse Questions"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                  <span className="sr-only">Collapse Questions</span>
                 </Button>
               </div>
             </CardHeader>

--- a/frontend/src/features/qa-interface-page/QaHeader.tsx
+++ b/frontend/src/features/qa-interface-page/QaHeader.tsx
@@ -119,7 +119,10 @@ export const QaHeader=({ questions,
                   <span className="sr-only">Refresh</span>
                 </Button>
 
-                 <Button
+                {
+                  !isLoading && questions.length !== 0
+                   && (
+                    <Button
                   variant="ghost"
                   size="sm"
                   onClick={onToggleCollapse}
@@ -129,6 +132,9 @@ export const QaHeader=({ questions,
                   <ChevronLeft className="w-4 h-4" />
                   <span className="sr-only">Collapse Questions</span>
                 </Button>
+                   )
+                }
+                 
               </div>
             </CardHeader>
             {isLoading || isLoadingTarget ? (

--- a/frontend/src/features/qa-interface-page/QaHeader.tsx
+++ b/frontend/src/features/qa-interface-page/QaHeader.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from "../../components/atoms/button";
 import { Review_Level_QAI } from "@/components/MetaData";
 import {Select,SelectTrigger, SelectValue,SelectContent,SelectItem,} from "@/components/atoms/select";
-import {CheckCircle,RefreshCw,RotateCcw,Info,Loader2,Send,FileText,Bot} from "lucide-react";
+import {CheckCircle,RefreshCw,RotateCcw,Info,Loader2,Send,FileText,Bot, ChevronLeft} from "lucide-react";
 import type {
   HistoryItem,
   IQuestion,
@@ -35,6 +35,8 @@ type QaHeaderProps={
   scrollRef: React.RefObject<HTMLDivElement|null>;
   questionItemRefs: React.MutableRefObject<Record<string, HTMLDivElement>>;
   setQuestionRef: (id: string, el: HTMLDivElement | null) => void;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
 }
 export const QaHeader=({ questions,
   selectedQuestion,
@@ -48,13 +50,25 @@ export const QaHeader=({ questions,
   reviewLevel,
   onReviewLevelChange,
   scrollRef,
-  setQuestionRef}:QaHeaderProps)=>{
+  setQuestionRef,
+  isCollapsed,
+  onToggleCollapse,
+}:QaHeaderProps)=>{
   return(
     <div>
       <Card className="w-full md:max-h-[120vh]  max-h-[80vh] min-h-[90vh] border border-gray-200 dark:border-gray-700 shadow-sm rounded-lg bg-transparent">
             <CardHeader className="border-b flex flex-row items-center justify-between pb-4">
               <TooltipProvider>
                 <div className="flex items-center gap-2">
+                  <Button
+                variant="outline"
+                size="sm"
+                onClick={onToggleCollapse}
+                className="h-9 px-2"
+              >
+                <ChevronLeft className="w-4 h-4" />
+                <span className="sr-only">Collapse sidebar</span>
+              </Button>
                   <CardTitle className="text-md md:text-lg font-semibold">
                     Question Queues
                   </CardTitle>


### PR DESCRIPTION
**Description**

This PR introduces a new feature that allows the question queue on the expert side to be shrunk or expanded, improving focus on the Response area while keeping the queue accessible when needed.


<img width="1845" height="768" alt="af-1" src="https://github.com/user-attachments/assets/cd27c008-71cd-465d-9217-3e35033107a0" />




<img width="1895" height="774" alt="af-2" src="https://github.com/user-attachments/assets/9a294bde-8d9f-4fe9-9d65-9dbc25fa8260" />
