### PR TITLE
feat: integrate IMD Weather API Wrapper with Docker and CI/CD

### DIFF
--- a/.github/workflows/api-deployment.yml
+++ b/.github/workflows/api-deployment.yml
@@ -1,7 +1,17 @@
 name: API Deployment
 
+# Added inputs to allow selection of which API to build and deploy
 on:
   workflow_dispatch:
+    inputs:
+      target_api:
+        description: "Select API to build"
+        required: true
+        default: "acc_api"
+        type: choice
+        options:
+          - acc_api
+          - imd_weather_api_wrapper
 
 permissions:
   contents: read
@@ -10,6 +20,7 @@ permissions:
 
 jobs:
   build-and-push:
+    if: github.event.inputs.target_api == 'acc_api'
     name: Build & Push acc_api
     runs-on: ubuntu-latest
     steps:
@@ -43,3 +54,32 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/acc_api:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/acc_api:${{ github.sha }}
+  # 2. Added conditional job to build and push IMD Wrapper only if selected in the workflow dispatch inputs
+  build-and-push-imd:
+    if: github.event.inputs.target_api == 'imd_weather_api_wrapper'
+    name: Build & Push IMD Wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build & Push IMD Wrapper
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./mcp/imd_weather_api_wrapper/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/imd-api-wrapper:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/imd-api-wrapper:${{ github.sha }}

--- a/mcp/imd_weather_api_wrapper/Dockerfile
+++ b/mcp/imd_weather_api_wrapper/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+WORKDIR /app
+
+COPY mcp/imd_weather_api_wrapper/requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY mcp/imd_weather_api_wrapper/ .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
I have completed the containerization of the IMD Weather API Wrapper. Following our discussion, I have integrated the deployment into the existing api-deployment.yml workflow using a selective workflow_dispatch approach.

**Changes Made:**

- Added Dockerfile to mcp/imd_weather_api_wrapper/.
- Updated .github/workflows/api-deployment.yml to include a target_api dropdown.
- Added a conditional job build-and-push-imd that follows the existing team pattern.

**Verification Performed (on feature branch):**

- Test 1: Triggered acc_api → Verified that only the original API built and my new job was correctly skipped.
- Test 2: Triggered imd_weather_api_wrapper → Verified successful build and push to Docker Hub (using existing repo secrets).

The main branch remains untouched and safe. 