### PR TITLE
duplicate download button and api addition

### DIFF
--- a/backend/src/modules/question/controllers/QuestionController.ts
+++ b/backend/src/modules/question/controllers/QuestionController.ts
@@ -303,9 +303,34 @@ export class QuestionController {
     });
 
     if (!data) {
-      response.status(200).json({ 
-        success: false, 
-        message: "No questions found for the selected filters" 
+      response.status(200).json({
+        success: false,
+        message: "No questions found for the selected filters"
+      });
+      return;
+    }
+
+    return Buffer.from(data);
+  }
+
+  @Get("/download-duplicate-questions-report")
+  @Authorized()
+  @ContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+  @OpenAPI({ summary: 'Download duplicate questions report as Excel' })
+  async downloadDuplicateReport(
+    @QueryParams() query: { startDate?: string; endDate?: string },
+    @CurrentUser() user: IUser,
+    @Res() response: any,
+  ) {
+    const startDate = query.startDate ? new Date(query.startDate) : undefined;
+    const endDate = query.endDate ? new Date(query.endDate) : undefined;
+
+    const data = await this.questionService.generateDuplicateQuestionReport(startDate, endDate);
+
+    if (!data) {
+      response.status(200).json({
+        success: false,
+        message: "No duplicate questions found for the selected date range"
       });
       return;
     }

--- a/backend/src/modules/question/interfaces/IQuestionService.ts
+++ b/backend/src/modules/question/interfaces/IQuestionService.ts
@@ -151,4 +151,5 @@ export interface IQuestionService {
     domain?: string;
     status?: string;
   }): Promise<ArrayBuffer | null>
+  generateDuplicateQuestionReport(startDate?: Date, endDate?: Date): Promise<ArrayBuffer | null>
 }

--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2508,5 +2508,52 @@ export class QuestionService extends BaseService implements IQuestionService {
     });
   }
 
-  
+  async generateDuplicateQuestionReport(startDate?: Date, endDate?: Date): Promise<ArrayBuffer | null> {
+    return this._withTransaction(async (session) => {
+      if (!startDate || !endDate) {
+        throw new BadRequestError('startDate and endDate are required');
+      }
+
+      // Fetch duplicates using the repository
+      const duplicateQuestions = await this.duplicateQuestionRepository.findDuplicatesByDateRange(startDate, endDate, session);
+
+      if (!duplicateQuestions || duplicateQuestions.length === 0) {
+        return null;
+      }
+
+      // Create Excel workbook
+      const workbook = new ExcelJS.Workbook();
+      const sheet = workbook.addWorksheet("Similar Questions");
+
+      // Define columns
+      sheet.columns = [
+        { header: "createdAt", key: "createdAt", width: 22 },
+        { header: "question", key: "question", width: 60 },
+        { header: "source", key: "source", width: 15 },
+        { header: "similarityScore", key: "similarityScore", width: 15 },
+        { header: "referenceQuestion", key: "referenceQuestion", width: 30 },
+      ];
+
+      // Add data rows
+      duplicateQuestions.forEach(q => {
+        sheet.addRow({
+          createdAt: q.createdAt,
+          question: q.question,
+          source: q.source,
+          similarityScore: q.similarityScore,
+          referenceQuestion: q.referenceQuestion ? q.referenceQuestion : '',
+        });
+      });
+
+      // Style the header row
+      const headerRow = sheet.getRow(1);
+      headerRow.font = { bold: true };
+      headerRow.alignment = { horizontal: 'center', vertical: 'middle' };
+
+      // Generate buffer
+      const buffer = await workbook.xlsx.writeBuffer();
+      return buffer as ArrayBuffer;
+    });
+  }
+
 }

