### PR TITLE
Feature/switch to live api weather imd

### DIFF
--- a/mcp/imd_weather_api_wrapper/wrapper/client.py
+++ b/mcp/imd_weather_api_wrapper/wrapper/client.py
@@ -1,9 +1,7 @@
 # imd_api_wrapper/wrapper/client.py
 # ─────────────────────────────────────────────────────────────
 # IMD API Client
-# Currently runs in MOCK mode (no real credentials needed).
-# Switch to LIVE by setting BASE_URL and API_KEY in config.py
-# and flipping USE_MOCK = False below.
+# Currently runs in Live mode with IP-whitelist auth (no API key required).
 # ─────────────────────────────────────────────────────────────
 
 import time

--- a/mcp/imd_weather_api_wrapper/wrapper/config.py
+++ b/mcp/imd_weather_api_wrapper/wrapper/config.py
@@ -8,7 +8,7 @@
 # IMD endpoint slugs 
 ENDPOINTS = {
     "city_forecast"    : "/city/api/cityweather.php",                    # CRITICAL
-    "district_forecast": "/mausam/api/districtwise_weather_api.php",     # HIGH
+    "district_forecast": "/mausam/api/districtwise_forecast_api.php",    # HIGH
     "rainfall_forecast": "/mausam/api/districtwise_rainfall_api.php",    # MEDIUM
     "current_weather"  : "/city/api/cityweather.php",                    # MEDIUM
     "nowcast"          : "/mausam/api/nowcast_district_api.php",         # LOW

--- a/mcp/imd_weather_api_wrapper/wrapper/config.py
+++ b/mcp/imd_weather_api_wrapper/wrapper/config.py
@@ -8,7 +8,7 @@
 # IMD endpoint slugs 
 ENDPOINTS = {
     "city_forecast"    : "/city/api/cityweather.php",                    # CRITICAL
-    "district_forecast": "/mausam/api/districtwise_rainfall_api.php",    # HIGH
+    "district_forecast": "/mausam/api/districtwise_weather_api.php",     # HIGH
     "rainfall_forecast": "/mausam/api/districtwise_rainfall_api.php",    # MEDIUM
     "current_weather"  : "/city/api/cityweather.php",                    # MEDIUM
     "nowcast"          : "/mausam/api/nowcast_district_api.php",         # LOW


### PR DESCRIPTION
Replacing the district weather endpoint to return district wise weather (including rainfall) not only district wise rainfall in config.py file and also changing the header to Iive mode in Client.py file. @Kshitij3h @shubhankar-git 