### PR TITLE
Consecutive Approvals & Auto Allocate Filter Improvements

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -348,6 +348,9 @@ export class QuestionRepository implements IQuestionRepository {
           : null;
       // --- Consecutive Approvals Filter ---
       if (approvalCount !== null && !isNaN(approvalCount)) {
+        // Only exclude closed questions for consecutive approvals
+        filter.status = { $not: { $regex: '^closed$', $options: 'i' } };
+        
         const answers = await this.AnswersCollection.aggregate([
           {
             $group: {

--- a/backend/src/utils/buildQuestionFilter.ts
+++ b/backend/src/utils/buildQuestionFilter.ts
@@ -124,6 +124,9 @@ if (autoAllocateFilter && autoAllocateFilter !== 'all') {
     : null;
     // --- Consecutive Approvals Filter ---
 if (approvalCount !== null && !isNaN(approvalCount)) {
+  // Only exclude closed questions for consecutive approvals
+  filter.status = { $not: { $regex: '^closed$', $options: 'i' } };
+
   const answers = await AnswersCollection.aggregate([
     // 1. Sort so latest answer comes first per question
     {

--- a/frontend/src/components/advanced-question-filter.tsx
+++ b/frontend/src/components/advanced-question-filter.tsx
@@ -666,7 +666,21 @@ export const AdvanceFilterDialog: React.FC<AdvanceFilterDialogProps> = ({
                 <Label className="relative flex items-center gap-2 text-sm font-semibold">
                   <BadgeCheck className="h-4 w-4 text-primary" />
                   Consecutive Approvals
-                  <TopRightBadge label="New" />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button type="button" className="text-muted-foreground hover:text-primary transition-colors">
+                        <Info className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="max-w-xs text-sm">
+                      <p>
+                        Filter questions based on the number of consecutive approvals received by their latest answer.
+                      </p>
+                    </TooltipContent>
+
+                  </Tooltip>
+
+                  
                 </Label>
                 <Select
                   value={advanceFilter.consecutiveApprovals}
@@ -712,7 +726,7 @@ export const AdvanceFilterDialog: React.FC<AdvanceFilterDialogProps> = ({
                 <Label className="relative flex items-center gap-2 text-sm font-semibold">
                   <Users className="h-4 w-4 text-primary" />
                   Auto Allocate Experts
-                  <TopRightBadge label="New" />
+                  
                 </Label>
                 <Select
                   value={advanceFilter.autoAllocateFilter}


### PR DESCRIPTION
## Description

### UI Improvements
- Removed the **"NEW"** badge from **Consecutive Approvals** and **Auto Allocate Experts** filters in the **Preferences dialog** to clean up the UI, as these features are no longer new.

### Tooltip Addition
- Added a tooltip for the **Consecutive Approvals** filter in the **Preferences dialog**, providing users with a brief explanation:  
  > "Filter questions based on the number of consecutive approvals received by their latest answer."

- The tooltip follows the same pattern used in the existing **User filter tooltip** for consistency.

### Backend Enhancement
- Added a **closed questions exclusion filter** in the backend for the **Consecutive Approvals** logic.

- When a consecutive approval value (**1, 2, or 3**) is selected:
  - **Closed questions are excluded** from the results.
  - Only **active questions** are displayed:
    - Open
    - In Review
    - Delayed
    - Re-routed