--- a/backend/src/shared/database/interfaces/IDuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/interfaces/IDuplicateQuestionRepository.ts
@@ -23,13 +23,18 @@ export interface IDuplicateQuestionRepository {
    * @param session - Optional MongoDB client session for transactions.
    * @returns A promise that resolves to an object containing the number of inserted questions.
    */
- 
+
   addDuplicate(
     duplicateData: ISimilarQuestion,
     session?: ClientSession,
   ): Promise<{ insertedId: string }>;
   findDuplicatesByMatchedId(
     matchedQuestionId: string,
+    session?: ClientSession,
+  ): Promise<ISimilarQuestion[]>;
+  findDuplicatesByDateRange(
+    startDate: Date,
+    endDate: Date,
     session?: ClientSession,
   ): Promise<ISimilarQuestion[]>;
 }

--- a/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
@@ -68,4 +68,36 @@ export class DuplicateQuestionRepository  implements IDuplicateQuestionRepositor
       );
     }
   }
+  async findDuplicatesByDateRange(
+    startDate: Date,
+    endDate: Date,
+    session?: ClientSession,
+  ): Promise<ISimilarQuestion[]> {
+    try {
+      await this.init();
+
+      // Ensure endDate includes the full day
+      const endOfDay = new Date(endDate);
+      endOfDay.setHours(23, 59, 59, 999);
+
+      const duplicates = await this.DuplicateQuestionCollection.find(
+        {
+          createdAt: {
+            $gte: startDate,
+            $lte: endOfDay
+          }
+        },
+        { session },
+      ).toArray();
+
+      return duplicates.map(d => ({
+        ...d,
+        _id: d._id?.toString(),
+      })) as ISimilarQuestion[];
+    } catch (error) {
+      throw new InternalServerError(
+        `Error while fetching similar questions by date range: ${error}`,
+      );
+    }
+  }
 }

