### PR TITLE
filtering questions based on metadata

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -519,49 +519,50 @@ export class QuestionService extends BaseService implements IQuestionService {
       ) {
         throw new BadRequestError(`All fields are required`);
       }
-  
+
       // 🔹 Create Embedding — OUTSIDE transaction
       const text = `Question: ${question}`;
       let textEmbedding: number[] = [];
-      
-  
+
+
       if (appConfig.ENABLE_AI_SERVER) {
         const { embedding } = await this.aiService.getEmbedding(text);
         textEmbedding = embedding;
       }
-      
+
       
       // 🔥 Similarity Check — OUTSIDE transaction ($vectorSearch cannot run inside one)
       let highestScore = 0;
       let referenceQuestionId: ObjectId | null = null;
       let referenceQuestion=''
-  
-      if (textEmbedding.length) {
+      
+      if (textEmbedding.length && source === 'AJRASAKHA') {
         // No session passed here intentionally
         const topSimilar = await this.questionRepo.findTopSimilarQuestions(
           textEmbedding,
           5,
+          { state: details.state, district: details.district, crop: details.crop, domain: details.domain, season: details.season },
         );
-  
+
         if (topSimilar.length > 0) {
           const best = topSimilar[0];
           highestScore = (best._vectorSearchScore ?? 0) * 100;
           referenceQuestionId = best._id as ObjectId;
           referenceQuestion=best.question
         }
-        
+
       }
-  
+
       // ✅ Everything that needs atomicity goes inside the transaction
       return this._withTransaction(async (session: ClientSession) => {
         // 🔹 Create Context
         let contextId: ObjectId | null = null;
-  
+
         if (context) {
           const { insertedId } = await this.contextRepo.addContext(context, session);
           contextId = new ObjectId(insertedId);
         }
-  
+
         // 🔹 Create Base Question Object
         const baseQuestion: IQuestion = {
           userId: userId?.trim() !== '' ? new ObjectId(userId) : null,

--- a/backend/src/shared/database/interfaces/IQuestionRepository.ts
+++ b/backend/src/shared/database/interfaces/IQuestionRepository.ts
@@ -214,8 +214,8 @@ export interface IQuestionRepository {
   ): Promise<IQuestion[]>;
 
   getClosedQuestionsCount(
-session?: ClientSession,
-): Promise<number>;
+    session?: ClientSession,
+  ): Promise<number>;
   /**
    * get yearly analytics.
    * @param goldenDataSelectedYear - question status.
@@ -334,10 +334,10 @@ session?: ClientSession,
   ): Promise<QuestionLevelResponse>;
 
   findByDateRangeAndSource(
-      startDate: Date,
-      endDate: Date,
-      sources: 'AJRASAKHA',
-    ): Promise<IQuestion[]>
+    startDate: Date,
+    endDate: Date,
+    sources: 'AJRASAKHA',
+  ): Promise<IQuestion[]>
   getMonthlyQuestionStats(
     startDate?: Date,
     endDate?: Date,
@@ -358,9 +358,10 @@ session?: ClientSession,
   getAllQuestionEmbeddings(
     session?: ClientSession,
   ): Promise<IQuestionEmbedding[]>;
-   findTopSimilarQuestions(
+  findTopSimilarQuestions(
     embedding: number[],
     k?: number,
+    filter?: { state?: string; district?: string; crop?: string; domain?: string; season?: string },
     session?: ClientSession,
   ): Promise<(ISimilarQuestion & { _vectorSearchScore: number })[]>
 

--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -3248,20 +3248,44 @@ return await this.QuestionCollection.countDocuments({ status: 'closed' }, { sess
   async findTopSimilarQuestions(
     embedding: number[],
     k = 5,
+    filter?: { state?: string; district?: string; crop?: string; domain?: string; season?: string },
     session?: ClientSession,
   ): Promise<(ISimilarQuestion & { _vectorSearchScore: number })[]> {
     await this.init()
-  
+
+    const vectorSearchFilter: Record<string, string> = {};
+    if (filter?.state) {
+      vectorSearchFilter["details.state"] = filter.state;
+    }
+    if (filter?.district) {
+      vectorSearchFilter["details.district"] = filter.district;
+    }
+    if (filter?.crop) {
+      vectorSearchFilter["details.crop"] = filter.crop;
+    }
+    if (filter?.domain) {
+      vectorSearchFilter["details.domain"] = filter.domain;
+    }
+    if (filter?.season) {
+      vectorSearchFilter["details.season"] = filter.season;
+    }
+
+    const vectorSearchStage: any = {
+      index: "review_questions_vector_index", // your Atlas Vector Search index name
+      path: "embedding",     // field storing the embeddings
+      queryVector: embedding,
+      numCandidates: k * 10, // recommended: 10x of k for better recall
+      limit: k,
+    };
+
+    if (Object.keys(vectorSearchFilter).length > 0) {
+      vectorSearchStage.filter = vectorSearchFilter;
+    }
+
     const topSimilar = await this.QuestionCollection.aggregate(
       [
         {
-          $vectorSearch: {
-            index: "review_questions_vector_index", // your Atlas Vector Search index name
-            path: "embedding",     // field storing the embeddings
-            queryVector: embedding,
-            numCandidates: k * 10, // recommended: 10x of k for better recall
-            limit: k,
-          },
+          $vectorSearch: vectorSearchStage,
         },
         {
           $project: {
@@ -3277,7 +3301,7 @@ return await this.QuestionCollection.countDocuments({ status: 'closed' }, { sess
       ],
       { session },
     ).toArray();
-  
+
     return topSimilar as any;
   }
 }


### PR DESCRIPTION
## Improve Duplicate Question Detection

### Changes

- Added filtering using **all question metadata (except `status`)** when checking for duplicate questions.
- Updated the **MongoDB Atlas vector search filter** to include the same metadata fields.

### Duplicate Detection Criteria

A question will now be considered a duplicate only if:

- The following metadata fields match:
  - `crop`
  - `domain`
  - `season`
  - `state`
  - `district`
- The **question text similarity is greater than 85%**.

This ensures duplicate detection is limited to **questions with the same contextual metadata**