### PR TITLE
Added Duplicate Questions to Outreach Report

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2240,14 +2240,24 @@ export class QuestionService extends BaseService implements IQuestionService {
       'AJRASAKHA',
     );
 
-    if (questions.length === 0) {
+    const duplicateQuestions = await this.duplicateQuestionRepository.findDuplicatesByDateRange(start, end, 'AJRASAKHA');
+
+    const allQuestions = [
+      ...questions.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+            ...duplicateQuestions.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    ];
+
+
+    if (allQuestions.length === 0) {
+
       return {
         success: true,
         message: 'There are no Outreach questions in the selected time',
       };
     }
 
-    const csv = this.convertQuestionsToCSV(questions, startDate, endDate);
+    const csv = this.convertQuestionsToCSV(allQuestions, startDate, endDate);
+
 
     await sendEmailWithAttachment(
       emails,
@@ -2515,7 +2525,7 @@ export class QuestionService extends BaseService implements IQuestionService {
       }
 
       // Fetch duplicates using the repository
-      const duplicateQuestions = await this.duplicateQuestionRepository.findDuplicatesByDateRange(startDate, endDate, session);
+      const duplicateQuestions = await this.duplicateQuestionRepository.findDuplicatesByDateRange(startDate, endDate, 'AJRASAKHA',session);
 
       if (!duplicateQuestions || duplicateQuestions.length === 0) {
         return null;

--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2241,10 +2241,10 @@ export class QuestionService extends BaseService implements IQuestionService {
     );
 
     const duplicateQuestions = await this.duplicateQuestionRepository.findDuplicatesByDateRange(start, end, 'AJRASAKHA');
-
+      const combineQuestions=[...questions,...duplicateQuestions]
     const allQuestions = [
-      ...questions.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
-            ...duplicateQuestions.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      ...combineQuestions.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+            
     ];
 
 

--- a/backend/src/shared/database/interfaces/IDuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/interfaces/IDuplicateQuestionRepository.ts
@@ -35,6 +35,7 @@ export interface IDuplicateQuestionRepository {
   findDuplicatesByDateRange(
     startDate: Date,
     endDate: Date,
+    source: 'AJRASAKHA' | 'AGRI_EXPERT',
     session?: ClientSession,
   ): Promise<ISimilarQuestion[]>;
 }

--- a/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
@@ -71,7 +71,7 @@ export class DuplicateQuestionRepository  implements IDuplicateQuestionRepositor
   async findDuplicatesByDateRange(
     startDate: Date,
     endDate: Date,
-    source: string,  
+    sources: 'AJRASAKHA',  
     session?: ClientSession,
   ): Promise<ISimilarQuestion[]> {
     try {
@@ -83,7 +83,7 @@ export class DuplicateQuestionRepository  implements IDuplicateQuestionRepositor
 
       const duplicates = await this.DuplicateQuestionCollection.find(
         {
-          source: source as 'AJRASAKHA' | 'AGRI_EXPERT',
+          source: sources,
           createdAt: {
             $gte: startDate,
             $lte: endOfDay

--- a/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
@@ -71,6 +71,7 @@ export class DuplicateQuestionRepository  implements IDuplicateQuestionRepositor
   async findDuplicatesByDateRange(
     startDate: Date,
     endDate: Date,
+    source: string,  
     session?: ClientSession,
   ): Promise<ISimilarQuestion[]> {
     try {
@@ -82,10 +83,11 @@ export class DuplicateQuestionRepository  implements IDuplicateQuestionRepositor
 
       const duplicates = await this.DuplicateQuestionCollection.find(
         {
+          source: source as 'AJRASAKHA' | 'AGRI_EXPERT',
           createdAt: {
             $gte: startDate,
             $lte: endOfDay
-          }
+          },
         },
         { session },
       ).toArray();


### PR DESCRIPTION
## Enhanced Outreach Report with Duplicate Questions

Enhanced the Outreach Report to include duplicate questions alongside the original **AJRASAKHA** questions. Duplicate questions now appear **below the original questions** in the report, with each section **sorted by `createdAt`**.

### Changes

- Added a **`source` parameter** to the `findDuplicatesByDateRange` method in the repository interface and implementation to **filter duplicates by source**.
- Updated the **MongoDB query** to filter duplicate questions using the provided **`source` parameter**.
- Modified the `sendOutReachQuestionsMail` method to:
  - Fetch duplicate questions filtered by **AJRASAKHA** source.
  - Merge them with the **original questions**.
  - Generate a **combined CSV report** where **original questions appear first**, followed by **duplicate questions**.
- Updated the `generateDuplicateQuestionReport` method call to **pass the `source` parameter**.