--- a/frontend/src/features/question-table-page/DownloadDuplicateReportButton.tsx
+++ b/frontend/src/features/question-table-page/DownloadDuplicateReportButton.tsx
@@ -15,7 +15,7 @@ import {
 import { Calendar } from "@/components/atoms/calendar";
 import { formatDateLocal } from "@/utils/formatDate";
 import type { DateRange } from "react-day-picker";
-import { format } from "date-fns";
+import { format, differenceInDays } from "date-fns";
 
 export const DownloadDuplicateReportButton = ({ onOpenDialog }: { onOpenDialog?: () => void }) => {
   const questionService = new QuestionService();
@@ -30,6 +30,11 @@ export const DownloadDuplicateReportButton = ({ onOpenDialog }: { onOpenDialog?:
     if (!downloadDateRange?.from || !downloadDateRange?.to) {
       toast.error("Please select a date range first");
       setIsDateDialogOpen(true);
+      return;
+    }
+
+    if (differenceInDays(downloadDateRange.to, downloadDateRange.from) > 31) {
+      toast.error("Date range cannot exceed 1 month. Please select a shorter range.");
       return;
     }
 

--- a/frontend/src/features/question-table-page/DownloadDuplicateReportButton.tsx
+++ b/frontend/src/features/question-table-page/DownloadDuplicateReportButton.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { Button } from "../../components/atoms/button";
+import { Download, Loader2, CalendarIcon } from "lucide-react";
+import { toast } from "sonner";
+import { QuestionService } from "@/hooks/services/questionService";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+  DialogClose,
+} from "@/components/atoms/dialog";
+import { Calendar } from "@/components/atoms/calendar";
+import { formatDateLocal } from "@/utils/formatDate";
+import type { DateRange } from "react-day-picker";
+import { format } from "date-fns";
+
+export const DownloadDuplicateReportButton = ({ onOpenDialog }: { onOpenDialog?: () => void }) => {
+  const questionService = new QuestionService();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [downloadDateRange, setDownloadDateRange] = useState<
+    DateRange | undefined
+  >(undefined);
+  const [isDateDialogOpen, setIsDateDialogOpen] = useState(false);
+
+  const handleDownloadReport = async () => {
+    // Validate date range
+    if (!downloadDateRange?.from || !downloadDateRange?.to) {
+      toast.error("Please select a date range first");
+      setIsDateDialogOpen(true);
+      return;
+    }
+
+    try {
+      setIsDownloading(true);
+      toast.info("Preparing download...");
+
+      const startDate = formatDateLocal(downloadDateRange.from);
+      const endDate = formatDateLocal(downloadDateRange.to);
+
+      // Download duplicate report
+      const blob = await questionService.downloadDuplicateQuestionsReport(
+        startDate,
+        endDate
+      );
+
+      // Create download link
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `similar-questions-report-${startDate}-to-${endDate}.xlsx`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+
+      toast.success("Similar Questions report downloaded successfully!");
+      setIsDateDialogOpen(false);
+    } catch (error) {
+      console.error("Download error:", error);
+      const errorMessage = error instanceof Error ? error.message : "Failed to download similar questions report";
+      toast.error(errorMessage);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isDateDialogOpen} onOpenChange={setIsDateDialogOpen}>
+      <DialogTrigger asChild>
+        <button
+          className="w-full flex items-center justify-between p-0 bg-transparent transition-all"
+          disabled={isDownloading}
+          onClick={() => onOpenDialog?.()}
+        >
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-lg bg-teal-100 dark:bg-teal-500/10 flex items-center justify-center text-teal-600 dark:text-teal-400">
+              {isDownloading ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <Download className="h-5 w-5" />
+              )}
+            </div>
+            <div className="text-left">
+              <p className="text-sm font-bold text-gray-900 dark:text-white">
+                {isDownloading ? "Downloading..." : "Similar Questions Report"}
+              </p>
+              <p className="text-[11px] text-gray-500">
+                List of similar questions within a date range
+              </p>
+            </div>
+          </div>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-w-[min(90vw,800px)] w-full max-h-[90vh] overflow-hidden flex flex-col p-4">
+        <DialogHeader className="space-y-2 flex-shrink-0">
+          <DialogTitle className="text-lg font-semibold">
+            Select Date Range for Similar Questions Report
+          </DialogTitle>
+          <div className="text-xs text-muted-foreground bg-muted/50 p-2 rounded-md border">
+            Select a date range to download the list of similar
+            questions matching with the database.
+          </div>
+        </DialogHeader>
+        <div className="space-y-3 overflow-y-auto flex-1 py-2">
+          <div className="flex items-center gap-2 text-xs bg-primary/5 p-2 rounded-md border border-primary/20">
+            <CalendarIcon className="h-4 w-4 text-primary flex-shrink-0" />
+            <span className="font-medium text-sm">
+              {downloadDateRange?.from && downloadDateRange?.to
+                ? `${format(downloadDateRange.from, "MMM dd, yyyy")} - ${format(downloadDateRange.to, "MMM dd, yyyy")}`
+                : "No date range selected"}
+            </span>
+          </div>
+          <div className="flex justify-center overflow-x-auto pb-2">
+            <Calendar
+              mode="range"
+              selected={downloadDateRange}
+              onSelect={setDownloadDateRange}
+              numberOfMonths={2}
+              disabled={(date) => date > new Date()}
+              className="rounded-md border shadow-sm scale-95"
+            />
+          </div>
+        </div>
+        <DialogFooter className="gap-2 pt-3 flex-shrink-0">
+          <DialogClose asChild>
+            <Button
+              variant="outline"
+              type="button"
+              className="w-full sm:w-auto"
+            >
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            onClick={handleDownloadReport}
+            disabled={
+              !downloadDateRange?.from ||
+              !downloadDateRange?.to ||
+              isDownloading
+            }
+            className="w-full sm:w-auto"
+          >
+            {isDownloading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Downloading...
+              </>
+            ) : (
+              <>
+                <Download className="h-4 w-4 mr-2" />
+                Download Excel
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+

--- a/frontend/src/features/question-table-page/QuestionsFilters.tsx
+++ b/frontend/src/features/question-table-page/QuestionsFilters.tsx
@@ -39,10 +39,11 @@ import { useAddQuestion } from "@/hooks/api/question/useAddQuestion";
 
 import { AddOrEditQuestionDialog } from "./AddOrEditQuestionDialog";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/atoms/tooltip";
-import {useReAllocateLessWorkload} from '@/hooks/api/question/useReAllocateLessWorkload';
+import { useReAllocateLessWorkload } from '@/hooks/api/question/useReAllocateLessWorkload';
 import { DownloadReportButton } from "./DownloadReportButton";
 import { DownloadOverallReportButton } from "./DownloadOverallReportButton";
 import { DownloadFilteredReportButton } from "./DownloadFilteredReportButton";
+import { DownloadDuplicateReportButton } from "./DownloadDuplicateReportButton";
 import {
   allModeColumns,
   commonColumns,
@@ -487,7 +488,7 @@ export const QuestionsFilters = ({
             </Button>
           </div>
         )}
-        
+
         {/* <span className="hidden md:block text-sm text-muted-foreground whitespace-nowrap">
           Total: {totalQuestions}
         </span> */}
@@ -563,11 +564,10 @@ export const QuestionsFilters = ({
                         key={key}
                         onClick={() => toggleColumn(key)}
                         className={`flex items-center justify-between px-5 py-2 rounded-lg border transition-all duration-300 hover:border-emerald-500/60
-              ${
-                isVisible
-                  ? "bg-emerald-500/5 border-emerald-500/30 dark:text-white text-gray-600"
-                  : "bg-transparent border-slate-200 dark:border-white/5 text-slate-400 dark:text-gray-600"
-              }
+              ${isVisible
+                            ? "bg-emerald-500/5 border-emerald-500/30 dark:text-white text-gray-600"
+                            : "bg-transparent border-slate-200 dark:border-white/5 text-slate-400 dark:text-gray-600"
+                          }
             `}
                       >
                         <span className="text-xs font-semibold tracking-wider capitalize">
@@ -703,17 +703,21 @@ export const QuestionsFilters = ({
                 <div className="p-4 bg-white dark:bg-[#1a1a1a] hover:bg-blue-50 dark:hover:bg-blue-500/5 border border-gray-200 dark:border-gray-800 hover:border-blue-500/50 rounded-xl transition-all shadow-sm dark:shadow-none">
                   <DownloadReportButton onOpenDialog={() => setIsSidebarOpen(false)} />
                 </div>
-                
+
                 <div className="p-4 bg-white dark:bg-[#1a1a1a] hover:bg-purple-50 dark:hover:bg-purple-500/5 border border-gray-200 dark:border-gray-800 hover:border-purple-500/50 rounded-xl transition-all shadow-sm dark:shadow-none">
                   <DownloadOverallReportButton onOpenDialog={() => setIsSidebarOpen(false)} />
                 </div>
-                
+
                 <div className="p-4 bg-white dark:bg-[#1a1a1a] hover:bg-green-50 dark:hover:bg-green-500/5 border border-gray-200 dark:border-gray-800 hover:border-green-500/50 rounded-xl transition-all shadow-sm dark:shadow-none">
                   <DownloadFilteredReportButton onOpenDialog={() => setIsSidebarOpen(false)} />
                 </div>
-                
+
+                <div className="p-4 bg-white dark:bg-[#1a1a1a] hover:bg-teal-50 dark:hover:bg-teal-500/5 border border-gray-200 dark:border-gray-800 hover:border-teal-500/50 rounded-xl transition-all shadow-sm dark:shadow-none">
+                  <DownloadDuplicateReportButton onOpenDialog={() => setIsSidebarOpen(false)} />
+                </div>
+
                 <div className="p-4 bg-white dark:bg-[#1a1a1a] hover:bg-amber-50 dark:hover:bg-amber-500/5 border border-gray-200 dark:border-gray-800 hover:border-amber-500/50 rounded-xl transition-all shadow-sm dark:shadow-none">
-                  <DownloadLevelWiseReportButton closeSideBar={()=>setIsSidebarOpen(false)} />
+                  <DownloadLevelWiseReportButton closeSideBar={() => setIsSidebarOpen(false)} />
                 </div>
               </div>
             </section>

--- a/frontend/src/hooks/services/questionService.ts
+++ b/frontend/src/hooks/services/questionService.ts
@@ -340,177 +340,220 @@ export class QuestionService {
     if (filter.dateRange && filter.dateRange !== "all")
       params.append("dateRange", filter.dateRange);
     return apiFetch(
-    `${this._baseUrl}?${params.toString()}`
-   );
-}
-async reAllocateLessWorkload(): Promise<WorkloadBalanceResponse|null> {
-  return apiFetch<WorkloadBalanceResponse|null>(`${this._baseUrl}/reAllocateLessWorkload`,{method: "POST",});
-}
+      `${this._baseUrl}?${params.toString()}`
+    );
+  }
+  async reAllocateLessWorkload(): Promise<WorkloadBalanceResponse | null> {
+    return apiFetch<WorkloadBalanceResponse | null>(`${this._baseUrl}/reAllocateLessWorkload`, { method: "POST", });
+  }
 
-async downloadQuestionReport(consecutiveApprovals?: string, startDate?: string, endDate?: string): Promise<Blob> {
-  const params = new URLSearchParams();
-  if (consecutiveApprovals && consecutiveApprovals !== "all") {
-    params.append("consecutiveApprovals", consecutiveApprovals);
-  }
-  if (startDate) {
-    params.append("startDate", startDate);
-  }
-  if (endDate) {
-    params.append("endDate", endDate);
-  }
-  
-  // Get the current Firebase user and token
-  const firebaseUser = auth.currentUser;
-  if (!firebaseUser) {
-    throw new Error("User not authenticated");
-  }
-  
-  const token = await getIdToken(firebaseUser);
-  
-  const response = await fetch(
-    `${this._baseUrl}/download-question-report?${params.toString()}`,
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`, 
-      },
+  async downloadQuestionReport(consecutiveApprovals?: string, startDate?: string, endDate?: string): Promise<Blob> {
+    const params = new URLSearchParams();
+    if (consecutiveApprovals && consecutiveApprovals !== "all") {
+      params.append("consecutiveApprovals", consecutiveApprovals);
     }
-  );
-  
-  if (!response.ok) {
-    throw new Error("Failed to download report");
-  }
-  
-  // Check if response is JSON (no data case)
-  const contentType = response.headers.get("content-type");
-  if (contentType && contentType.includes("application/json")) {
-    const jsonResponse = await response.json();
-    if (!jsonResponse.success) {
-      throw new Error(jsonResponse.message || "No data found for the selected filters");
+    if (startDate) {
+      params.append("startDate", startDate);
     }
+    if (endDate) {
+      params.append("endDate", endDate);
+    }
+
+    // Get the current Firebase user and token
+    const firebaseUser = auth.currentUser;
+    if (!firebaseUser) {
+      throw new Error("User not authenticated");
+    }
+
+    const token = await getIdToken(firebaseUser);
+
+    const response = await fetch(
+      `${this._baseUrl}/download-question-report?${params.toString()}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to download report");
+    }
+
+    // Check if response is JSON (no data case)
+    const contentType = response.headers.get("content-type");
+    if (contentType && contentType.includes("application/json")) {
+      const jsonResponse = await response.json();
+      if (!jsonResponse.success) {
+        throw new Error(jsonResponse.message || "No data found for the selected filters");
+      }
+    }
+
+    return await response.blob();
   }
-  
-  return await response.blob();
-}
 
 
-async sendOutreachReport(
-  startDate: Date,
-  endDate: Date,
-  emails: string[]
-): Promise<{ success: boolean; message: string } | null> {
-  return apiFetch<{ success: boolean; message: string } | null>(
-    `${this._baseUrl}/data/out-reach/date`,
-    {
-      method: "POST",
-      body: JSON.stringify({
-        startDate: formatDateLocal(startDate),
-        endDate: formatDateLocal(endDate),
-        emails,
-      }),
-    }
-  );
-}
+  async sendOutreachReport(
+    startDate: Date,
+    endDate: Date,
+    emails: string[]
+  ): Promise<{ success: boolean; message: string } | null> {
+    return apiFetch<{ success: boolean; message: string } | null>(
+      `${this._baseUrl}/data/out-reach/date`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          startDate: formatDateLocal(startDate),
+          endDate: formatDateLocal(endDate),
+          emails,
+        }),
+      }
+    );
+  }
 
-async downloadOverallReport(startDate?: string, endDate?: string): Promise<Blob> {
-  const params = new URLSearchParams();
-  if (startDate) {
-    params.append("startDate", startDate);
-  }
-  if (endDate) {
-    params.append("endDate", endDate);
-  }
-  
-  // Get the current Firebase user and token
-  const firebaseUser = auth.currentUser;
-  if (!firebaseUser) {
-    throw new Error("User not authenticated");
-  }
-  
-  const token = await getIdToken(firebaseUser);
-  
-  const response = await fetch(
-    `${this._baseUrl}/download-overall-report?${params.toString()}`,
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`, 
-      },
+  async downloadOverallReport(startDate?: string, endDate?: string): Promise<Blob> {
+    const params = new URLSearchParams();
+    if (startDate) {
+      params.append("startDate", startDate);
     }
-  );
-  
-  if (!response.ok) {
-    throw new Error("Failed to download overall report");
-  }
-  
-  // Check if response is JSON (no data case)
-  const contentType = response.headers.get("content-type");
-  if (contentType && contentType.includes("application/json")) {
-    const jsonResponse = await response.json();
-    if (!jsonResponse.success) {
-      throw new Error(jsonResponse.message || "No data found for the selected date range");
+    if (endDate) {
+      params.append("endDate", endDate);
     }
-  }
-  
-  return await response.blob();
-}
 
-async downloadFilteredReport(filters: {
-  state?: string;
-  crop?: string;
-  season?: string;
-  domain?: string;
-  status?: string;
-}): Promise<Blob> {
-  const params = new URLSearchParams();
-  if (filters.state && filters.state !== 'all') {
-    params.append("state", filters.state);
-  }
-  if (filters.crop && filters.crop !== 'all') {
-    params.append("crop", filters.crop);
-  }
-  if (filters.season && filters.season !== 'all') {
-    params.append("season", filters.season);
-  }
-  if (filters.domain && filters.domain !== 'all') {
-    params.append("domain", filters.domain);
-  }
-  if (filters.status && filters.status !== 'all') {
-    params.append("status", filters.status);
-  }
-  
-  // Get the current Firebase user and token
-  const firebaseUser = auth.currentUser;
-  if (!firebaseUser) {
-    throw new Error("User not authenticated");
-  }
-  
-  const token = await getIdToken(firebaseUser);
-  
-  const response = await fetch(
-    `${this._baseUrl}/download-filtered-report?${params.toString()}`,
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`, 
-      },
+    // Get the current Firebase user and token
+    const firebaseUser = auth.currentUser;
+    if (!firebaseUser) {
+      throw new Error("User not authenticated");
     }
-  );
-  
-  if (!response.ok) {
-    throw new Error("Failed to download filtered report");
-  }
-  
-  // Check if response is JSON (no data case)
-  const contentType = response.headers.get("content-type");
-  if (contentType && contentType.includes("application/json")) {
-    const jsonResponse = await response.json();
-    if (!jsonResponse.success) {
-      throw new Error(jsonResponse.message || "No questions found for the selected filters");
+
+    const token = await getIdToken(firebaseUser);
+
+    const response = await fetch(
+      `${this._baseUrl}/download-overall-report?${params.toString()}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to download overall report");
     }
+
+    // Check if response is JSON (no data case)
+    const contentType = response.headers.get("content-type");
+    if (contentType && contentType.includes("application/json")) {
+      const jsonResponse = await response.json();
+      if (!jsonResponse.success) {
+        throw new Error(jsonResponse.message || "No data found for the selected date range");
+      }
+    }
+
+    return await response.blob();
   }
-  
-  return await response.blob();
-}
+
+  async downloadDuplicateQuestionsReport(startDate?: string, endDate?: string): Promise<Blob> {
+    const params = new URLSearchParams();
+    if (startDate) {
+      params.append("startDate", startDate);
+    }
+    if (endDate) {
+      params.append("endDate", endDate);
+    }
+
+    // Get the current Firebase user and token
+    const firebaseUser = auth.currentUser;
+    if (!firebaseUser) {
+      throw new Error("User not authenticated");
+    }
+
+    const token = await getIdToken(firebaseUser);
+
+    const response = await fetch(
+      `${this._baseUrl}/download-duplicate-questions-report?${params.toString()}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to download similar questions report");
+    }
+
+    // Check if response is JSON (no data case)
+    const contentType = response.headers.get("content-type");
+    if (contentType && contentType.includes("application/json")) {
+      const jsonResponse = await response.json();
+      if (!jsonResponse.success) {
+        throw new Error(jsonResponse.message || "No similar questions found for the selected date range");
+      }
+    }
+
+    return await response.blob();
+  }
+
+  async downloadFilteredReport(filters: {
+    state?: string;
+    crop?: string;
+    season?: string;
+    domain?: string;
+    status?: string;
+  }): Promise<Blob> {
+    const params = new URLSearchParams();
+    if (filters.state && filters.state !== 'all') {
+      params.append("state", filters.state);
+    }
+    if (filters.crop && filters.crop !== 'all') {
+      params.append("crop", filters.crop);
+    }
+    if (filters.season && filters.season !== 'all') {
+      params.append("season", filters.season);
+    }
+    if (filters.domain && filters.domain !== 'all') {
+      params.append("domain", filters.domain);
+    }
+    if (filters.status && filters.status !== 'all') {
+      params.append("status", filters.status);
+    }
+
+    // Get the current Firebase user and token
+    const firebaseUser = auth.currentUser;
+    if (!firebaseUser) {
+      throw new Error("User not authenticated");
+    }
+
+    const token = await getIdToken(firebaseUser);
+
+    const response = await fetch(
+      `${this._baseUrl}/download-filtered-report?${params.toString()}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to download filtered report");
+    }
+
+    // Check if response is JSON (no data case)
+    const contentType = response.headers.get("content-type");
+    if (contentType && contentType.includes("application/json")) {
+      const jsonResponse = await response.json();
+      if (!jsonResponse.success) {
+        throw new Error(jsonResponse.message || "No questions found for the selected filters");
+      }
+    }
+
+    return await response.blob();
+  }
 
 }


### PR DESCRIPTION
Similar Questions Report Download
 
Added a new feature that allows users to download a report of duplicate questions as an Excel file.
 
- Added a new *"Similar Questions Report"* button in the Management Tools sidebar under the Download Reports section.
- When clicked, a calendar dialog opens where users can select a date range.
- After selecting the date range, an Excel file is generated and downloaded containing the following fields:
  - createdAt
  - question
  - source
  - similarityScore
  - referenceQuestion
- Created a new backend API endpoint that queries the duplicate_questions collection, filters by the selected date range, and returns the data as an Excel file.
- The entire flow follows the same pattern as the existing Overall Report and Filtered Report download features.