### PR TITLE
feat: display sourceName for all source types with consistent badge layout

### DIFF
--- a/frontend/src/components/source-url-manager.tsx
+++ b/frontend/src/components/source-url-manager.tsx
@@ -48,7 +48,7 @@ export const SourceUrlManager = ({
       return;
     }
 
-    if (selectedType === "other" && !sourceName.trim()) {
+    if (!sourceName.trim()) {
       toast.error("Please enter the source name.");
       return;
     }
@@ -83,7 +83,7 @@ export const SourceUrlManager = ({
       ...sources,
       {
         sourceType: selectedType,
-        sourceName: selectedType === "other" ? sourceName.trim() : undefined,
+        sourceName: sourceName.trim(),
         source: trimmedUrl,
         page: pageNum,
       },
@@ -129,19 +129,17 @@ export const SourceUrlManager = ({
           </SelectContent>
         </Select>
 
-        {/* Source Name (only for Other) & URL fields */}
+        {/* Source Name & URL fields */}
         {selectedType && (
           <div className="space-y-2 animate-in fade-in-0 slide-in-from-top-1 duration-200">
-            {selectedType === "other" && (
-              <Input
-                type="text"
-                placeholder="Other Source Name"
-                value={sourceName}
-                onChange={(e) => setSourceName(e.target.value)}
-                onKeyDown={handleKeyDown}
-                className="w-full"
-              />
-            )}
+            <Input
+              type="text"
+              placeholder={`${SOURCE_TYPE_LABELS[selectedType]} Source Name`}
+              value={sourceName}
+              onChange={(e) => setSourceName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="w-full"
+            />
             <div className="flex gap-2">
               <Input
                 type="url"

--- a/frontend/src/components/source-url-manager.tsx
+++ b/frontend/src/components/source-url-manager.tsx
@@ -176,14 +176,17 @@ export const SourceUrlManager = ({
               {sources.map((item, idx) => (
                 <div
                   key={idx}
-                  className="grid grid-cols-[minmax(100px,auto)_1fr_auto_auto] items-center gap-10 px-3 py-2 bg-tag border border-tag-border rounded-lg text-sm text-tag-foreground hover:bg-tag-hover transition-colors"
+                  className="grid grid-cols-[140px_1fr_auto_auto] items-center gap-6 px-3 py-2 bg-tag border border-tag-border rounded-lg text-sm text-tag-foreground hover:bg-tag-hover transition-colors"
                 >
                   {/* Column 1: Source Type Badge */}
                   {item.sourceType ? (
-                    <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap">
-                      {item.sourceType === 'other' && item.sourceName && item.sourceName.toLowerCase() !== 'other'
-                        ? `Other: ${item.sourceName}`
-                        : SOURCE_TYPE_LABELS[item.sourceType] || item.sourceType}
+                    <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap overflow-x-auto">
+                      {(() => {
+                        const label = SOURCE_TYPE_LABELS[item.sourceType!] || item.sourceType;
+                        return item.sourceName && item.sourceName.toLowerCase() !== (label || '').toLowerCase()
+                          ? `${label}: ${item.sourceName}`
+                          : label;
+                      })()}
                     </span>
                   ) : (
                     <span />

--- a/frontend/src/features/qa-interface-page/ReviewHistoryTimeline.tsx
+++ b/frontend/src/features/qa-interface-page/ReviewHistoryTimeline.tsx
@@ -19,7 +19,7 @@ const sortSources = (sources: SourceItem[]) =>
 
 const getSourceBadgeLabel = (source: SourceItem) => {
   const label = source.sourceType === 'hyper_local' ? 'Hyper Local' : source.sourceType === 'state' ? 'State' : source.sourceType === 'central' ? 'Central' : 'Other';
-  if (source.sourceType === 'other' && source.sourceName && source.sourceName.toLowerCase() !== 'other') {
+  if (source.sourceName && source.sourceName.toLowerCase() !== label.toLowerCase()) {
     return `${label}: ${source.sourceName}`;
   }
   return label;
@@ -464,11 +464,11 @@ if (!h || !h.rerouteId || !h.question?._id || !h.moderator?._id || !h.reroute?.r
                                               (source: any, idx: number) => (
                                                 <div
                                                   key={idx}
-                                                  className="grid grid-cols-[minmax(100px,auto)_1fr_auto_auto] items-center gap-10 p-3 border rounded-md hover:bg-muted/40 transition-colors text-sm"
+                                                  className="grid grid-cols-[140px_1fr_auto_auto] items-center gap-6 p-3 border rounded-md hover:bg-muted/40 transition-colors text-sm"
                                                 >
                                                   {/* Column 1: Source Type Badge */}
                                                   {source.sourceType ? (
-                                                    <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap">
+                                                    <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap overflow-x-auto">
                                                       {getSourceBadgeLabel(source)}
                                                     </span>
                                                   ) : (

--- a/frontend/src/features/question_details/components/answer_item/ViewMoreContent.tsx
+++ b/frontend/src/features/question_details/components/answer_item/ViewMoreContent.tsx
@@ -14,7 +14,7 @@ const sortSources = (sources: SourceItem[]) =>
 
 const getSourceBadgeLabel = (source: SourceItem) => {
   const label = source.sourceType === 'hyper_local' ? 'Hyper Local' : source.sourceType === 'state' ? 'State' : source.sourceType === 'central' ? 'Central' : 'Other';
-  if (source.sourceType === 'other' && source.sourceName && source.sourceName.toLowerCase() !== 'other') {
+  if (source.sourceName && source.sourceName.toLowerCase() !== label.toLowerCase()) {
     return `${label}: ${source.sourceName}`;
   }
   return label;
@@ -176,11 +176,11 @@ export const ViewMoreContent = ({
             {sortSources(answer.sources).map((source, idx) => (
               <div
                 key={idx}
-                className="grid grid-cols-[minmax(100px,auto)_1fr_auto_auto] items-center gap-10 rounded-lg border bg-muted/30 p-3"
+                className="grid grid-cols-[140px_1fr_auto_auto] items-center gap-6 rounded-lg border bg-muted/30 p-3"
               >
                 {/* Column 1: Source Type Badge */}
                 {source.sourceType ? (
-                  <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap">
+                  <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-foreground/10 text-foreground border border-foreground/20 whitespace-nowrap overflow-x-auto">
                     {getSourceBadgeLabel(source)}
                   </span>
                 ) : (


### PR DESCRIPTION
Added sourceName support for all source types (Hyper Local, State, Central, Other) in the expert source dropdown and updated the frontend display components to show source names consistently with a fixed-width badge layout. Tested locally.