### PR TITLE
Fix/wrong filter name

### DIFF
--- a/frontend/src/components/advanced-question-filter.tsx
+++ b/frontend/src/components/advanced-question-filter.tsx
@@ -21,6 +21,7 @@ import {
 import { Separator } from "@/components/atoms/separator";
 import { Badge } from "@/components/atoms/badge";
 import { Slider } from "@/components/atoms/slider";
+import { Checkbox } from "@/components/atoms/checkbox";
 import {
   Filter,
   FileText,
@@ -867,16 +868,12 @@ export const AdvanceFilterDialog: React.FC<AdvanceFilterDialogProps> = ({
 
               <div className="space-y-3 rounded-lg border border-border bg-background p-4">
                 <label className="flex items-center gap-3">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={advanceFilter.hiddenQuestions ?? false}
-                    onChange={(event) =>
-                      handleDialogChange(
-                        "hiddenQuestions",
-                        event.target.checked,
-                      )
+                    onCheckedChange={(checked) =>
+                      handleDialogChange("hiddenQuestions", checked === true)
                     }
-                    className="h-3.5 w-3.5 rounded border-gray-300 text-primary focus:ring-primary"
+                    className="h-3.5 w-3.5 border-green-300"
                   />
                   <span className="text-sm">Show passed questions</span>
                 </label>

--- a/frontend/src/components/advanced-question-filter.tsx
+++ b/frontend/src/components/advanced-question-filter.tsx
@@ -873,7 +873,7 @@ export const AdvanceFilterDialog: React.FC<AdvanceFilterDialogProps> = ({
                     onCheckedChange={(checked) =>
                       handleDialogChange("hiddenQuestions", checked === true)
                     }
-                    className="h-3.5 w-3.5 border-green-300"
+                    className="h-3.5 w-3.5 border-primary"
                   />
                   <span className="text-sm">Show passed questions</span>
                 </label>

--- a/frontend/src/components/advanced-question-filter.tsx
+++ b/frontend/src/components/advanced-question-filter.tsx
@@ -927,7 +927,7 @@ export const AdvanceFilterDialog: React.FC<AdvanceFilterDialogProps> = ({
 
                       const label =
                         key === "hiddenQuestions"
-                          ? "Show hidden questions"
+                          ? "Show passed questions"
                           : key === "duplicateQuestions"
                             ? "Show duplicate questions"
                             : key;

--- a/frontend/src/features/question-table-page/DownloadFilteredReportButton.tsx
+++ b/frontend/src/features/question-table-page/DownloadFilteredReportButton.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/atoms/select";
 import { Label } from "@/components/atoms/label";
 import { Separator } from "@/components/atoms/separator";
+import { Checkbox } from "@/components/atoms/checkbox";
 import { STATES, CROPS, SEASONS, DOMAINS, STATUS } from "@/components/MetaData";
 import { useGetAllCrops } from "@/hooks/api/crop/useGetAllCrops";
 import {
@@ -307,13 +308,12 @@ export const DownloadFilteredReportButton = ({ onOpenDialog }: { onOpenDialog?: 
                 <Label className="text-sm font-medium">Question Type</Label>
                 <div className="grid grid-cols-2 gap-3 rounded-md border p-3">
                   <label className="flex items-center gap-3">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={filters.hiddenQuestions}
-                      onChange={(event) =>
-                        handleCheckboxChange("hiddenQuestions", event.target.checked)
+                      onCheckedChange={(checked) =>
+                        handleCheckboxChange("hiddenQuestions", checked === true)
                       }
-                      className="h-3.5 w-3.5 rounded border-gray-300 text-primary focus:ring-primary"
+                      className="h-3.5 w-3.5 border-gray-300"
                     />
                     <span className="text-sm">Show passed questions</span>
                   </label>

--- a/frontend/src/features/question-table-page/DownloadFilteredReportButton.tsx
+++ b/frontend/src/features/question-table-page/DownloadFilteredReportButton.tsx
@@ -313,7 +313,7 @@ export const DownloadFilteredReportButton = ({ onOpenDialog }: { onOpenDialog?: 
                       onCheckedChange={(checked) =>
                         handleCheckboxChange("hiddenQuestions", checked === true)
                       }
-                      className="h-3.5 w-3.5 border-gray-300"
+                      className="h-3.5 w-3.5 border-primary"
                     />
                     <span className="text-sm">Show passed questions</span>
                   </label>


### PR DESCRIPTION
**Description**

This PR introduces a fix to rename “Hidden Questions” to “Passed Questions” in the Active filter tab, and replaces the existing checkbox input with a reusable component to improve consistency and maintainability.