### PR TITLE
Feat/add confirmation modal reallocate

### DIFF
--- a/frontend/src/components/atoms/ThemeToggle.tsx
+++ b/frontend/src/components/atoms/ThemeToggle.tsx
@@ -18,7 +18,7 @@ export const ThemeToggleCompact = () => {
       variant="ghost"
       size="sm"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className="h-10 w-10 px-0 me-3 hover:bg-gray-200 "
+      className="h-10 w-10 px-0 me-3 hover:bg-gray-200 ml-1"
     >
       <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />

--- a/frontend/src/features/question-table-page/QuestionsFilters.tsx
+++ b/frontend/src/features/question-table-page/QuestionsFilters.tsx
@@ -120,6 +120,7 @@ export const QuestionsFilters = ({
     });
   const { mutateAsync: reAllocateLessWorkload, isPending: reAllocateQuestion } =
     useReAllocateLessWorkload();
+  const [isReAllocateOpen,setIsReAllocateOpen] = useState(false);
   const [isReAllocateDisabled, setIsReAllocateDisabled] = useState(false);
   const handleReAllocateLessWorkload = async () => {
     try {
@@ -634,7 +635,7 @@ export const QuestionsFilters = ({
                 <button
                   className="w-full flex items-center justify-between p-4 bg-white dark:bg-[#1a1a1a] hover:bg-green-50 dark:hover:bg-green-500/5 border border-gray-200 dark:border-gray-800 hover:border-green-500/50 rounded-xl group transition-all shadow-sm dark:shadow-none"
                   onClick={() => {
-                    handleReAllocateLessWorkload();
+                    setIsReAllocateOpen(true);
                     setIsSidebarOpen(false);
                   }}
                 >
@@ -718,6 +719,17 @@ export const QuestionsFilters = ({
           </span>
         </span>
       </div>
+      <ConfirmationModal
+                title="ReAllocate Work load?"
+                description="Are you sure you want to ReAllocate work load?"
+                confirmText="ReAllocate"
+                cancelText="Cancel"
+                isLoading={reAllocateQuestion}
+                type="default"
+                open={isReAllocateOpen}
+                onOpenChange={setIsReAllocateOpen}
+                onConfirm={handleReAllocateLessWorkload}
+              />
     </div>
   );
 };

--- a/frontend/src/features/question-table-page/QuestionsFilters.tsx
+++ b/frontend/src/features/question-table-page/QuestionsFilters.tsx
@@ -402,7 +402,7 @@ export const QuestionsFilters = ({
       </div>
 
       <div className="w-full sm:w-auto flex flex-wrap items-center gap-2 sm:gap-3 justify-between sm:justify-end">
-        <div className="relative flex items-center gap-2">
+        <div className="relative hidden md:flex items-center gap-2">
           <ViewDropdown view={view} setView={setView} />
           <span className="absolute -top-2 -right-2 bg-red-500 text-[8px] text-white px-1 rounded uppercase font-bold">
             New

--- a/frontend/src/features/question-table-page/QuestionsFilters.tsx
+++ b/frontend/src/features/question-table-page/QuestionsFilters.tsx
@@ -720,7 +720,7 @@ export const QuestionsFilters = ({
         </span>
       </div>
       <ConfirmationModal
-                title="ReAllocate Work load?"
+                title="ReAllocate work load?"
                 description="Are you sure you want to ReAllocate work load?"
                 confirmText="ReAllocate"
                 cancelText="Cancel"


### PR DESCRIPTION
**Description**

This PR introduces a confirmation modal for the ReAllocate feature and includes several minor UI bug fixes.

**Changes**

- Added a confirmation modal for the ReAllocate feature to prevent accidental actions.
- Fixed overlapping issue between the notification icon and theme icon on hover.
- Hid the "New" tag on small devices.

**before**

- No confirmation modal was shown for the ReAllocate feature.
- The theme icon overlapped the notification icon on hover.
- The "New" tag was visible on small screens where the related component is hide in small screen.


<img width="193" height="112" alt="Screenshot 2026-02-18 160901" src="https://github.com/user-attachments/assets/a1e25138-3f56-407c-89a0-9c203948a158" />
<img width="908" height="401" alt="Screenshot 2026-02-18 172154" src="https://github.com/user-attachments/assets/65e4c02f-2b26-49ae-bb3f-b7e5c772568a" />


**After**

- A confirmation modal is displayed before performing the ReAllocate action.
- Hover interaction between the notification and theme icons is properly aligned with no overlap.
- The "New" tag is hidden on small devices.

<img width="1871" height="805" alt="Screenshot 2026-02-18 173406" src="https://github.com/user-attachments/assets/c569f377-045e-4990-89f3-75ca756a7967" />
<img width="914" height="749" alt="Screenshot 2026-02-18 173342" src="https://github.com/user-attachments/assets/b2fe7386-b188-4fd5-bee2-20f6dd5f11d3" />
<img width="461" height="151" alt="Screenshot 2026-02-18 173523" src="https://github.com/user-attachments/assets/66df2435-91c9-42e4-ac8b-a31bea5fea4c" />
