### PR TITLE
feat(mcp-tool): secure API and add WhatsApp source tracking

### DIFF
--- a/ai/ajrasakha/tools/reviewer/reviewer_system_tool.py
+++ b/ai/ajrasakha/tools/reviewer/reviewer_system_tool.py
@@ -1,10 +1,16 @@
 import requests
+import os
+from dotenv import load_dotenv
 from typing import List, Dict, Any
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
+load_dotenv()
+
 CREATE_QUESTION_URL = "https://desk.vicharanashala.ai/api/questions"
 CHECK_STATUS_URL = "https://desk.vicharanashala.ai/api/questions/check-status"
+
+INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "")
 
 mcp = FastMCP(
     "ajrasakha-reviewer-mcp",
@@ -28,17 +34,26 @@ def upload_question_to_reviewer_system(
         "question": question,
         "state_name": state_name,
         "crop": crop,
-        "details": details
+        "details": details,
+        "source": "whatsapp" 
+    }
+    
+    headers = {
+        "x-internal-api-key": INTERNAL_API_KEY
     }
     
     try:
-        response = requests.post(CREATE_QUESTION_URL, json=payload, timeout=10)
+        response = requests.post(
+            CREATE_QUESTION_URL, 
+            json=payload, 
+            headers=headers, 
+            timeout=10
+        )
         response.raise_for_status()
         return response.json()
     except requests.exceptions.RequestException as e:
         print(f"Error submitting question: {e}")
         return {"error": str(e)}
-
 
 if __name__ == "__main__":
     mcp.run(transport="streamable-http")


### PR DESCRIPTION
- Add x-internal-api-key for vicharanashala API authentication
- Include "source": "whatsapp" in the payload body
- chore: remove unused question status checker tool