### PR TITLE
Fix the UI issue in the history and Reroute timeline.

### DIFF
--- a/frontend/src/components/ExpertHistory.tsx
+++ b/frontend/src/components/ExpertHistory.tsx
@@ -130,17 +130,17 @@ const ViewContextModal = ({
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent
-        className="w-[90vw] max-w-6xl flex flex-col"
+        className="w-[90vw] max-w-6xl flex flex-col max-h-[90vh]"
         style={{ maxWidth: "70vw" }}
       >
-        <DialogHeader className="pb-4 border-b">
+        <DialogHeader className="pb-4 border-b flex-shrink-0">
           <DialogTitle className="text-xl font-semibold">
             {actionTitleMap[item.action] || "View Context"}
           </DialogTitle>
         </DialogHeader>
 
-        <ScrollArea className="flex-1 h-[85vh]">
-          <div className="space-y-6 p-4 text-sm">
+        <ScrollArea className="flex-1 overflow-y-auto">
+          <div className="space-y-6 p-4 text-sm pr-6">
             {/* ====================== QUESTION ====================== */}
             <div>
               <p className="text-sm font-medium mb-1">Question</p>
@@ -153,7 +153,7 @@ const ViewContextModal = ({
             {(item.action === "author") && createdAnswer && (
               <div>
                 <p className="text-sm font-medium mb-1">Submitted Answer</p>
-                <div className="rounded-lg border bg-muted/30 p-3">
+                <div className="rounded-lg border bg-muted/30 p-3 max-h-[300px] overflow-y-auto">
                   {createdAnswer}
                 </div>
               </div>
@@ -162,7 +162,7 @@ const ViewContextModal = ({
             {(item.action === "rerouted") && createdAnswer && (
               <div>
                 <p className="text-sm font-medium mb-1">ReRouted Answer</p>
-                <div className="rounded-lg border bg-muted/30 p-3">
+                <div className="rounded-lg border bg-muted/30 p-3 max-h-[300px] overflow-y-auto">
                   {createdAnswer}
                 </div>
               </div>
@@ -183,7 +183,7 @@ const ViewContextModal = ({
               item.action === "rejected"||item.action=="reroute_approved") && (
               <div>
                 <p className="text-sm font-medium mb-1">Answer</p>
-                <div className="rounded-lg border bg-muted/30 p-3">
+                <div className="rounded-lg border bg-muted/30 p-3 max-h-[300px] overflow-y-auto">
                   {currentAnswer}
                 </div>
               </div>
@@ -203,7 +203,7 @@ const ViewContextModal = ({
             {modifiedAnswer && (
               <div>
                 <p className="text-sm font-medium mb-1">Modified Answer</p>
-                <div className="rounded-lg border bg-muted/30 p-3">
+                <div className="rounded-lg border bg-muted/30 p-3 max-h-[300px] overflow-y-auto">
                   {modifiedAnswer}
                 </div>
               </div>
@@ -213,7 +213,7 @@ const ViewContextModal = ({
             {rejectedAnswer && item.activityType!="reroute" && (
               <div>
                 <p className="text-sm font-medium mb-1">Rejected Answer</p>
-                <div className="rounded-lg border bg-muted/30 p-3">
+                <div className="rounded-lg border bg-muted/30 p-3 max-h-[300px] overflow-y-auto">
                   {rejectedAnswer}
                 </div>
               </div>
@@ -222,7 +222,7 @@ const ViewContextModal = ({
              {rejectedAnswer && item.activityType=="reroute"&& (
               <div>
                 <p className="text-sm font-medium mb-1">Created Answer</p>
-                <div className="rounded-lg border bg-muted/30 p-3">
+                <div className="rounded-lg border bg-muted/30 p-3 max-h-[300px] overflow-y-auto">
                   {rejectedAnswer}
                 </div>
               </div>

--- a/frontend/src/features/question_details/components/RerouteTimeline.tsx
+++ b/frontend/src/features/question_details/components/RerouteTimeline.tsx
@@ -3,6 +3,12 @@ import { AlertCircle, ChevronDown, ChevronUp, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getStatusInfo } from "../constants/rerouteStatusConfig";
 import { formatDate } from "../utils/formatDate";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/atoms/dialog";
 
 interface RerouteTimelineProps {
   currentUser: IUser;
@@ -18,8 +24,10 @@ export const RerouteTimeline = ({
   const [hoverTimeout, setHoverTimeout] = useState<ReturnType<
     typeof setTimeout
   > | null>(null);
+  const [selectedReason, setSelectedReason] = useState<string | null>(null);
 
   const INITIAL_DISPLAY_COUNT = 12;
+  const MAX_REASON_LENGTH = 50;
 
   const handleMouseEnter = (id: string) => {
     const timeout = setTimeout(() => {
@@ -216,9 +224,24 @@ export const RerouteTimeline = ({
                           {formatDate(reroute.reroutedAt)}
                         </p>
                         {reroute.rejectionReason && (
-                          <p className="text-[10px] text-gray-500 dark:text-gray-500 italic mt-1">
-                            "{reroute.rejectionReason}"
-                          </p>
+                          <div className="text-[10px] text-gray-500 dark:text-gray-500 italic mt-1">
+                            {reroute.rejectionReason.length > MAX_REASON_LENGTH ? (
+                              <>
+                                "{reroute.rejectionReason.slice(0, MAX_REASON_LENGTH)}..."
+                                <button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    setSelectedReason(reroute.rejectionReason);
+                                  }}
+                                  className="text-blue-600 dark:text-blue-400 hover:underline ml-1"
+                                >
+                                  see more
+                                </button>
+                              </>
+                            ) : (
+                              `"${reroute.rejectionReason}"`
+                            )}
+                          </div>
                         )}
                         <div className="h-0.5 w-6 rounded-full bg-gradient-to-r from-blue-400/20 to-blue-400/60" />
                       </div>
@@ -252,6 +275,18 @@ export const RerouteTimeline = ({
           </button>
         </div>
       )}
+
+      {/* Rejection Reason Dialog */}
+      <Dialog open={!!selectedReason} onOpenChange={() => setSelectedReason(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+          <DialogHeader className="flex-shrink-0">
+            <DialogTitle>Rejection Reason</DialogTitle>
+          </DialogHeader>
+          <div className="mt-4 p-4 rounded-lg bg-muted/30 border overflow-y-auto flex-1">
+            <p className="text-sm whitespace-pre-wrap break-words">{selectedReason}</p>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
1. Fixed the UI breakdown issue in the history section.
2. Fixed the issue in the re-route timeline by adding a "..see more" clickable text to see the full rejection reason.

<img width="1919" height="974" alt="image" src="https://github.com/user-attachments/assets/8a4ef34f-304f-4e0e-821a-68f1c3e64ff6" />
<img width="1919" height="1026" alt="image" src="https://github.com/user-attachments/assets/de68dcb7-95d1-421f-8e67-4247edbdef30" />
