### PR TITLE
feat: add source type dropdown in expert answer form (Hyper Local, State,Other)

### DIFF
--- a/backend/src/modules/reroute/classes/validators/AnswerValidators.ts
+++ b/backend/src/modules/reroute/classes/validators/AnswerValidators.ts
@@ -18,6 +18,24 @@ import {JSONSchema} from 'class-validator-jsonschema';
 
 class SourceItem {
   @JSONSchema({
+    description: 'Type of source (hyper_local, state, central, other)',
+    example: 'hyper_local',
+    enum: ['hyper_local', 'state', 'central', 'other'],
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['hyper_local', 'state', 'central', 'other'])
+  sourceType?: 'hyper_local' | 'state' | 'central' | 'other';
+
+  @JSONSchema({
+    description: 'Name of the source',
+    example: 'Punjab Agricultural University',
+  })
+  @IsOptional()
+  @IsString()
+  sourceName?: string;
+
+  @JSONSchema({
     description: 'Source URL for the answer',
     example: 'https://example.com',
     format: 'uri',

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -63,7 +63,11 @@ export interface IQuestion {
   updatedAt?: Date;
 }
 
+export type SourceType = 'hyper_local' | 'state' | 'central' | 'other';
+
 export interface SourceItem {
+  sourceType?: SourceType;
+  sourceName?: string;
   source: string;
   page?: number;
 }

--- a/frontend/src/components/source-url-manager.tsx
+++ b/frontend/src/components/source-url-manager.tsx
@@ -3,7 +3,28 @@ import { Input } from "./atoms/input";
 import { useState, type KeyboardEvent } from "react";
 import { ScrollArea } from "./atoms/scroll-area";
 import { toast } from "sonner";
-import type { SourceItem } from "@/types";
+import type { SourceItem, SourceType } from "@/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./atoms/select";
+
+const SOURCE_TYPE_OPTIONS: { value: SourceType; label: string }[] = [
+  { value: "hyper_local", label: "Hyper Local" },
+  { value: "state", label: "State" },
+  { value: "central", label: "Central" },
+  { value: "other", label: "Other" },
+];
+
+const SOURCE_TYPE_LABELS: Record<SourceType, string> = {
+  hyper_local: "Hyper Local",
+  state: "State",
+  central: "Central",
+  other: "Other",
+};
 
 interface SourceUrlManagerProps {
   sources: SourceItem[];
@@ -16,36 +37,50 @@ export const SourceUrlManager = ({
   onSourcesChange,
   className,
 }: SourceUrlManagerProps) => {
+  const [selectedType, setSelectedType] = useState<SourceType | "">("");
+  const [sourceName, setSourceName] = useState("");
   const [urlInput, setUrlInput] = useState("");
-  const [pageInput, setPageInput] = useState("");
 
   const addSource = () => {
-    const trimmedUrl = urlInput.trim();
-    const pageNum = pageInput ? Number(pageInput) : undefined;
-
-    try {
-      new URL(trimmedUrl);
-    } catch {
-      toast.error("Please enter a valid URL before adding.");
+    if (!selectedType) {
+      toast.error("Please select a source type.");
       return;
     }
 
-    if (pageNum !== undefined && (isNaN(pageNum) || pageNum < 1)) {
-      toast.error("Please enter a valid page number (1 or greater).");
+    if (selectedType === "other" && !sourceName.trim()) {
+      toast.error("Please enter the source name.");
+      return;
+    }
+
+    const trimmedUrl = urlInput.trim();
+    try {
+      new URL(trimmedUrl);
+    } catch {
+      toast.error("Please enter a valid URL.");
       return;
     }
 
     const exists = sources.some(
-      (item) => item.source === trimmedUrl && item.page === pageNum
+      (item) =>
+        item.sourceType === selectedType &&
+        item.source === trimmedUrl
     );
     if (exists) {
       toast.error("This source already exists.");
       return;
     }
 
-    onSourcesChange([...sources, { source: trimmedUrl, page: pageNum }]);
+    onSourcesChange([
+      ...sources,
+      {
+        sourceType: selectedType,
+        sourceName: selectedType === "other" ? sourceName.trim() : undefined,
+        source: trimmedUrl,
+      },
+    ]);
+    setSelectedType("");
+    setSourceName("");
     setUrlInput("");
-    setPageInput("");
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -66,41 +101,75 @@ export const SourceUrlManager = ({
       </label>
 
       <div className="space-y-3">
-        <div className="flex gap-2">
-          <Input
-            type="url"
-            placeholder="https://example.com"
-            value={urlInput}
-            onChange={(e) => setUrlInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            className="flex-1"
-          />
-          <Input
-            type="number"
-            placeholder="Page"
-            value={pageInput}
-            onChange={(e) => setPageInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            className="w-24"
-            min={1}
-          />
-          <button
-            type="button"
-            onClick={addSource}
-            className="px-3 py-2 text-sm font-medium text-primary hover:text-primary/80 transition-colors"
-          >
-            <PlusCircle className="h-5 w-5" />
-          </button>
-        </div>
+        {/* Source Type Dropdown */}
+        <Select
+          value={selectedType}
+          onValueChange={(val) => setSelectedType(val as SourceType)}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select Source Type" />
+          </SelectTrigger>
+          <SelectContent>
+            {SOURCE_TYPE_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
+        {/* Source Name (only for Other) & URL fields */}
+        {selectedType && (
+          <div className="space-y-2 animate-in fade-in-0 slide-in-from-top-1 duration-200">
+            {selectedType === "other" && (
+              <Input
+                type="text"
+                placeholder="Other Source Name"
+                value={sourceName}
+                onChange={(e) => setSourceName(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="w-full"
+              />
+            )}
+            <div className="flex gap-2">
+              <Input
+                type="url"
+                placeholder={`${SOURCE_TYPE_LABELS[selectedType]} Source Link URL`}
+                value={urlInput}
+                onChange={(e) => setUrlInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="flex-1"
+              />
+              <button
+                type="button"
+                onClick={addSource}
+                className="px-3 py-2 text-sm font-medium text-primary hover:text-primary/80 transition-colors"
+              >
+                <PlusCircle className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Added sources list */}
         {sources.length > 0 && (
-          <ScrollArea className="h-[5rem] rounded-lg border p-2">
-            <div className="flex flex-wrap gap-2">
+          <ScrollArea className="h-[7rem] rounded-lg border p-2">
+            <div className="flex flex-col gap-2">
               {sources.map((item, idx) => (
                 <div
                   key={idx}
                   className="group inline-flex items-center gap-2 px-3 py-1.5 bg-tag border border-tag-border rounded-lg text-sm text-tag-foreground hover:bg-tag-hover transition-colors"
                 >
+                  {item.sourceType && (
+                    <span className="shrink-0 px-1.5 py-0.5 rounded text-xs font-medium bg-primary/10 text-primary">
+                      {SOURCE_TYPE_LABELS[item.sourceType] || item.sourceType}
+                    </span>
+                  )}
+                  {item.sourceName && (
+                    <span className="font-medium truncate max-w-[120px]" title={item.sourceName}>
+                      {item.sourceName}
+                    </span>
+                  )}
                   <span className="max-w-[200px] truncate" title={item.source}>
                     {item.source}
                   </span>
@@ -112,7 +181,7 @@ export const SourceUrlManager = ({
                   <button
                     type="button"
                     onClick={() => removeSource(idx)}
-                    className="flex-shrink-0 text-tag-foreground/60 hover:text-tag-foreground transition-colors"
+                    className="flex-shrink-0 ml-auto text-tag-foreground/60 hover:text-tag-foreground transition-colors"
                     aria-label="Remove source"
                   >
                     <X className="h-3.5 w-3.5" />

--- a/frontend/src/components/source-url-manager.tsx
+++ b/frontend/src/components/source-url-manager.tsx
@@ -40,6 +40,7 @@ export const SourceUrlManager = ({
   const [selectedType, setSelectedType] = useState<SourceType | "">("");
   const [sourceName, setSourceName] = useState("");
   const [urlInput, setUrlInput] = useState("");
+  const [pageInput, setPageInput] = useState("");
 
   const addSource = () => {
     if (!selectedType) {
@@ -53,6 +54,8 @@ export const SourceUrlManager = ({
     }
 
     const trimmedUrl = urlInput.trim();
+    const pageNum = pageInput ? Number(pageInput) : undefined;
+
     try {
       new URL(trimmedUrl);
     } catch {
@@ -60,10 +63,16 @@ export const SourceUrlManager = ({
       return;
     }
 
+    if (pageNum !== undefined && (isNaN(pageNum) || pageNum < 1)) {
+      toast.error("Please enter a valid page number (1 or greater).");
+      return;
+    }
+
     const exists = sources.some(
       (item) =>
         item.sourceType === selectedType &&
-        item.source === trimmedUrl
+        item.source === trimmedUrl &&
+        item.page === pageNum
     );
     if (exists) {
       toast.error("This source already exists.");
@@ -76,11 +85,13 @@ export const SourceUrlManager = ({
         sourceType: selectedType,
         sourceName: selectedType === "other" ? sourceName.trim() : undefined,
         source: trimmedUrl,
+        page: pageNum,
       },
     ]);
     setSelectedType("");
     setSourceName("");
     setUrlInput("");
+    setPageInput("");
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -139,6 +150,15 @@ export const SourceUrlManager = ({
                 onChange={(e) => setUrlInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 className="flex-1"
+              />
+              <Input
+                type="number"
+                placeholder="Page"
+                value={pageInput}
+                onChange={(e) => setPageInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="w-24"
+                min={1}
               />
               <button
                 type="button"

--- a/frontend/src/components/source-url-manager.tsx
+++ b/frontend/src/components/source-url-manager.tsx
@@ -178,30 +178,38 @@ export const SourceUrlManager = ({
               {sources.map((item, idx) => (
                 <div
                   key={idx}
-                  className="group inline-flex items-center gap-2 px-3 py-1.5 bg-tag border border-tag-border rounded-lg text-sm text-tag-foreground hover:bg-tag-hover transition-colors"
+                  className="grid grid-cols-[minmax(100px,auto)_1fr_auto_auto] items-center gap-10 px-3 py-2 bg-tag border border-tag-border rounded-lg text-sm text-tag-foreground hover:bg-tag-hover transition-colors"
                 >
-                  {item.sourceType && (
-                    <span className="shrink-0 px-1.5 py-0.5 rounded text-xs font-medium bg-primary/10 text-primary">
-                      {SOURCE_TYPE_LABELS[item.sourceType] || item.sourceType}
+                  {/* Column 1: Source Type Badge */}
+                  {item.sourceType ? (
+                    <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap">
+                      {item.sourceType === 'other' && item.sourceName && item.sourceName.toLowerCase() !== 'other'
+                        ? `Other: ${item.sourceName}`
+                        : SOURCE_TYPE_LABELS[item.sourceType] || item.sourceType}
                     </span>
+                  ) : (
+                    <span />
                   )}
-                  {item.sourceName && (
-                    <span className="font-medium truncate max-w-[120px]" title={item.sourceName}>
-                      {item.sourceName}
-                    </span>
-                  )}
-                  <span className="max-w-[200px] truncate" title={item.source}>
+
+                  {/* Column 2: Link */}
+                  <span className="truncate" title={item.source}>
                     {item.source}
                   </span>
-                  {item.page && (
-                    <span className="text-xs text-muted-foreground">
-                      (p.{item.page})
+
+                  {/* Column 3: Page Number */}
+                  {item.page ? (
+                    <span className="text-xs text-muted-foreground whitespace-nowrap">
+                      pg {item.page}
                     </span>
+                  ) : (
+                    <span />
                   )}
+
+                  {/* Column 4: Remove Button */}
                   <button
                     type="button"
                     onClick={() => removeSource(idx)}
-                    className="flex-shrink-0 ml-auto text-tag-foreground/60 hover:text-tag-foreground transition-colors"
+                    className="flex-shrink-0 text-tag-foreground/60 hover:text-tag-foreground transition-colors"
                     aria-label="Remove source"
                   >
                     <X className="h-3.5 w-3.5" />

--- a/frontend/src/features/qa-interface-page/ReviewHistoryTimeline.tsx
+++ b/frontend/src/features/qa-interface-page/ReviewHistoryTimeline.tsx
@@ -5,6 +5,25 @@ import type {
   SourceItem,
   QuestionRerouteRepo
 } from "@/types";
+
+const sourceTypeOrder: Record<string, number> = {
+  hyper_local: 0, state: 1, central: 2, other: 3,
+};
+
+const sortSources = (sources: SourceItem[]) =>
+  [...sources].sort((a, b) => {
+    const orderA = sourceTypeOrder[a.sourceType || ""] ?? 99;
+    const orderB = sourceTypeOrder[b.sourceType || ""] ?? 99;
+    return orderA - orderB;
+  });
+
+const getSourceBadgeLabel = (source: SourceItem) => {
+  const label = source.sourceType === 'hyper_local' ? 'Hyper Local' : source.sourceType === 'state' ? 'State' : source.sourceType === 'central' ? 'Central' : 'Other';
+  if (source.sourceType === 'other' && source.sourceName && source.sourceName.toLowerCase() !== 'other') {
+    return `${label}: ${source.sourceName}`;
+  }
+  return label;
+};
 import { Textarea } from "../../components/atoms/textarea";
 import {
   Accordion,
@@ -441,12 +460,17 @@ if (!h || !h.rerouteId || !h.question?._id || !h.moderator?._id || !h.reroute?.r
                                           </p>
 
                                           <div className="space-y-2">
-                                            {item.answer.sources.map(
+                                            {sortSources(item.answer.sources).map(
                                               (source: any, idx: number) => (
                                                 <div
                                                   key={idx}
                                                   className="flex items-center justify-between gap-2 p-3 border rounded-md hover:bg-muted/40 transition-colors text-sm"
                                                 >
+                                                  {source.sourceType && (
+                                                    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-primary/10 text-primary border border-primary/20 flex-shrink-0">
+                                                      {getSourceBadgeLabel(source)}
+                                                    </span>
+                                                  )}
                                                   <a
                                                     href={source.source}
                                                     target="_blank"

--- a/frontend/src/features/qa-interface-page/ReviewHistoryTimeline.tsx
+++ b/frontend/src/features/qa-interface-page/ReviewHistoryTimeline.tsx
@@ -464,35 +464,37 @@ if (!h || !h.rerouteId || !h.question?._id || !h.moderator?._id || !h.reroute?.r
                                               (source: any, idx: number) => (
                                                 <div
                                                   key={idx}
-                                                  className="flex items-center justify-between gap-2 p-3 border rounded-md hover:bg-muted/40 transition-colors text-sm"
+                                                  className="grid grid-cols-[minmax(100px,auto)_1fr_auto_auto] items-center gap-10 p-3 border rounded-md hover:bg-muted/40 transition-colors text-sm"
                                                 >
-                                                  {source.sourceType && (
-                                                    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-primary/10 text-primary border border-primary/20 flex-shrink-0">
+                                                  {/* Column 1: Source Type Badge */}
+                                                  {source.sourceType ? (
+                                                    <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap">
                                                       {getSourceBadgeLabel(source)}
                                                     </span>
+                                                  ) : (
+                                                    <span />
                                                   )}
+
+                                                  {/* Column 2: Link */}
                                                   <a
                                                     href={source.source}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
-                                                    className="text-blue-600 dark:text-blue-400 break-all inline-flex items-center gap-1 hover:underline text-sm"
+                                                    className="text-blue-600 dark:text-blue-400 truncate hover:underline text-sm"
                                                   >
-                                                    <span className="line-clamp-2">
-                                                      {source.source}
-                                                    </span>
-
-                                                    {source.page && (
-                                                      <>
-                                                        <span className="text-muted-foreground flex-shrink-0">
-                                                          •
-                                                        </span>
-                                                        <span className="text-muted-foreground flex-shrink-0">
-                                                          p{source.page}
-                                                        </span>
-                                                      </>
-                                                    )}
+                                                    {source.source}
                                                   </a>
 
+                                                  {/* Column 3: Page Number */}
+                                                  {source.page ? (
+                                                    <span className="text-xs text-muted-foreground whitespace-nowrap">
+                                                      pg {source.page}
+                                                    </span>
+                                                  ) : (
+                                                    <span />
+                                                  )}
+
+                                                  {/* Column 4: Copy Button */}
                                                   <button
                                                     onClick={() =>
                                                       handleCopy(

--- a/frontend/src/features/question_details/components/answer_item/AnswerContent.tsx
+++ b/frontend/src/features/question_details/components/answer_item/AnswerContent.tsx
@@ -1,89 +1,15 @@
-import type { IAnswer, SourceItem } from "@/types";
-import { ExternalLink } from "lucide-react";
+import type { IAnswer } from "@/types";
 
 interface AnswerContentProps {
   answer: IAnswer;
 }
 
-const sourceTypeLabels: Record<string, string> = {
-  hyper_local: "Hyper Local",
-  state: "State",
-  central: "Central",
-  other: "Other",
-};
-
-const sourceTypeOrder: Record<string, number> = {
-  hyper_local: 0,
-  state: 1,
-  central: 2,
-  other: 3,
-};
-
-const sortSources = (sources: SourceItem[]) =>
-  [...sources].sort((a, b) => {
-    const orderA = sourceTypeOrder[a.sourceType || ""] ?? 99;
-    const orderB = sourceTypeOrder[b.sourceType || ""] ?? 99;
-    return orderA - orderB;
-  });
-
-const getSourceBadgeLabel = (item: SourceItem) => {
-  const typeLabel = sourceTypeLabels[item.sourceType || ""] || item.sourceType || "";
-  if (item.sourceType === "other" && item.sourceName && item.sourceName.toLowerCase() !== "other") {
-    return `${typeLabel}: ${item.sourceName}`;
-  }
-  return typeLabel;
-};
-
 export const AnswerContent = ({ answer }: AnswerContentProps) => {
-  const sortedSources = answer.sources?.length ? sortSources(answer.sources) : [];
-
   return (
     <div className="rounded-lg border bg-card p-4">
       <p className="whitespace-pre-wrap leading-relaxed line-clamp-4 text-card-foreground px-5">
         {answer.answer}
       </p>
-
-      {sortedSources.length > 0 && (
-        <div className="mt-4 px-5 pt-4 border-t border-border">
-          <h4 className="text-sm font-semibold text-foreground mb-3">
-            Source References
-          </h4>
-          <div className="space-y-2">
-            {sortedSources.map((item, idx) => (
-              <div key={idx} className="flex items-center gap-2 text-sm">
-                {item.sourceType && (
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-primary/10 text-primary border border-primary/20">
-                    {getSourceBadgeLabel(item)}
-                  </span>
-                )}
-                {/* Show sourceName separately only for non-other types when it's a unique name */}
-                {item.sourceName &&
-                  item.sourceType !== "other" &&
-                  item.sourceName.toLowerCase() !== (sourceTypeLabels[item.sourceType || ""] || "").toLowerCase() && (
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {item.sourceName}
-                    </span>
-                  )}
-
-                <a
-                  href={item.source}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 hover:text-blue-800 hover:underline truncate max-w-md flex items-center gap-1"
-                >
-                  {item.source}
-                  <ExternalLink className="h-3 w-3 flex-shrink-0" />
-                </a>
-                {item.page && (
-                  <span className="text-xs text-muted-foreground">
-                    (p.{item.page})
-                  </span>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/features/question_details/components/answer_item/AnswerContent.tsx
+++ b/frontend/src/features/question_details/components/answer_item/AnswerContent.tsx
@@ -1,15 +1,89 @@
-import type { IAnswer } from "@/types";
+import type { IAnswer, SourceItem } from "@/types";
+import { ExternalLink } from "lucide-react";
 
 interface AnswerContentProps {
   answer: IAnswer;
 }
 
+const sourceTypeLabels: Record<string, string> = {
+  hyper_local: "Hyper Local",
+  state: "State",
+  central: "Central",
+  other: "Other",
+};
+
+const sourceTypeOrder: Record<string, number> = {
+  hyper_local: 0,
+  state: 1,
+  central: 2,
+  other: 3,
+};
+
+const sortSources = (sources: SourceItem[]) =>
+  [...sources].sort((a, b) => {
+    const orderA = sourceTypeOrder[a.sourceType || ""] ?? 99;
+    const orderB = sourceTypeOrder[b.sourceType || ""] ?? 99;
+    return orderA - orderB;
+  });
+
+const getSourceBadgeLabel = (item: SourceItem) => {
+  const typeLabel = sourceTypeLabels[item.sourceType || ""] || item.sourceType || "";
+  if (item.sourceType === "other" && item.sourceName && item.sourceName.toLowerCase() !== "other") {
+    return `${typeLabel}: ${item.sourceName}`;
+  }
+  return typeLabel;
+};
+
 export const AnswerContent = ({ answer }: AnswerContentProps) => {
+  const sortedSources = answer.sources?.length ? sortSources(answer.sources) : [];
+
   return (
     <div className="rounded-lg border bg-card p-4">
       <p className="whitespace-pre-wrap leading-relaxed line-clamp-4 text-card-foreground px-5">
         {answer.answer}
       </p>
+
+      {sortedSources.length > 0 && (
+        <div className="mt-4 px-5 pt-4 border-t border-border">
+          <h4 className="text-sm font-semibold text-foreground mb-3">
+            Source References
+          </h4>
+          <div className="space-y-2">
+            {sortedSources.map((item, idx) => (
+              <div key={idx} className="flex items-center gap-2 text-sm">
+                {item.sourceType && (
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-primary/10 text-primary border border-primary/20">
+                    {getSourceBadgeLabel(item)}
+                  </span>
+                )}
+                {/* Show sourceName separately only for non-other types when it's a unique name */}
+                {item.sourceName &&
+                  item.sourceType !== "other" &&
+                  item.sourceName.toLowerCase() !== (sourceTypeLabels[item.sourceType || ""] || "").toLowerCase() && (
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {item.sourceName}
+                    </span>
+                  )}
+
+                <a
+                  href={item.source}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:text-blue-800 hover:underline truncate max-w-md flex items-center gap-1"
+                >
+                  {item.source}
+                  <ExternalLink className="h-3 w-3 flex-shrink-0" />
+                </a>
+                {item.page && (
+                  <span className="text-xs text-muted-foreground">
+                    (p.{item.page})
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/features/question_details/components/answer_item/ViewMoreContent.tsx
+++ b/frontend/src/features/question_details/components/answer_item/ViewMoreContent.tsx
@@ -176,36 +176,40 @@ export const ViewMoreContent = ({
             {sortSources(answer.sources).map((source, idx) => (
               <div
                 key={idx}
-                className="flex items-center justify-between rounded-lg border bg-muted/30 p-2 pr-3"
+                className="grid grid-cols-[minmax(100px,auto)_1fr_auto_auto] items-center gap-10 rounded-lg border bg-muted/30 p-3"
               >
-                <div className="flex items-center gap-2 min-w-0">
-                  {source.sourceType && (
-                    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-primary/10 text-primary border border-primary/20 flex-shrink-0">
-                      {getSourceBadgeLabel(source)}
+                {/* Column 1: Source Type Badge */}
+                {source.sourceType ? (
+                  <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap">
+                    {getSourceBadgeLabel(source)}
+                  </span>
+                ) : (
+                  <span />
+                )}
+
+                {/* Column 2: Link */}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="text-sm truncate text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+                      onClick={() => window.open(source.source, "_blank")}
+                    >
+                      {source.source}
                     </span>
-                  )}
+                  </TooltipTrigger>
+                  <TooltipContent>{source.source}</TooltipContent>
+                </Tooltip>
 
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        className="text-sm truncate max-w-[260px] text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
-                        onClick={() => window.open(source.source, "_blank")}
-                      >
-                        {source.source}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>{source.source}</TooltipContent>
-                  </Tooltip>
+                {/* Column 3: Page Number */}
+                {source.page ? (
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    pg {source.page}
+                  </span>
+                ) : (
+                  <span />
+                )}
 
-                  {source.page && (
-                    <>
-                      <span className="text-muted-foreground">•</span>
-                      <span className="text-xs text-muted-foreground">
-                        page {source.page}
-                      </span>
-                    </>
-                  )}
-                </div>
+                {/* Column 4: Arrow */}
                 <a
                   href={source.source}
                   target="_blank"

--- a/frontend/src/features/question_details/components/answer_item/ViewMoreContent.tsx
+++ b/frontend/src/features/question_details/components/answer_item/ViewMoreContent.tsx
@@ -1,5 +1,24 @@
 // components/ViewMoreContent.tsx
-import type { IAnswer, ISubmissionHistory, QuestionStatus } from "@/types";
+import type { IAnswer, ISubmissionHistory, QuestionStatus, SourceItem } from "@/types";
+
+const sourceTypeOrder: Record<string, number> = {
+  hyper_local: 0, state: 1, central: 2, other: 3,
+};
+
+const sortSources = (sources: SourceItem[]) =>
+  [...sources].sort((a, b) => {
+    const orderA = sourceTypeOrder[a.sourceType || ""] ?? 99;
+    const orderB = sourceTypeOrder[b.sourceType || ""] ?? 99;
+    return orderA - orderB;
+  });
+
+const getSourceBadgeLabel = (source: SourceItem) => {
+  const label = source.sourceType === 'hyper_local' ? 'Hyper Local' : source.sourceType === 'state' ? 'State' : source.sourceType === 'central' ? 'Central' : 'Other';
+  if (source.sourceType === 'other' && source.sourceName && source.sourceName.toLowerCase() !== 'other') {
+    return `${label}: ${source.sourceName}`;
+  }
+  return label;
+};
 import { ScrollArea } from "@/components/atoms/scroll-area";
 import { Badge } from "@/components/atoms/badge";
 import { XCircle, Clock, AlertCircle, ArrowUpRight } from "lucide-react";
@@ -154,12 +173,18 @@ export const ViewMoreContent = ({
             Source URLs
           </p>
           <div className="space-y-2">
-            {answer.sources.map((source, idx) => (
+            {sortSources(answer.sources).map((source, idx) => (
               <div
                 key={idx}
                 className="flex items-center justify-between rounded-lg border bg-muted/30 p-2 pr-3"
               >
                 <div className="flex items-center gap-2 min-w-0">
+                  {source.sourceType && (
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-primary/10 text-primary border border-primary/20 flex-shrink-0">
+                      {getSourceBadgeLabel(source)}
+                    </span>
+                  )}
+
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -344,7 +344,11 @@ export interface FinalizedAnswersResponse {
   heatMapResults: HeatMapResult[];
 }
 
+export type SourceType = "hyper_local" | "state" | "central" | "other";
+
 export interface SourceItem {
+  sourceType?: SourceType;
+  sourceName?: string;
   source: string;
   page?: number;
 }


### PR DESCRIPTION
### Overview
Modified the **"Source References"** section in the expert answer form to replace the static URL input with a category-based dropdown system.

---

### Key Changes

#### 1. New Dropdown
Added options to select source types:
- Hyper Local  
- State  
- Central  
- Other  

#### 2. Conditional Fields
- For **Hyper Local**, **State**, and **Central**:
  - Only the **Source Link URL** field is displayed.
- For **Other**:
  - An additional **Source Name** field is shown to specify custom sources.

#### 3. Type Updates
Updated the `SourceItem` interface in both frontend and backend to include:
- `sourceType`
- `sourceName`

