### PR TITLE
feat: enable IP-whitelist live mode for IMD API wrapper

### DIFF
--- a/mcp/imd_weather_api_wrapper/wrapper/client.py
+++ b/mcp/imd_weather_api_wrapper/wrapper/client.py
@@ -8,8 +8,10 @@
 
 import time
 import random
+import json
 import logging
 from datetime import datetime
+import requests
 
 from .config import (
     ENDPOINTS,
@@ -21,9 +23,9 @@ from .config import (
 logger = logging.getLogger("IMDClient")
 
 # Toggle 
-BASE_URL = "MOCK"       # replace with real URL when available
-API_KEY  = "MOCK"       # replace with real API key when available
-USE_MOCK = (BASE_URL == "MOCK" or API_KEY == "MOCK")
+BASE_URL = "http://100.100.108.101:18080"
+API_KEY  = ""  # Optional. Leave empty for IP-whitelist auth mode.
+USE_MOCK = False
 
 
 # Season helper (drives realistic mock values) 
@@ -248,25 +250,40 @@ def _fetch(endpoint_key: str, params: dict,
         raw = mock_fn(**params)
         return _normalise(raw, endpoint_key)
 
-    # LIVE MODE (uncomment for live API) 
-    # import requests
-    # url     = BASE_URL.rstrip("/") + ENDPOINTS[endpoint_key]
-    # headers = {"Authorization": f"Bearer {API_KEY}"}
-    # last_err = None
-    # for attempt in range(1, max_retries + 1):
-    #     try:
-    #         resp = requests.get(url, params=params,
-    #                             headers=headers, timeout=timeout)
-    #         if resp.status_code == 200:
-    #             return _normalise(resp.json(), endpoint_key)
-    #         if resp.status_code == 429:
-    #             time.sleep(5); continue
-    #         last_err = f"HTTP {resp.status_code}"
-    #     except Exception as exc:
-    #         last_err = str(exc)
-    #     if attempt < max_retries:
-    #         time.sleep(attempt)
-    # raise RuntimeError(f"[{endpoint_key}] Failed: {last_err}")
+    # LIVE MODE: IP-whitelist supported (no API key required).
+    url = BASE_URL.rstrip("/") + ENDPOINTS[endpoint_key]
+    headers = {"Authorization": f"Bearer {API_KEY}"} if API_KEY else {}
+    last_err = None
+    auth_mode = "bearer" if API_KEY else "ip-whitelist"
+    logger.info("[LIVE] %s | url=%s | auth=%s", endpoint_key, url, auth_mode)
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=timeout)
+            if resp.status_code == 200:
+                try:
+                    json_data = resp.json()
+                    logger.info("[LIVE OK] %s | status=200 | bytes=%d", endpoint_key, len(resp.content))
+                    return _normalise(json_data, endpoint_key)
+                except json.JSONDecodeError as je:
+                    last_err = f"JSON decode error: {str(je)}"
+                    logger.error("[LIVE ERROR] %s | JSON parse failed: %s", endpoint_key, last_err)
+
+            if resp.status_code == 429:
+                logger.warning("[LIVE RETRY] %s | rate limited (429), waiting 5s", endpoint_key)
+                time.sleep(5)
+                continue
+
+            last_err = f"HTTP {resp.status_code}: {resp.text[:200]}"
+            logger.error("[LIVE ERROR] %s | HTTP %d", endpoint_key, resp.status_code)
+        except Exception as exc:
+            last_err = str(exc)
+            logger.error("[LIVE ERROR] %s | exception: %s", endpoint_key, last_err)
+
+        if attempt < max_retries:
+            time.sleep(attempt)
+
+    raise RuntimeError(f"[{endpoint_key}] Failed: {last_err}")
 
 
 # ── Public API class ──────────────────────────────────────────


### PR DESCRIPTION
- Switch client.py to live mode (USE_MOCK = False)
- Configure BASE_URL to IMD endpoint without API key requirement
- Add comprehensive logging for live API calls (success, errors, retries)
- Handle JSON parse errors 

This enables the wrapper to make real requests to IMD endpoints via IP whitelist authentication.
@Kshitij3h 
@shubhankar-git 