### PR TITLE
remove duplicate question when question got deleted

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2105,6 +2105,9 @@ export class QuestionService extends BaseService implements IQuestionService {
       );
       await this.requestRepository.deleteByEntityId(questionId, activeSession);
 
+      // Delete duplicate question records referencing this question
+      await this.duplicateQuestionRepository.deleteByReferenceQuestionId(questionId, activeSession);
+
       // Finally, delete the question itself
       return this.questionRepo.deleteQuestion(questionId, activeSession);
     };

--- a/backend/src/shared/database/interfaces/IDuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/interfaces/IDuplicateQuestionRepository.ts
@@ -38,4 +38,9 @@ export interface IDuplicateQuestionRepository {
     source: 'AJRASAKHA' | 'AGRI_EXPERT',
     session?: ClientSession,
   ): Promise<ISimilarQuestion[]>;
+
+  deleteByReferenceQuestionId(
+ referenceQuestionId: string,
+session?: ClientSession,
+ ): Promise<{deletedCount: number}>;
 }

--- a/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
@@ -102,4 +102,23 @@ export class DuplicateQuestionRepository  implements IDuplicateQuestionRepositor
       );
     }
   }
+
+  async deleteByReferenceQuestionId(
+referenceQuestionId: string,
+session?: ClientSession,
+): Promise<{deletedCount: number}> {
+try {
+await this.init();
+const result = await this.DuplicateQuestionCollection.deleteMany(
+{referenceQuestionId: new ObjectId(referenceQuestionId)},
+{session},
+);
+return {deletedCount: result.deletedCount};
+} catch (error) {
+throw new InternalServerError(
+"Error while deleting duplicate questions by reference: ${error}",
+);
+}
+}
+
 }


### PR DESCRIPTION
Fix: Duplicate Question Cleanup on Delete                                                 
                                                                                               
  ### DuplicateQuestionRepository.ts                                                         
  - Fixed deleteByReferenceQuestionId to query with new ObjectId(referenceQuestionId)      
  instead of a raw string                                                                      
                  
  ### QuestionService.ts                                                                     
  - Added deleteByReferenceQuestionId call inside deleteQuestion to clean up related
  duplicate records before deleting the question
