### PR TITLE
refactor: remove excel report button in dashboard

### DIFF
--- a/frontend/src/components/dashboard.tsx
+++ b/frontend/src/components/dashboard.tsx
@@ -206,23 +206,6 @@ export const Dashboard = () => {
           </div>
         </div>
        <div>
-  <button
-    className="
-      inline-flex items-center gap-2
-      bg-primary text-primary-foreground
-      px-5 py-2.5
-      rounded-xl
-      text-sm font-semibold
-      shadow-md hover:shadow-lg
-      transition-all duration-300
-      hover:scale-[1.02]
-      active:scale-[0.98]
-      focus:outline-none focus:ring-2 focus:ring-primary/40
-      mb-5
-    "
-  >
-    Excel Report
-  </button>
 </div>
 
         {/* Top Stats Row */}


### PR DESCRIPTION
**Description**

This PR removes the unused Excel report button from the dashboard UI. The button was no longer required and its removal improves interface clarity and prevents user confusion.