### PR TITLE
Add countdown timer to expert questions sidebar 

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -1084,6 +1084,7 @@ export class QuestionRepository implements IQuestionRepository {
           'details.crop': 1,
           'details.state': 1,
           source: 1,
+          status: 1,
           _id: 0,
         },
       });

--- a/frontend/src/features/qa-interface-page/QaHeader.tsx
+++ b/frontend/src/features/qa-interface-page/QaHeader.tsx
@@ -26,7 +26,7 @@ import type {
 } from "@/types";
 import { Label } from "../../components/atoms/label";
 import { formatDate } from "@/utils/formatDate";
-import { useCountdown } from "@/hooks/ui/useCountdown";
+import { useQuestionTimer } from "@/hooks/ui/useQuestionTimer";
 import { TimerDisplay } from "../../components/timer-display";
 
 type QaHeaderProps={
@@ -305,8 +305,7 @@ const QaQuestionItem = ({
   onQuestionSelect: (id: string) => void;
   setQuestionRef: (id: string, el: HTMLDivElement | null) => void;
 }) => {
-  const DURATION_HOURS = question?.source === "AJRASAKHA" ? 2 : 4;
-  const timer = useCountdown(question?.createdAt, DURATION_HOURS, () => {});
+  const { timer } = useQuestionTimer(question?.source, question?.createdAt);
 
   return (
     <div

--- a/frontend/src/features/qa-interface-page/QaHeader.tsx
+++ b/frontend/src/features/qa-interface-page/QaHeader.tsx
@@ -26,6 +26,8 @@ import type {
 } from "@/types";
 import { Label } from "../../components/atoms/label";
 import { formatDate } from "@/utils/formatDate";
+import { useCountdown } from "@/hooks/ui/useCountdown";
+import { TimerDisplay } from "../../components/timer-display";
 
 type QaHeaderProps={
   questions: any
@@ -292,6 +294,139 @@ const QaPreferencesDialog = ({
   );
 };
 
+const QaQuestionItem = ({
+  question,
+  selectedQuestion,
+  onQuestionSelect,
+  setQuestionRef,
+}: {
+  question: any;
+  selectedQuestion: string | null;
+  onQuestionSelect: (id: string) => void;
+  setQuestionRef: (id: string, el: HTMLDivElement | null) => void;
+}) => {
+  const DURATION_HOURS = question?.source === "AJRASAKHA" ? 2 : 4;
+  const timer = useCountdown(question?.createdAt, DURATION_HOURS, () => {});
+
+  return (
+    <div
+      key={question?.id}
+      ref={(el) => setQuestionRef(question?.id || "", el)}
+      className={`relative group rounded-xl border transition-all duration-200 overflow-hidden bg-transparent ${
+        selectedQuestion === question?.id
+          ? "border-primary bg-primary/5 shadow-md ring-2 ring-primary/20"
+          : "border-border bg-card hover:border-primary/40 hover:bg-accent/20 hover:shadow-sm"
+      }`}
+    >
+      {selectedQuestion === question?.id && (
+        <div className="absolute left-0 top-0 bottom-0 w-1 bg-primary"></div>
+      )}
+
+      <div className="p-4">
+        <div className="flex items-start gap-3">
+          <RadioGroupItem
+            value={question?.id || ""}
+            id={question?.id}
+            className="mt-1  w-5 h-5 rounded-full border-2 border-gray-400 dark:border-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 checked:bg-green-600 dark:checked:bg-green-400"
+          />
+
+          <div className="flex-1 min-w-0">
+            <Label
+              htmlFor={question?.id}
+              className="text-sm md:text-base font-medium leading-relaxed cursor-pointer text-foreground group-hover:text-foreground/90 transition-colors block"
+            >
+              {question?.text}
+            </Label>
+          </div>
+        </div>
+        <div className="mt-2 ml-7">
+          <TimerDisplay timer={timer} status={question?.status} source={question?.source} size="sm" />
+        </div>
+        <div className="mt-1 ml-7 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+          <div className="items-center gap-1.5 flex">
+            {question?.priority && (
+              <span
+                className={`px-2 py-0.5 rounded-full text-[10px] font-semibold border ${
+                  question.priority === "high"
+                    ? "bg-red-500/10 text-red-600 border-red-500/30"
+                    : question.priority === "medium"
+                    ? "bg-yellow-500/10 text-yellow-600 border-yellow-500/30"
+                    : "bg-green-500/10 text-green-600 border-green-500/30"
+                }`}
+              >
+                {question.priority.charAt(0).toUpperCase() +
+                  question.priority.slice(1)}
+              </span>
+            )}
+
+            <svg
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span className="font-medium text-xs">
+              Created:
+            </span>
+            <span>
+              {formatDate(new Date(question?.createdAt!))}
+            </span>
+          </div>
+
+          <div className="hidden md:flex items-center gap-1.5">
+            <svg
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+              />
+            </svg>
+            <span className="font-medium">Updated:</span>
+            {formatDate(new Date(question?.updatedAt!))}
+          </div>
+
+          <div className="hidden md:flex items-center gap-1.5">
+            <svg
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-3.582 8-8 8a8.965 8.965 0 01-4.126-.937l-3.157.937.937-3.157A8.965 8.965 0 013 12c0-4.418 3.582-8 8-8s8 3.582 8 8z"
+              />
+            </svg>
+            <span className="font-medium">Answers:</span>
+            <span className="px-1.5 py-0.5 bg-muted text-muted-foreground rounded text-xs font-medium">
+              {question?.totalAnswersCount}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {selectedQuestion === question?.id && (
+        <div className="absolute inset-0 bg-gradient-to-r from-primary/5 to-transparent pointer-events-none"></div>
+      )}
+    </div>
+  );
+};
+
 export const QaHeader=({ questions,
   selectedQuestion,
   onQuestionSelect,
@@ -455,119 +590,13 @@ export const QaHeader=({ questions,
                   className="space-y-4"
                 >
                   {questions?.map((question:any) => (
-                    <div
-                      // key={index}
+                    <QaQuestionItem
                       key={question?.id}
-                      ref={(el) => setQuestionRef(question?.id || "", el)} //comment if scroll is not needed
-                      className={`relative group rounded-xl border transition-all duration-200 overflow-hidden bg-transparent ${
-                        selectedQuestion === question?.id
-                          ? "border-primary bg-primary/5 shadow-md ring-2 ring-primary/20"
-                          : "border-border bg-card hover:border-primary/40 hover:bg-accent/20 hover:shadow-sm"
-                      }`}
-                    >
-                      {selectedQuestion === question?.id && (
-                        <div className="absolute left-0 top-0 bottom-0 w-1 bg-primary"></div>
-                      )}
-
-                      <div className="p-4">
-                        <div className="flex items-start gap-3">
-                          <RadioGroupItem
-                            value={question?.id || ""}
-                            id={question?.id}
-                            className="mt-1  w-5 h-5 rounded-full border-2 border-gray-400 dark:border-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 checked:bg-green-600 dark:checked:bg-green-400"
-                          />
-
-                          <div className="flex-1 min-w-0">
-                            <Label
-                              htmlFor={question?.id}
-                              className="text-sm md:text-base font-medium leading-relaxed cursor-pointer text-foreground group-hover:text-foreground/90 transition-colors block"
-                            >
-                              {question?.text}
-                            </Label>
-                          </div>
-                        </div>
-                        <div className="mt-3 ml-7 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
-                          <div className="items-center gap-1.5 flex">
-                            {question?.priority && (
-                              <span
-                                className={`px-2 py-0.5 rounded-full text-[10px] font-semibold border ${
-                                  question.priority === "high"
-                                    ? "bg-red-500/10 text-red-600 border-red-500/30"
-                                    : question.priority === "medium"
-                                    ? "bg-yellow-500/10 text-yellow-600 border-yellow-500/30"
-                                    : "bg-green-500/10 text-green-600 border-green-500/30"
-                                }`}
-                              >
-                                {question.priority.charAt(0).toUpperCase() +
-                                  question.priority.slice(1)}
-                              </span>
-                            )}
-
-                            <svg
-                              className="w-3 h-3"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                              />
-                            </svg>
-                            <span className="font-medium text-xs">
-                              Created:
-                            </span>
-                            <span>
-                              {formatDate(new Date(question?.createdAt!))}
-                            </span>
-                          </div>
-
-                          <div className="hidden md:flex items-center gap-1.5">
-                            <svg
-                              className="w-3 h-3"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                              />
-                            </svg>
-                            <span className="font-medium">Updated:</span>
-                            {formatDate(new Date(question?.updatedAt!))}
-                          </div>
-
-                          <div className="hidden md:flex items-center gap-1.5">
-                            <svg
-                              className="w-3 h-3"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-3.582 8-8 8a8.965 8.965 0 01-4.126-.937l-3.157.937.937-3.157A8.965 8.965 0 013 12c0-4.418 3.582-8 8-8s8 3.582 8 8z"
-                              />
-                            </svg>
-                            <span className="font-medium">Answers:</span>
-                            <span className="px-1.5 py-0.5 bg-muted text-muted-foreground rounded text-xs font-medium">
-                              {question?.totalAnswersCount}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-
-                      {selectedQuestion === question?.id && (
-                        <div className="absolute inset-0 bg-gradient-to-r from-primary/5 to-transparent pointer-events-none"></div>
-                      )}
-                    </div>
+                      question={question}
+                      selectedQuestion={selectedQuestion}
+                      onQuestionSelect={onQuestionSelect}
+                      setQuestionRef={setQuestionRef}
+                    />
                   ))}
                 </RadioGroup>
                 {isFetchingNextPage && (

--- a/frontend/src/features/question-table-page/AddOrEditQuestionDialog.tsx
+++ b/frontend/src/features/question-table-page/AddOrEditQuestionDialog.tsx
@@ -576,18 +576,6 @@ export const AddOrEditQuestionDialog = ({
                   <div className="flex flex-col gap-2">
                     <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
                       <label>Crop*</label>
-                      {mode !== "edit" && (
-                        <TooltipProvider delayDuration={200}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Info className="h-4 w-4 cursor-pointer hover:text-foreground transition-colors" aria-hidden="true" />
-                            </TooltipTrigger>
-                            <TooltipContent side="top" className="max-w-xs text-xs">
-                              <p>The names here are normalized and unique. You can view a crop's alternative names by hovering over the "+" icon next to it.</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      )}
                     </div>
                     <CropSelect
                       value={updatedData?.details?.crop}

--- a/frontend/src/features/question-table-page/MobileQuestionCard.tsx
+++ b/frontend/src/features/question-table-page/MobileQuestionCard.tsx
@@ -3,11 +3,8 @@ import type {
   QuestionStatus,
   UserRole,
 } from "@/types";
-import {
-  useMemo,
-  useRef,
-} from "react";
-import { useCountdown } from "@/hooks/ui/useCountdown";
+import { useMemo } from "react";
+import { useQuestionClickability } from "@/hooks/ui/useQuestionClickability";
 import { Badge } from "../../components/atoms/badge";
 import { Button } from "../../components/atoms/button";
 import { TimerDisplay } from "../../components/timer-display";
@@ -100,22 +97,9 @@ export const MobileQuestionCard: React.FC<QuestionRowProps> = ({
   handleDelete,
   onViewMore,
 }) => {
-  const uploadedCountRef = useRef(uploadedQuestionsCount);
-
-  // const DURATION_HOURS = 4;
-  const DURATION_HOURS = q && q.source == "AJRASAKHA" ? 2 : 4;
-  const timer = useCountdown(q.createdAt, DURATION_HOURS, () => { });
-  const totalSeconds = DURATION_HOURS * 3600;
-
-  const [h, m, s] = timer.split(":").map(Number);
-  const remainingSeconds = h * 3600 + m * 60 + s;
-
-  const delayPerQuestion = 180 / 200;
-  let delaySeconds = uploadedCountRef.current * delayPerQuestion;
-  if (userRole === "expert") delaySeconds = 200;
-
-  const isClickable =
-    remainingSeconds <= totalSeconds - delaySeconds && !isBulkUpload;
+  const { timer, isClickable } = useQuestionClickability(
+    q.source, q.createdAt, uploadedQuestionsCount, userRole, isBulkUpload
+  );
 
   const statusBadge = useMemo(() => {
     // const status = q.status || "NIL";

--- a/frontend/src/features/question-table-page/QuestionRow.tsx
+++ b/frontend/src/features/question-table-page/QuestionRow.tsx
@@ -1,6 +1,6 @@
 import type { IDetailedQuestion, QuestionStatus, UserRole } from "@/types";
-import { useMemo, useRef } from "react";
-import { useCountdown } from "@/hooks/ui/useCountdown";
+import { useMemo } from "react";
+import { useQuestionClickability } from "@/hooks/ui/useQuestionClickability";
 import { Badge } from "../../components/atoms/badge";
 import {
   ContextMenu,
@@ -85,33 +85,9 @@ export const QuestionRow: React.FC<QuestionRowProps> = ({
   const visibleColumns = useQuestionTableStore((state) => state.visibleColumns);
   // To track cont
 
-  const uploadedCountRef = useRef(uploadedQuestionsCount);
-
-  // const DURATION_HOURS = 4;
-  const DURATION_HOURS = q && q.source == "AJRASAKHA" ? 2 : 4;
-  const timer = useCountdown(q.createdAt, DURATION_HOURS, () => { });
-
-  const totalSeconds = DURATION_HOURS * 60 * 60;
-
-  // Parse timer string ("hh:mm:ss") to seconds
-  const [h, m, s] = timer.split(":").map(Number);
-  const remainingSeconds = h * 3600 + m * 60 + s;
-
-  //  Calculate delay based on uploaded questions
-  // 200 questions → 3 minutes = 180 seconds
-  const delayPerQuestion = 180 / 200; // 0.9 seconds per question
-  let delaySeconds = uploadedCountRef.current * delayPerQuestion;
-
-  if (userRole === "expert") {
-    delaySeconds = 200;
-  }
-
-  // For tooltip
-  const delayMinutes = delaySeconds / 60;
-
-  //  Check if enough time has passed
-  const isClickable =
-    remainingSeconds <= totalSeconds - delaySeconds && !isBulkUpload;
+  const { timer, isClickable, delayMinutes } = useQuestionClickability(
+    q.source, q.createdAt, uploadedQuestionsCount, userRole, isBulkUpload
+  );
 
   const priorityBadge = useMemo(() => {
     if (!q.priority)

--- a/frontend/src/features/question-table-page/QuestionsCard.tsx
+++ b/frontend/src/features/question-table-page/QuestionsCard.tsx
@@ -1,6 +1,6 @@
 import type { IDetailedQuestion, QuestionStatus, UserRole } from "@/types";
-import React, { useMemo, useRef, useState } from "react";
-import { useCountdown } from "@/hooks/ui/useCountdown";
+import React, { useMemo, useState } from "react";
+import { useQuestionClickability } from "@/hooks/ui/useQuestionClickability";
 import { Badge } from "../../components/atoms/badge";
 import { TimerDisplay } from "../../components/timer-display";
 import { formatDate } from "@/utils/formatDate";
@@ -78,22 +78,9 @@ const QuestionsCard: React.FC<QuestionsCardProps> = ({
 }) => {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
-  const uploadedCountRef = useRef(uploadedQuestionsCount);
-
-  // const DURATION_HOURS = 4;
-  const DURATION_HOURS = q && q.source == "AJRASAKHA" ? 2 : 4;
-  const timer = useCountdown(q.createdAt, DURATION_HOURS, () => { });
-  const totalSeconds = DURATION_HOURS * 3600;
-
-  const [h, m, s] = timer.split(":").map(Number);
-  const remainingSeconds = h * 3600 + m * 60 + s;
-
-  const delayPerQuestion = 180 / 200;
-  let delaySeconds = uploadedCountRef.current * delayPerQuestion;
-  if (userRole === "expert") delaySeconds = 200;
-
-  const isClickable =
-    remainingSeconds <= totalSeconds - delaySeconds && !isBulkUpload;
+  const { timer, isClickable } = useQuestionClickability(
+    q.source, q.createdAt, uploadedQuestionsCount, userRole, isBulkUpload
+  );
 
   const statusBadge = useMemo(() => {
     // const status = q.status || "NIL";

--- a/frontend/src/features/question_details/components/QuestionHeader.tsx
+++ b/frontend/src/features/question_details/components/QuestionHeader.tsx
@@ -3,7 +3,7 @@ import { Badge } from "@/components/atoms/badge";
 import { Button } from "@/components/atoms/button";
 import { TimerDisplay } from "@/components/timer-display";
 import { formatDate } from "@/utils/formatDate";
-import { useCountdown } from "@/hooks/ui/useCountdown";
+import { useQuestionTimer } from "@/hooks/ui/useQuestionTimer";
 import SarvamTranslateDropdown from "@/components/SarvamTranslateDropdown";
 import { useState } from "react";
 
@@ -15,9 +15,7 @@ interface QuestionHeaderProps {
 export const QuestionHeader = ({ question, goBack }: QuestionHeaderProps) => {
   //translation state
   const [translatedText, setTranslatedText] = useState<string>("");
-  const DURATION_HOURS = question && question.source == "AJRASAKHA" ? 2 : 4;
-
-  const timer = useCountdown(question.createdAt!, DURATION_HOURS, () => { });
+  const { timer } = useQuestionTimer(question.source, question.createdAt!);
 
   return (
     <header className="grid gap-3 w-full">

--- a/frontend/src/hooks/ui/useQuestionClickability.ts
+++ b/frontend/src/hooks/ui/useQuestionClickability.ts
@@ -1,0 +1,28 @@
+import type { UserRole } from "@/types";
+import { useRef } from "react";
+import { useQuestionTimer } from "./useQuestionTimer";
+
+export function useQuestionClickability(
+  source: string | undefined,
+  createdAt: string | undefined | null,
+  uploadedQuestionsCount: number,
+  userRole: UserRole,
+  isBulkUpload: boolean
+) {
+  const uploadedCountRef = useRef(uploadedQuestionsCount);
+  const { timer, DURATION_HOURS } = useQuestionTimer(source, createdAt);
+
+  const totalSeconds = DURATION_HOURS * 3600;
+  const [h, m, s] = timer.split(":").map(Number);
+  const remainingSeconds = h * 3600 + m * 60 + s;
+
+  const delayPerQuestion = 180 / 200;
+  let delaySeconds = uploadedCountRef.current * delayPerQuestion;
+  if (userRole === "expert") delaySeconds = 200;
+
+  const delayMinutes = delaySeconds / 60;
+  const isClickable =
+    remainingSeconds <= totalSeconds - delaySeconds && !isBulkUpload;
+
+  return { timer, isClickable, delayMinutes };
+}

--- a/frontend/src/hooks/ui/useQuestionTimer.ts
+++ b/frontend/src/hooks/ui/useQuestionTimer.ts
@@ -1,0 +1,10 @@
+import { useCountdown } from "./useCountdown";
+
+export function useQuestionTimer(
+  source: string | undefined,
+  createdAt: string | undefined | null
+) {
+  const DURATION_HOURS = source === "AJRASAKHA" ? 2 : 4;
+  const timer = useCountdown(createdAt, DURATION_HOURS, () => {});
+  return { timer, DURATION_HOURS };
+}


### PR DESCRIPTION
Shows the remaining response time on each question card  
  in the expert Questions page (same timer already visible 
  in All Questions). Fixed by adding status to the         
  allocated questions MongoDB projection so TimerDisplay 
  could render correctly, and extracted the question card
  into a QaQuestionItem component to properly use the
  useCountdown hook.
