### PR TITLE
feat: add User Details view to ChatBot Analytics dashboard 

### DIFF
--- a/backend/src/modules/chatbot/classes/validators/ChatbotQueryValidators.ts
+++ b/backend/src/modules/chatbot/classes/validators/ChatbotQueryValidators.ts
@@ -1,0 +1,60 @@
+import { IsOptional, IsIn, IsInt, IsString, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { JSONSchema } from 'class-validator-jsonschema';
+
+export class DashboardQueryDto {
+  @JSONSchema({ example: 30, description: 'Number of days to look back' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  days: number = 30;
+
+  @JSONSchema({ example: 'vicharanashala', description: 'Data source to query' })
+  @IsOptional()
+  @IsIn(['vicharanashala', 'annam'])
+  source: 'vicharanashala' | 'annam' = 'vicharanashala';
+}
+
+export class SourceQueryDto {
+  @JSONSchema({ example: 'vicharanashala', description: 'Data source to query' })
+  @IsOptional()
+  @IsIn(['vicharanashala', 'annam'])
+  source: 'vicharanashala' | 'annam' = 'vicharanashala';
+}
+
+export class UserDetailsQueryDto {
+  @JSONSchema({ example: '2025-01-01', description: 'Filter start date (ISO string)' })
+  @IsOptional()
+  @IsString()
+  startDate?: string;
+
+  @JSONSchema({ example: '2025-12-31', description: 'Filter end date (ISO string)' })
+  @IsOptional()
+  @IsString()
+  endDate?: string;
+
+  @JSONSchema({ example: 1, description: 'Page number' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @JSONSchema({ example: 10, description: 'Results per page' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit: number = 10;
+
+  @JSONSchema({ example: 'john', description: 'Search by name or email' })
+  @IsOptional()
+  @IsString()
+  search: string = '';
+
+  @JSONSchema({ example: 'vicharanashala', description: 'Data source to query' })
+  @IsOptional()
+  @IsIn(['vicharanashala', 'annam'])
+  source: 'vicharanashala' | 'annam' = 'vicharanashala';
+}

--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -96,7 +96,7 @@ export class ChatbotController {
     @QueryParam('endDate') endDate?: string,
     @QueryParam('page') page = 1,
     @QueryParam('limit') limit = 10,
-    @QueryParam('search') search = '',
+    @QueryParam('search') search: string = '',
   ) {
     return this.chatbotService.getUserDetails(startDate, endDate, Number(page), Number(limit), search);
   }

--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -90,11 +90,14 @@ export class ChatbotController {
   @Get('/user-details')
   @HttpCode(200)
   @Authorized()
-  @OpenAPI({ summary: 'Get all users with question counts, optionally filtered by date range' })
+  @OpenAPI({ summary: 'Get users with question counts, paginated, optionally filtered by date range and search' })
   async getUserDetails(
     @QueryParam('startDate') startDate?: string,
     @QueryParam('endDate') endDate?: string,
+    @QueryParam('page') page = 1,
+    @QueryParam('limit') limit = 10,
+    @QueryParam('search') search = '',
   ) {
-    return this.chatbotService.getUserDetails(startDate, endDate);
+    return this.chatbotService.getUserDetails(startDate, endDate, Number(page), Number(limit), search);
   }
 }

--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -86,4 +86,15 @@ export class ChatbotController {
   async getDailyUserTrend(@QueryParam('days') days = 30) {
     return this.chatbotService.getDailyUserTrend(days);
   }
+
+  @Get('/user-details')
+  @HttpCode(200)
+  @Authorized()
+  @OpenAPI({ summary: 'Get all users with question counts, optionally filtered by date range' })
+  async getUserDetails(
+    @QueryParam('startDate') startDate?: string,
+    @QueryParam('endDate') endDate?: string,
+  ) {
+    return this.chatbotService.getUserDetails(startDate, endDate);
+  }
 }

--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -3,13 +3,18 @@ import {
   JsonController,
   Get,
   HttpCode,
-  QueryParam,
+  QueryParams,
   Authorized,
 } from 'routing-controllers';
 import { OpenAPI } from 'routing-controllers-openapi';
 import { inject, injectable } from 'inversify';
 import { CHATBOT_TYPES } from '../types.js';
 import type { IChatbotService } from '../interfaces/IChatbotService.js';
+import {
+  DashboardQueryDto,
+  SourceQueryDto,
+  UserDetailsQueryDto,
+} from '../classes/validators/ChatbotQueryValidators.js';
 
 @OpenAPI({
   tags: ['analytics'],
@@ -27,87 +32,78 @@ export class ChatbotController {
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get full chatbot analytics dashboard data' })
-  async getDashboard(
-    @QueryParam('days') days = 30,
-    @QueryParam('source') source: string = 'vicharanashala',
-  ) {
-    return this.chatbotService.getDashboard(days, source);
+  async getDashboard(@QueryParams() query: DashboardQueryDto) {
+    return this.chatbotService.getDashboard(query.days, query.source);
   }
 
   @Get('/kpi')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get KPI summary for today' })
-  async getKpiSummary(@QueryParam('source') source: string = 'vicharanashala') {
-    return this.chatbotService.getKpiSummary(source);
+  async getKpiSummary(@QueryParams() query: SourceQueryDto) {
+    return this.chatbotService.getKpiSummary(query.source);
   }
 
   @Get('/dau')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get daily active users trend' })
-  async getDailyActiveUsers(
-    @QueryParam('days') days = 30,
-    @QueryParam('source') source: string = 'vicharanashala',
-  ) {
-    return this.chatbotService.getDailyActiveUsers(days, source);
+  async getDailyActiveUsers(@QueryParams() query: DashboardQueryDto) {
+    return this.chatbotService.getDailyActiveUsers(query.days, query.source);
   }
 
   @Get('/channel-split')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get channel split percentages' })
-  async getChannelSplit(@QueryParam('source') source: string = 'vicharanashala') {
-    return this.chatbotService.getChannelSplit(source);
+  async getChannelSplit(@QueryParams() query: SourceQueryDto) {
+    return this.chatbotService.getChannelSplit(query.source);
   }
 
   @Get('/voice-accuracy')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get voice accuracy by language' })
-  async getVoiceAccuracy(@QueryParam('source') source: string = 'vicharanashala') {
-    return this.chatbotService.getVoiceAccuracyByLanguage(source);
+  async getVoiceAccuracy(@QueryParams() query: SourceQueryDto) {
+    return this.chatbotService.getVoiceAccuracyByLanguage(query.source);
   }
 
   @Get('/geo')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get geographic distribution of sessions' })
-  async getGeoDistribution(@QueryParam('source') source: string = 'vicharanashala') {
-    return this.chatbotService.getGeoDistribution(source);
+  async getGeoDistribution(@QueryParams() query: SourceQueryDto) {
+    return this.chatbotService.getGeoDistribution(query.source);
   }
 
   @Get('/query-categories')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get query category breakdown' })
-  async getQueryCategories(@QueryParam('source') source: string = 'vicharanashala') {
-    return this.chatbotService.getQueryCategories(source);
+  async getQueryCategories(@QueryParams() query: SourceQueryDto) {
+    return this.chatbotService.getQueryCategories(query.source);
   }
 
   @Get('/user-trend')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get daily user activity trend for bar graph (last N days, daily granularity)' })
-  async getDailyUserTrend(
-    @QueryParam('days') days = 30,
-    @QueryParam('source') source: string = 'vicharanashala',
-  ) {
-    return this.chatbotService.getDailyUserTrend(days, source);
+  async getDailyUserTrend(@QueryParams() query: DashboardQueryDto) {
+    return this.chatbotService.getDailyUserTrend(query.days, query.source);
   }
 
   @Get('/user-details')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get users with question counts, paginated, optionally filtered by date range and search' })
-  async getUserDetails(
-    @QueryParam('startDate') startDate?: string,
-    @QueryParam('endDate') endDate?: string,
-    @QueryParam('page') page = 1,
-    @QueryParam('limit') limit = 10,
-    @QueryParam('search') search: string = '',
-    @QueryParam('source') source: string = 'vicharanashala',
-  ) {
-    return this.chatbotService.getUserDetails(startDate, endDate, Number(page), Number(limit), search, source);
+  async getUserDetails(@QueryParams() query: UserDetailsQueryDto) {
+    return this.chatbotService.getUserDetails(
+      query.startDate,
+      query.endDate,
+      query.page,
+      query.limit,
+      query.search,
+      query.source,
+    );
   }
 }

--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -27,64 +27,73 @@ export class ChatbotController {
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get full chatbot analytics dashboard data' })
-  async getDashboard(@QueryParam('days') days = 30) {
-    return this.chatbotService.getDashboard(days);
+  async getDashboard(
+    @QueryParam('days') days = 30,
+    @QueryParam('source') source: string = 'vicharanashala',
+  ) {
+    return this.chatbotService.getDashboard(days, source);
   }
 
   @Get('/kpi')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get KPI summary for today' })
-  async getKpiSummary() {
-    return this.chatbotService.getKpiSummary();
+  async getKpiSummary(@QueryParam('source') source: string = 'vicharanashala') {
+    return this.chatbotService.getKpiSummary(source);
   }
 
   @Get('/dau')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get daily active users trend' })
-  async getDailyActiveUsers(@QueryParam('days') days = 30) {
-    return this.chatbotService.getDailyActiveUsers(days);
+  async getDailyActiveUsers(
+    @QueryParam('days') days = 30,
+    @QueryParam('source') source: string = 'vicharanashala',
+  ) {
+    return this.chatbotService.getDailyActiveUsers(days, source);
   }
 
   @Get('/channel-split')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get channel split percentages' })
-  async getChannelSplit() {
-    return this.chatbotService.getChannelSplit();
+  async getChannelSplit(@QueryParam('source') source: string = 'vicharanashala') {
+    return this.chatbotService.getChannelSplit(source);
   }
 
   @Get('/voice-accuracy')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get voice accuracy by language' })
-  async getVoiceAccuracy() {
-    return this.chatbotService.getVoiceAccuracyByLanguage();
+  async getVoiceAccuracy(@QueryParam('source') source: string = 'vicharanashala') {
+    return this.chatbotService.getVoiceAccuracyByLanguage(source);
   }
 
   @Get('/geo')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get geographic distribution of sessions' })
-  async getGeoDistribution() {
-    return this.chatbotService.getGeoDistribution();
+  async getGeoDistribution(@QueryParam('source') source: string = 'vicharanashala') {
+    return this.chatbotService.getGeoDistribution(source);
   }
 
   @Get('/query-categories')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get query category breakdown' })
-  async getQueryCategories() {
-    return this.chatbotService.getQueryCategories();
+  async getQueryCategories(@QueryParam('source') source: string = 'vicharanashala') {
+    return this.chatbotService.getQueryCategories(source);
   }
 
   @Get('/user-trend')
   @HttpCode(200)
   @Authorized()
   @OpenAPI({ summary: 'Get daily user activity trend for bar graph (last N days, daily granularity)' })
-  async getDailyUserTrend(@QueryParam('days') days = 30) {
-    return this.chatbotService.getDailyUserTrend(days);
+  async getDailyUserTrend(
+    @QueryParam('days') days = 30,
+    @QueryParam('source') source: string = 'vicharanashala',
+  ) {
+    return this.chatbotService.getDailyUserTrend(days, source);
   }
 
   @Get('/user-details')
@@ -97,7 +106,8 @@ export class ChatbotController {
     @QueryParam('page') page = 1,
     @QueryParam('limit') limit = 10,
     @QueryParam('search') search: string = '',
+    @QueryParam('source') source: string = 'vicharanashala',
   ) {
-    return this.chatbotService.getUserDetails(startDate, endDate, Number(page), Number(limit), search);
+    return this.chatbotService.getUserDetails(startDate, endDate, Number(page), Number(limit), search, source);
   }
 }

--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -8,6 +8,7 @@ import type {
   WeeklySessionDurationEntry,
   DailyQueryCountEntry,
   WeeklyQueryCountEntry,
+  UserDetailEntry,
 } from '#root/shared/database/interfaces/IChatbotRepository.js';
 
 export interface DashboardResponse {
@@ -35,4 +36,5 @@ export interface IChatbotService {
   getTodayQueryCount(): Promise<number>;
   getWeeklyQueryCounts(): Promise<WeeklyQueryCountEntry[]>;
   getDailyUserTrend(days?: number): Promise<DailyActiveUsersEntry[]>;
+  getUserDetails(startDate?: string, endDate?: string): Promise<UserDetailEntry[]>;
 }

--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -9,6 +9,7 @@ import type {
   DailyQueryCountEntry,
   WeeklyQueryCountEntry,
   UserDetailEntry,
+  PaginatedUserDetails,
 } from '#root/shared/database/interfaces/IChatbotRepository.js';
 
 export interface DashboardResponse {
@@ -36,5 +37,6 @@ export interface IChatbotService {
   getTodayQueryCount(): Promise<number>;
   getWeeklyQueryCounts(): Promise<WeeklyQueryCountEntry[]>;
   getDailyUserTrend(days?: number): Promise<DailyActiveUsersEntry[]>;
-  getUserDetails(startDate?: string, endDate?: string): Promise<UserDetailEntry[]>;
+  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string): Promise<PaginatedUserDetails>;
 }
+

--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -25,18 +25,18 @@ export interface DashboardResponse {
 }
 
 export interface IChatbotService {
-  getDashboard(days: number): Promise<DashboardResponse>;
-  getKpiSummary(): Promise<KpiSummary>;
-  getDailyActiveUsers(days: number): Promise<DailyActiveUsersEntry[]>;
-  getChannelSplit(): Promise<ChannelSplitEntry[]>;
-  getVoiceAccuracyByLanguage(): Promise<VoiceAccuracyEntry[]>;
-  getGeoDistribution(): Promise<GeoStateEntry[]>;
-  getQueryCategories(): Promise<QueryCategoryEntry[]>;
-  getWeeklyAvgSessionDuration(weeks?: number): Promise<WeeklySessionDurationEntry[]>;
-  getDailyQueryCounts(days?: number): Promise<DailyQueryCountEntry[]>;
-  getTodayQueryCount(): Promise<number>;
-  getWeeklyQueryCounts(): Promise<WeeklyQueryCountEntry[]>;
-  getDailyUserTrend(days?: number): Promise<DailyActiveUsersEntry[]>;
-  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string): Promise<PaginatedUserDetails>;
+  getDashboard(days: number, source?: string): Promise<DashboardResponse>;
+  getKpiSummary(source?: string): Promise<KpiSummary>;
+  getDailyActiveUsers(days: number, source?: string): Promise<DailyActiveUsersEntry[]>;
+  getChannelSplit(source?: string): Promise<ChannelSplitEntry[]>;
+  getVoiceAccuracyByLanguage(source?: string): Promise<VoiceAccuracyEntry[]>;
+  getGeoDistribution(source?: string): Promise<GeoStateEntry[]>;
+  getQueryCategories(source?: string): Promise<QueryCategoryEntry[]>;
+  getWeeklyAvgSessionDuration(weeks?: number, source?: string): Promise<WeeklySessionDurationEntry[]>;
+  getDailyQueryCounts(days?: number, source?: string): Promise<DailyQueryCountEntry[]>;
+  getTodayQueryCount(source?: string): Promise<number>;
+  getWeeklyQueryCounts(source?: string): Promise<WeeklyQueryCountEntry[]>;
+  getDailyUserTrend(days?: number, source?: string): Promise<DailyActiveUsersEntry[]>;
+  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string, source?: string): Promise<PaginatedUserDetails>;
 }
 

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -11,20 +11,20 @@ export class ChatbotService implements IChatbotService {
     private readonly chatbotRepository: IChatbotRepository,
   ) {}
 
-  async getDashboard(days = 30): Promise<DashboardResponse> {
+  async getDashboard(days = 30, source = 'vicharanashala'): Promise<DashboardResponse> {
     try {
       const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, weeklySessionDuration, dailyQueries, todayQueryCount, weeklyQueries] =
         await Promise.all([
-          this.chatbotRepository.getKpiSummary(),
-          this.chatbotRepository.getDailyActiveUsers(days),
-          this.chatbotRepository.getChannelSplit(),
-          this.chatbotRepository.getVoiceAccuracyByLanguage(),
-          this.chatbotRepository.getGeoDistribution(),
-          this.chatbotRepository.getQueryCategories(),
-          this.chatbotRepository.getWeeklyAvgSessionDuration(Math.ceil(days / 7)),
-          this.chatbotRepository.getDailyQueryCounts(days),
-          this.chatbotRepository.getTodayQueryCount(),
-          this.chatbotRepository.getWeeklyQueryCounts(),
+          this.chatbotRepository.getKpiSummary(source),
+          this.chatbotRepository.getDailyActiveUsers(days, source),
+          this.chatbotRepository.getChannelSplit(source),
+          this.chatbotRepository.getVoiceAccuracyByLanguage(source),
+          this.chatbotRepository.getGeoDistribution(source),
+          this.chatbotRepository.getQueryCategories(source),
+          this.chatbotRepository.getWeeklyAvgSessionDuration(Math.ceil(days / 7), source),
+          this.chatbotRepository.getDailyQueryCounts(days, source),
+          this.chatbotRepository.getTodayQueryCount(source),
+          this.chatbotRepository.getWeeklyQueryCounts(source),
         ]);
 
       return {
@@ -43,99 +43,99 @@ export class ChatbotService implements IChatbotService {
     }
   }
 
-  async getKpiSummary() {
+  async getKpiSummary(source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getKpiSummary();
+      return await this.chatbotRepository.getKpiSummary(source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch KPI summary: ${error}`);
     }
   }
 
-  async getDailyActiveUsers(days = 30) {
+  async getDailyActiveUsers(days = 30, source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getDailyActiveUsers(days);
+      return await this.chatbotRepository.getDailyActiveUsers(days, source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch daily active users: ${error}`);
     }
   }
 
-  async getChannelSplit() {
+  async getChannelSplit(source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getChannelSplit();
+      return await this.chatbotRepository.getChannelSplit(source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch channel split: ${error}`);
     }
   }
 
-  async getVoiceAccuracyByLanguage() {
+  async getVoiceAccuracyByLanguage(source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getVoiceAccuracyByLanguage();
+      return await this.chatbotRepository.getVoiceAccuracyByLanguage(source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch voice accuracy: ${error}`);
     }
   }
 
-  async getGeoDistribution() {
+  async getGeoDistribution(source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getGeoDistribution();
+      return await this.chatbotRepository.getGeoDistribution(source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch geo distribution: ${error}`);
     }
   }
 
-  async getQueryCategories() {
+  async getQueryCategories(source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getQueryCategories();
+      return await this.chatbotRepository.getQueryCategories(source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch query categories: ${error}`);
     }
   }
 
-  async getWeeklyAvgSessionDuration(weeks = 52) {
+  async getWeeklyAvgSessionDuration(weeks = 52, source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getWeeklyAvgSessionDuration(weeks);
+      return await this.chatbotRepository.getWeeklyAvgSessionDuration(weeks, source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch weekly session duration: ${error}`);
     }
   }
 
-  async getDailyQueryCounts(days = 30) {
+  async getDailyQueryCounts(days = 30, source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getDailyQueryCounts(days);
+      return await this.chatbotRepository.getDailyQueryCounts(days, source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch daily query counts: ${error}`);
     }
   }
 
-  async getTodayQueryCount() {
+  async getTodayQueryCount(source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getTodayQueryCount();
+      return await this.chatbotRepository.getTodayQueryCount(source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch today query count: ${error}`);
     }
   }
 
-  async getDailyUserTrend(days = 30) {
+  async getDailyUserTrend(days = 30, source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getDailyUserTrend(days);
+      return await this.chatbotRepository.getDailyUserTrend(days, source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch daily user trend: ${error}`);
     }
   }
 
-  async getWeeklyQueryCounts() {
+  async getWeeklyQueryCounts(source = 'vicharanashala') {
     try {
-      return await this.chatbotRepository.getWeeklyQueryCounts();
+      return await this.chatbotRepository.getWeeklyQueryCounts(source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch weekly query counts: ${error}`);
     }
   }
 
-  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '') {
+  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '', source = 'vicharanashala') {
     try {
       const start = startDate ? new Date(startDate) : undefined;
       const end = endDate ? new Date(endDate) : undefined;
-      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search);
+      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search, source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch user details: ${error}`);
     }

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -131,11 +131,11 @@ export class ChatbotService implements IChatbotService {
     }
   }
 
-  async getUserDetails(startDate?: string, endDate?: string) {
+  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '') {
     try {
       const start = startDate ? new Date(startDate) : undefined;
       const end = endDate ? new Date(endDate) : undefined;
-      return await this.chatbotRepository.getUserDetails(start, end);
+      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch user details: ${error}`);
     }

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -130,4 +130,14 @@ export class ChatbotService implements IChatbotService {
       throw new InternalServerError(`Failed to fetch weekly query counts: ${error}`);
     }
   }
+
+  async getUserDetails(startDate?: string, endDate?: string) {
+    try {
+      const start = startDate ? new Date(startDate) : undefined;
+      const end = endDate ? new Date(endDate) : undefined;
+      return await this.chatbotRepository.getUserDetails(start, end);
+    } catch (error) {
+      throw new InternalServerError(`Failed to fetch user details: ${error}`);
+    }
+  }
 }

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -59,6 +59,14 @@ export interface UserDetailEntry {
   totalQuestions: number;
 }
 
+export interface PaginatedUserDetails {
+  users: UserDetailEntry[];
+  totalUsers: number;
+  totalPages: number;
+  activeUsers: number;
+  totalQuestions: number;
+}
+
 // ─── Single consolidated interface ───────────────────────────────────────────
 
 export interface IChatbotRepository {
@@ -113,10 +121,13 @@ export interface IChatbotRepository {
   findMatchingMessages(data: {question: string; details: any; createdAt: Date});
   findFromSecondDb(data: {question: string; details: any; createdAt: Date});
 
-  /** Get all users with their question counts, optionally filtered by date range. */
+  /** Get all users with their question counts, optionally filtered by date range, with server-side pagination. */
   getUserDetails(
     startDate?: Date,
     endDate?: Date,
+    page?: number,
+    limit?: number,
+    search?: string,
     session?: ClientSession,
-  ): Promise<UserDetailEntry[]>;
+  ): Promise<PaginatedUserDetails>;
 }

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -71,51 +71,57 @@ export interface PaginatedUserDetails {
 
 export interface IChatbotRepository {
   /** Aggregated KPI summary for the current day. */
-  getKpiSummary(session?: ClientSession): Promise<KpiSummary>;
+  getKpiSummary(source?: string, session?: ClientSession): Promise<KpiSummary>;
 
   /** Daily unique active users over the last `days` days. */
   getDailyActiveUsers(
     days: number,
+    source?: string,
     session?: ClientSession,
   ): Promise<DailyActiveUsersEntry[]>;
 
   /** Percentage breakdown of sessions by channel (voice / text / kcc_agent / ivrs). */
-  getChannelSplit(session?: ClientSession): Promise<ChannelSplitEntry[]>;
+  getChannelSplit(source?: string, session?: ClientSession): Promise<ChannelSplitEntry[]>;
 
   /** Average voice recognition accuracy grouped by language. */
   getVoiceAccuracyByLanguage(
+    source?: string,
     session?: ClientSession,
   ): Promise<VoiceAccuracyEntry[]>;
 
   /** Session counts grouped by state abbreviation, sorted descending. */
-  getGeoDistribution(session?: ClientSession): Promise<GeoStateEntry[]>;
+  getGeoDistribution(source?: string, session?: ClientSession): Promise<GeoStateEntry[]>;
 
   /** Percentage breakdown of sessions by query category, sorted descending. */
-  getQueryCategories(session?: ClientSession): Promise<QueryCategoryEntry[]>;
+  getQueryCategories(source?: string, session?: ClientSession): Promise<QueryCategoryEntry[]>;
 
   /** Weekly avg session duration (updatedAt - createdAt) over the last `weeks` ISO weeks, sorted ascending. */
   getWeeklyAvgSessionDuration(
     weeks?: number,
+    source?: string,
     session?: ClientSession,
   ): Promise<WeeklySessionDurationEntry[]>;
 
   /** Daily user-message counts from the messages collection over the last `days` days, sorted ascending. */
   getDailyQueryCounts(
     days?: number,
+    source?: string,
     session?: ClientSession,
   ): Promise<DailyQueryCountEntry[]>;
 
   /** Count of user messages created today from the messages collection. */
-  getTodayQueryCount(session?: ClientSession): Promise<number>;
+  getTodayQueryCount(source?: string, session?: ClientSession): Promise<number>;
 
   /** Weekly query totals (all-time) from the messages collection, sorted ascending by ISO week. */
   getWeeklyQueryCounts(
+    source?: string,
     session?: ClientSession,
   ): Promise<WeeklyQueryCountEntry[]>;
 
   /** Daily user activity trend (users active per day) over the last `days` days, sorted ascending. */
   getDailyUserTrend(
     days?: number,
+    source?: string,
     session?: ClientSession,
   ): Promise<DailyActiveUsersEntry[]>;
   findMatchingMessages(data: {question: string; details: any; createdAt: Date});
@@ -128,6 +134,7 @@ export interface IChatbotRepository {
     page?: number,
     limit?: number,
     search?: string,
+    source?: string,
     session?: ClientSession,
   ): Promise<PaginatedUserDetails>;
 }

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -52,6 +52,13 @@ export interface WeeklyQueryCountEntry {
   count: number;
 }
 
+export interface UserDetailEntry {
+  userId: string;
+  name: string;
+  email: string;
+  totalQuestions: number;
+}
+
 // ─── Single consolidated interface ───────────────────────────────────────────
 
 export interface IChatbotRepository {
@@ -105,4 +112,11 @@ export interface IChatbotRepository {
   ): Promise<DailyActiveUsersEntry[]>;
   findMatchingMessages(data: {question: string; details: any; createdAt: Date});
   findFromSecondDb(data: {question: string; details: any; createdAt: Date});
+
+  /** Get all users with their question counts, optionally filtered by date range. */
+  getUserDetails(
+    startDate?: Date,
+    endDate?: Date,
+    session?: ClientSession,
+  ): Promise<UserDetailEntry[]>;
 }

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -45,10 +45,10 @@ export class ChatbotRepository implements IChatbotRepository {
   private messagesCollection!: Collection<any>;
 
   constructor(
-    @inject(GLOBAL_TYPES.analyticsDatabase)
+    @inject(GLOBAL_TYPES.analyticsDatabase) //vicharansahsa
     private analyticsDb: AnalyticsMongoDatabase,
 
-    @inject(GLOBAL_TYPES.annamanalyticsDatabase)
+    @inject(GLOBAL_TYPES.annamanalyticsDatabase) //annamalytics
     private annamDb: AnnamDatabase,
   ) {}
 
@@ -57,10 +57,11 @@ export class ChatbotRepository implements IChatbotRepository {
     private analyticsDb: AnnamDatabase,
   ) {}*/
 
-  private async init() {
-    this.users = await this.analyticsDb.getCollection<IUser>('users');
-    this.conversations = await this.analyticsDb.getCollection<IConversation>('conversations');
-    this.messagesCollection = await this.analyticsDb.getCollection<any>('messages');
+  private async init(source = 'vicharanashala') {
+    const db = source === 'annam' ? this.annamDb : this.analyticsDb;
+    this.users = await db.getCollection<IUser>('users');
+    this.conversations = await db.getCollection<IConversation>('conversations');
+    this.messagesCollection = await db.getCollection<any>('messages');
   }
   private annamMessagesCollection!: Collection<any>;
 
@@ -68,9 +69,9 @@ private async initSecondDb() {
   this.annamMessagesCollection = await this.annamDb.getCollection<any>('messages');
 }
 
-  async getKpiSummary(session?: ClientSession): Promise<KpiSummary> {
+  async getKpiSummary(source = 'vicharanashala', session?: ClientSession): Promise<KpiSummary> {
     try {
-      await this.init();
+      await this.init(source);
 
       // Use MongoDB $dateToString with IST timezone (+05:30) to correctly bucket months
       const now = new Date();
@@ -100,7 +101,7 @@ private async initSecondDb() {
           .toArray(),
 
         // Today's query count from messages
-        this.getTodayQueryCount(session),
+        this.getTodayQueryCount(source, session),
       ]);
 
       const monthMap = Object.fromEntries((monthlyActivity as any[]).map(m => [m._id, m.count]));
@@ -127,9 +128,9 @@ private async initSecondDb() {
     }
   }
 
-  async getDailyActiveUsers(days = 13, session?: ClientSession): Promise<DailyActiveUsersEntry[]> {
+  async getDailyActiveUsers(days = 13, source = 'vicharanashala', session?: ClientSession): Promise<DailyActiveUsersEntry[]> {
     try {
-      await this.init();
+      await this.init(source);
 
       // Count distinct users who sent messages per month (true monthly active users)
       const since = new Date();
@@ -167,25 +168,25 @@ private async initSecondDb() {
     }
   }
 
-  async getChannelSplit(_session?: ClientSession): Promise<ChannelSplitEntry[]> {
+  async getChannelSplit(_source = 'vicharanashala', _session?: ClientSession): Promise<ChannelSplitEntry[]> {
     return [];
   }
 
-  async getVoiceAccuracyByLanguage(_session?: ClientSession): Promise<VoiceAccuracyEntry[]> {
+  async getVoiceAccuracyByLanguage(_source = 'vicharanashala', _session?: ClientSession): Promise<VoiceAccuracyEntry[]> {
     return [];
   }
 
-  async getGeoDistribution(_session?: ClientSession): Promise<GeoStateEntry[]> {
+  async getGeoDistribution(_source = 'vicharanashala', _session?: ClientSession): Promise<GeoStateEntry[]> {
     return [];
   }
 
-  async getQueryCategories(_session?: ClientSession): Promise<QueryCategoryEntry[]> {
+  async getQueryCategories(_source = 'vicharanashala', _session?: ClientSession): Promise<QueryCategoryEntry[]> {
     return [];
   }
 
-  async getWeeklyAvgSessionDuration(weeks = 52, session?: ClientSession): Promise<WeeklySessionDurationEntry[]> {
+  async getWeeklyAvgSessionDuration(weeks = 52, source = 'vicharanashala', session?: ClientSession): Promise<WeeklySessionDurationEntry[]> {
     try {
-      await this.init();
+      await this.init(source);
 
       const since = new Date();
       since.setDate(since.getDate() - weeks * 7);
@@ -217,9 +218,9 @@ private async initSecondDb() {
     }
   }
 
-  async getDailyQueryCounts(days = 30, session?: ClientSession): Promise<DailyQueryCountEntry[]> {
+  async getDailyQueryCounts(days = 30, source = 'vicharanashala', session?: ClientSession): Promise<DailyQueryCountEntry[]> {
     try {
-      await this.init();
+      await this.init(source);
 
       const since = new Date();
       since.setDate(since.getDate() - days);
@@ -244,9 +245,9 @@ private async initSecondDb() {
     }
   }
 
-  async getDailyUserTrend(days = 30, session?: ClientSession): Promise<DailyActiveUsersEntry[]> {
+  async getDailyUserTrend(days = 30, source = 'vicharanashala', session?: ClientSession): Promise<DailyActiveUsersEntry[]> {
     try {
-      await this.init();
+      await this.init(source);
 
       const since = new Date();
       since.setDate(since.getDate() - days);
@@ -283,9 +284,9 @@ private async initSecondDb() {
     }
   }
 
-  async getWeeklyQueryCounts(session?: ClientSession): Promise<WeeklyQueryCountEntry[]> {
+  async getWeeklyQueryCounts(source = 'vicharanashala', session?: ClientSession): Promise<WeeklyQueryCountEntry[]> {
     try {
-      await this.init();
+      await this.init(source);
 
       const result = await this.messagesCollection
         .aggregate(
@@ -312,9 +313,9 @@ private async initSecondDb() {
     }
   }
 
-  async getTodayQueryCount(session?: ClientSession): Promise<number> {
+  async getTodayQueryCount(source = 'vicharanashala', session?: ClientSession): Promise<number> {
     try {
-      await this.init();
+      await this.init(source);
 
       const today = new Date();
       today.setHours(0, 0, 0, 0);
@@ -730,10 +731,11 @@ private async initSecondDb() {
     page = 1,
     limit = 10,
     search = '',
+    source = 'vicharanashala',
     session?: ClientSession,
   ): Promise<PaginatedUserDetails> {
     try {
-      await this.init();
+      await this.init(source);
 
       // Build date match for messages (optional)
       const dateMatch: Record<string, any> = { isCreatedByUser: true };

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -15,6 +15,7 @@ import type {
   WeeklySessionDurationEntry,
   DailyQueryCountEntry,
   WeeklyQueryCountEntry,
+  UserDetailEntry,
 } from '#root/shared/database/interfaces/IChatbotRepository.js';
 
 interface IUser {
@@ -720,5 +721,63 @@ private async initSecondDb() {
       }
     });
     return result1
+  }
+
+  async getUserDetails(
+    startDate?: Date,
+    endDate?: Date,
+    session?: ClientSession,
+  ): Promise<UserDetailEntry[]> {
+    try {
+      await this.init();
+
+      // Build date match for messages (optional)
+      const dateMatch: Record<string, any> = { isCreatedByUser: true };
+      if (startDate || endDate) {
+        dateMatch.createdAt = {};
+        if (startDate) dateMatch.createdAt.$gte = startDate;
+        if (endDate) dateMatch.createdAt.$lte = endDate;
+      }
+
+      // Get question counts per user from messages
+      const messageCounts = await this.messagesCollection
+        .aggregate(
+          [
+            { $match: dateMatch },
+            {
+              $group: {
+                _id: '$user',
+                totalQuestions: { $sum: 1 },
+              },
+            },
+          ],
+          { session },
+        )
+        .toArray();
+
+      // Build a map: userId string → count
+      const countMap = new Map<string, number>();
+      for (const entry of messageCounts) {
+        countMap.set(String(entry._id), entry.totalQuestions);
+      }
+
+      // Get all users
+      const allUsers = await this.users.find({}, { session }).toArray();
+
+      // Merge
+      const result: UserDetailEntry[] = allUsers.map((u) => ({
+        userId: String(u._id),
+        name: u.name || u.username || 'Unknown',
+        email: u.email || '',
+        totalQuestions: countMap.get(String(u._id)) ?? 0,
+      }));
+
+      // Sort by totalQuestions desc
+      result.sort((a, b) => b.totalQuestions - a.totalQuestions);
+
+      return result;
+    } catch (error) {
+      throw new InternalServerError(`Failed to get user details: ${error}`);
+    }
   }
 }

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -129,12 +129,28 @@ private async initSecondDb() {
     try {
       await this.init();
 
-      // Group active users by month using IST timezone (matches KPI logic)
-      const result = await this.users
+      // Count distinct users who sent messages per month (true monthly active users)
+      const since = new Date();
+      since.setMonth(since.getMonth() - days); // `days` param used as number of months to look back
+      since.setDate(1);
+      since.setHours(0, 0, 0, 0);
+
+      const result = await this.messagesCollection
         .aggregate([
+          { $match: { createdAt: { $gte: since }, isCreatedByUser: true } },
+          // Deduplicate: one entry per (month, user) pair
           {
             $group: {
-              _id: { $dateToString: { format: '%Y-%m', date: '$updatedAt', timezone: '+05:30' } },
+              _id: {
+                month: { $dateToString: { format: '%Y-%m', date: '$createdAt', timezone: '+05:30' } },
+                user: '$user',
+              },
+            },
+          },
+          // Count distinct users per month
+          {
+            $group: {
+              _id: '$_id.month',
               count: { $sum: 1 },
             },
           },

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -16,6 +16,7 @@ import type {
   DailyQueryCountEntry,
   WeeklyQueryCountEntry,
   UserDetailEntry,
+  PaginatedUserDetails,
 } from '#root/shared/database/interfaces/IChatbotRepository.js';
 
 interface IUser {
@@ -726,8 +727,11 @@ private async initSecondDb() {
   async getUserDetails(
     startDate?: Date,
     endDate?: Date,
+    page = 1,
+    limit = 10,
+    search = '',
     session?: ClientSession,
-  ): Promise<UserDetailEntry[]> {
+  ): Promise<PaginatedUserDetails> {
     try {
       await this.init();
 
@@ -761,11 +765,22 @@ private async initSecondDb() {
         countMap.set(String(entry._id), entry.totalQuestions);
       }
 
-      // Get all users
-      const allUsers = await this.users.find({}, { session }).toArray();
+      // Get users — optionally filtered by search
+      const userFilter: Record<string, any> = {};
+      if (search && search.trim()) {
+        const escaped = search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const regex = { $regex: escaped, $options: 'i' };
+        userFilter.$or = [
+          { name: regex },
+          { username: regex },
+          { email: regex },
+        ];
+      }
+
+      const allUsers = await this.users.find(userFilter, { session }).toArray();
 
       // Merge
-      const result: UserDetailEntry[] = allUsers.map((u) => ({
+      const merged: UserDetailEntry[] = allUsers.map((u) => ({
         userId: String(u._id),
         name: u.name || u.username || 'Unknown',
         email: u.email || '',
@@ -773,9 +788,25 @@ private async initSecondDb() {
       }));
 
       // Sort by totalQuestions desc
-      result.sort((a, b) => b.totalQuestions - a.totalQuestions);
+      merged.sort((a, b) => b.totalQuestions - a.totalQuestions);
 
-      return result;
+      // Compute summary stats over the full filtered set
+      const totalUsers = merged.length;
+      const activeUsers = merged.filter((u) => u.totalQuestions > 0).length;
+      const totalQuestions = merged.reduce((sum, u) => sum + u.totalQuestions, 0);
+      const totalPages = Math.max(1, Math.ceil(totalUsers / limit));
+
+      // Paginate
+      const startIdx = (page - 1) * limit;
+      const users = merged.slice(startIdx, startIdx + limit);
+
+      return {
+        users,
+        totalUsers,
+        totalPages,
+        activeUsers,
+        totalQuestions,
+      };
     } catch (error) {
       throw new InternalServerError(`Failed to get user details: ${error}`);
     }

--- a/frontend/src/components/play-ground.tsx
+++ b/frontend/src/components/play-ground.tsx
@@ -10,11 +10,12 @@ import { QAInterface } from "../features/qa-interface-page/QA-interface";
 import { FullSubmissionHistory } from "./submission-history";
 import { VoiceRecorderCard } from "./voice-recorder-card";
 import { QuestionsPage } from "./questions-page";
-import { BellIcon } from "lucide-react";
+import { BellIcon, ChevronDownIcon } from "lucide-react";
 import { useGetCurrentUser } from "@/hooks/api/user/useGetCurrentUser";
 import { RequestsPage } from "./request-page";
 import { initializeNotifications } from "@/services/pushService";
 import { useEffect, useState } from "react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/atoms/dropdown-menu";
 import { useSelectedQuestion } from "@/hooks/api/question/useSelectedQuestion";
 import { MobileSidebar } from "./mobile-sidebar";
 import { HoverCard } from "./atoms/hover-card";
@@ -45,6 +46,7 @@ export const PlaygroundPage = () => {
   // Initialize from localStorage or default
 
   const [activeTab, setActiveTab] = useState<string>("all_questions");
+  const [chatbotSource, setChatbotSource] = useState<'vicharanashala' | 'annam'>('vicharanashala');
   const getStorageKey = (user?: { email?: string }) => {
     if (!user?.email) return null;
     return `playground_active_tab_${user.email}`;
@@ -384,17 +386,30 @@ export const PlaygroundPage = () => {
                   </HoverCard>
                 </TabsTrigger>
 
-                {/*user && user.role !== "expert" && (
-                  <TabsTrigger
-                    value="chatbotanalytics"
-                    className="px-2 md:px-3 py-1.5 rounded-lg font-medium text-sm md:text-base transition-all duration-150 flex-shrink-0"
-                  >
-                    <HoverCard openDelay={150}>
-                      <span>ChatBot Analytics</span>
-                     
-                    </HoverCard>
-                  </TabsTrigger>
-                )*/}
+                {user && user.role !== "expert" && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        className={`px-2 md:px-3 py-1.5 rounded-lg font-medium text-sm md:text-base transition-all duration-150 flex-shrink-0 flex items-center gap-1 ${
+                          activeTab === 'chatbotanalytics'
+                            ? 'bg-accent text-accent-foreground'
+                            : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+                        }`}
+                      >
+                        ChatBot Analytics
+                        <ChevronDownIcon className="w-3.5 h-3.5 opacity-60" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start">
+                      <DropdownMenuItem onClick={() => { setChatbotSource('vicharanashala'); handleTabChange('chatbotanalytics'); }}>
+                        Vicharanashala
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => { setChatbotSource('annam'); handleTabChange('chatbotanalytics'); }}>
+                        Annam
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
 
                 {user && (
                   <TabsTrigger
@@ -475,7 +490,7 @@ export const PlaygroundPage = () => {
                 value="chatbotanalytics"
                 className="-mt-8 border-0 p-0"
               >
-                <AnnamDashboard />
+                <AnnamDashboard source={chatbotSource} />
               </TabsContent>
 
               {user && user.role !== "expert" && (

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -18,6 +18,7 @@ import { GeoCard } from "./GeoCard";
 import { HealthScoreCard } from "./HealthScoreCard";
 import { SegmentDetailBanner } from "./components/SegmentDetailBanner";
 import { StatusBar } from "./components/StatusBar";
+import { UserDetailsView } from "./UserDetailsView";
 
 const DEFAULT_FILTERS: DashboardFilterValues = {
   village: "all",
@@ -90,12 +91,15 @@ export function AnnamDashboard_dev({ className }: { className?: string }) {
           activeView={activeView}
           onViewChange={(view) => {
             setActiveView(view);
-            scrollTo(view);
+            if (view !== "user-details") scrollTo(view);
           }}
           healthScore={70}
           healthLabel="Moderate · needs improvement"
         />
 
+        {activeView === "user-details" ? (
+          <UserDetailsView />
+        ) : (
         <div style={{ flex: 1, overflowY: "auto", padding: "0px 20px 20px 20px" }}>
                 {/* Page header */}                                
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>      
@@ -153,6 +157,7 @@ export function AnnamDashboard_dev({ className }: { className?: string }) {
             </div>
           </div>
         </div>
+        )}
       </div>
 
         <StatusBar

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useMemo } from "react";
 import { useDashboardData } from "./hooks/useDashboardData";
 import { useDailyUserTrend } from "./hooks/useDailyUserTrend";
 import type { Segment } from "./types";
@@ -48,6 +48,21 @@ export function AnnamDashboard_dev({ className }: { className?: string }) {
   }, [activeSegment]);
 
   const clearSegment = () => setActiveSegment(null);
+
+  // Patch the DAU card to show "today / total" instead of just total
+  const patchedKpiRow1 = useMemo(() => {
+    if (!data?.kpiRow1) return data.kpiRow1;
+    const todayCount = dauTrend && dauTrend.length > 0 ? dauTrend[dauTrend.length - 1] : null;
+    return data.kpiRow1.map(card => {
+      if (card.id === 'dau' && todayCount !== null) {
+        return {
+          ...card,
+          value: `${todayCount.toLocaleString()} / ${Number(card.value).toLocaleString()}`,
+        };
+      }
+      return card;
+    });
+  }, [data.kpiRow1, dauTrend]);
 
   return (
     <div className={className} style={{ fontFamily: "'DM Sans', 'Inter', system-ui, sans-serif", background: "var(--background)", minHeight: "100vh", display: "flex", flexDirection: "column" }}>
@@ -100,7 +115,7 @@ export function AnnamDashboard_dev({ className }: { className?: string }) {
 
           <div ref={(el) => { sectionRefs.current["overview"] = el; }} className="relative">
             {isLoading && <Spinner text="Fetching metrics..." fullScreen={false} />}
-            <EightCardsComponent kpiRow1={data.kpiRow1} kpiRow2={data.kpiRow2} />
+            <EightCardsComponent kpiRow1={patchedKpiRow1} kpiRow2={data.kpiRow2} />
           </div>
 
           {/* DAU trend + Channel split */}

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -28,13 +28,13 @@ const DEFAULT_FILTERS: DashboardFilterValues = {
   endTime: undefined,
 };
 
-export function AnnamDashboard_dev({ className }: { className?: string }) {
+export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { className?: string; source?: 'vicharanashala' | 'annam' }) {
   const [activeSegment, setActiveSegment] = useState<Segment | null>(null);
   const [activeView, setActiveView]       = useState<DashboardView>("overview");
   const [filters, setFilters]             = useState<DashboardFilterValues>(DEFAULT_FILTERS);
   const segmentRowRefs = useRef<Record<string, HTMLTableRowElement | null>>({});
-  const { data, isLoading, error } = useDashboardData(filters);
-  const { data: dauTrend, isLoading: dauLoading, error: dauError } = useDailyUserTrend(30);
+  const { data, isLoading, error } = useDashboardData(filters, source);
+  const { data: dauTrend, isLoading: dauLoading, error: dauError } = useDailyUserTrend(30, source);
 
   const sectionRefs = useRef<Partial<Record<DashboardView, HTMLDivElement | null>>>({});
 
@@ -86,7 +86,7 @@ export function AnnamDashboard_dev({ className }: { className?: string }) {
 
       {!error && data && (
         <>
-        <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
+<div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
         <DashboardSidebar
           activeView={activeView}
           onViewChange={(view) => {
@@ -98,7 +98,7 @@ export function AnnamDashboard_dev({ className }: { className?: string }) {
         />
 
         {activeView === "user-details" ? (
-          <UserDetailsView />
+          <UserDetailsView source={source} />
         ) : (
         <div style={{ flex: 1, overflowY: "auto", padding: "0px 20px 20px 20px" }}>
                 {/* Page header */}                                

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -1,8 +1,8 @@
 import { useState, useRef, useCallback, useMemo } from "react";
+import { cn } from "@/lib/utils";
 import { useDashboardData } from "./hooks/useDashboardData";
 import { useDailyUserTrend } from "./hooks/useDailyUserTrend";
 import type { Segment } from "./types";
-// import { TopNav } from "./components/TopNav";
 import { DashboardSidebar } from "./DashboardSidebar";
 import type { DashboardView } from "./DashboardSidebar";
 import { DashboardFilters } from "./DashboardFilters";
@@ -66,106 +66,94 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
   }, [data.kpiRow1, dauTrend]);
 
   return (
-    <div className={className} style={{ fontFamily: "'DM Sans', 'Inter', system-ui, sans-serif", background: "var(--background)", minHeight: "100vh", display: "flex", flexDirection: "column" }}>
+    <div className={cn("flex flex-col min-h-screen bg-background", className)}>
+      {/* Keyframe animations required by child components (seg-pulse, slideIn) */}
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&display=swap');
-        * { box-sizing: border-box;}
         @keyframes slideIn { from { opacity:0; transform:translateY(-8px); } to { opacity:1; transform:translateY(0); } }
         @keyframes custom-pulse { 0%,100%{box-shadow:0 0 0 2.5px #3AAA5A,0 4px 24px rgba(58,170,90,0.18)} 50%{box-shadow:0 0 0 4px #3AAA5A,0 4px 32px rgba(58,170,90,0.28)} }
         .seg-pulse { animation: custom-pulse 1.2s ease 2; }
-        ::-webkit-scrollbar { width: 5px; } ::-webkit-scrollbar-thumb { background: #ddd; border-radius: 4px; }
       `}</style>
 
-      {/* <TopNav season={data?.meta?.season} /> */}
-
       {error && (
-        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, color: 'red' }}>
+        <div className="flex flex-1 items-center justify-center text-destructive">
           Error fetching data: {error.message}
         </div>
       )}
 
       {!error && data && (
         <>
-<div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
-        <DashboardSidebar
-          activeView={activeView}
-          onViewChange={(view) => {
-            setActiveView(view);
-            if (view !== "user-details") scrollTo(view);
-          }}
-          healthScore={70}
-          healthLabel="Moderate · needs improvement"
-        />
+          <div className="flex flex-1 overflow-hidden">
+            <DashboardSidebar
+              activeView={activeView}
+              onViewChange={(view) => {
+                setActiveView(view);
+                if (view !== "user-details") scrollTo(view);
+              }}
+              healthScore={70}
+              healthLabel="Moderate · needs improvement"
+            />
 
-        {activeView === "user-details" ? (
-          <UserDetailsView source={source} />
-        ) : (
-        <div style={{ flex: 1, overflowY: "auto", padding: "0px 20px 20px 20px" }}>
-                {/* Page header */}                                
-                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>      
-                  {/* <div>                                               
-                    <div style={{ fontSize: 16, fontWeight: 500, color: "var(--foreground)" }}>National overview</div>                 
-                    <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 2 }}>Real-time platform health · Updated every 15 min · {data.meta.season}</div>                
-                  </div> */}                                       
-                  {/* <div style={{ display: "flex", gap: 8 }}>    
-                    <button style={{ fontSize: 12, padding: "6px 12px", border: "0.5px solid var(--border)", borderRadius: 6, background: "var(--card)", color: "var(--muted-foreground)", cursor: "pointer" }}>Export PDF</button>                       
-                    <button style={{ fontSize: 12, padding: "6px 12px", border: "0.5px solid #3AAA5A", borderRadius: 6, background: "rgba(58,170,90,0.1)", color: "#3AAA5A", cursor: "pointer" }}>Share report</button>                                   
-                  </div> */}                                       
-                </div> 
+            {activeView === "user-details" ? (
+              <UserDetailsView source={source} />
+            ) : (
+              <div className="flex-1 overflow-y-auto px-5 pb-5">
+                <DashboardFilters filters={filters} onFilterChange={setFilters} />
 
-          <DashboardFilters filters={filters} onFilterChange={setFilters} />
+                {activeSegment && <SegmentDetailBanner seg={activeSegment} onClose={clearSegment} />}
 
-          {activeSegment && <SegmentDetailBanner seg={activeSegment} onClose={clearSegment} />}
+                <div ref={(el) => { sectionRefs.current["overview"] = el; }} className="relative">
+                  {isLoading && <Spinner text="Fetching metrics..." fullScreen={false} />}
+                  <EightCardsComponent kpiRow1={patchedKpiRow1} kpiRow2={data.kpiRow2} />
+                </div>
 
-          <div ref={(el) => { sectionRefs.current["overview"] = el; }} className="relative">
-            {isLoading && <Spinner text="Fetching metrics..." fullScreen={false} />}
-            <EightCardsComponent kpiRow1={patchedKpiRow1} kpiRow2={data.kpiRow2} />
+                {/* DAU trend + Channel split */}
+                <div
+                  ref={(el) => { sectionRefs.current["usage-patterns"] = el; }}
+                  className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-3 mb-4"
+                >
+                  <DailyActiveUsers data={dauTrend} isLoading={dauLoading} error={dauError} />
+                  <ChannelSplitCard channelSplit={data.channelSplit} voiceAccuracy={data.voiceAccuracy} />
+                </div>
+
+                {/* 3-col row */}
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 mb-4">
+                  <div ref={(el) => { sectionRefs.current["query-analysis"] = el; }}>
+                    <DashboardQueryCategories categories={data.queryCategories} />
+                  </div>
+                  <div ref={(el) => { sectionRefs.current["farmer-segments"] = el; }}>
+                    <DashboardFarmerSegments
+                      segments={data.farmerSegments}
+                      activeSegment={activeSegment}
+                      onSegmentClick={handleSegmentClick}
+                      onClear={clearSegment}
+                      segmentRowRefs={segmentRowRefs}
+                    />
+                  </div>
+                  <div ref={(el) => { sectionRefs.current["bugs-ux"] = el; }}>
+                    <AlertCard alerts={data.alerts} />
+                  </div>
+                </div>
+
+                {/* Geo + Health */}
+                <div
+                  ref={(el) => { sectionRefs.current["geo-intelligence"] = el; }}
+                  className="grid grid-cols-1 lg:grid-cols-2 gap-3 mb-4"
+                >
+                  <GeoCard states={data.geoStates} />
+                  <div ref={(el) => { sectionRefs.current["app-health"] = el; }}>
+                    <HealthScoreCard pillars={data.healthPillars} />
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
 
-          {/* DAU trend + Channel split */}
-          <div ref={(el) => { sectionRefs.current["usage-patterns"] = el; }}
-            className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-3 mb-4">
-            <DailyActiveUsers data={dauTrend} isLoading={dauLoading} error={dauError} />
-            <ChannelSplitCard channelSplit={data.channelSplit} voiceAccuracy={data.voiceAccuracy} />
-          </div>
-
-          {/* 3-col row */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 mb-4">
-            <div ref={(el) => { sectionRefs.current["query-analysis"] = el; }}>
-              <DashboardQueryCategories categories={data.queryCategories} />
-            </div>
-            <div ref={(el) => { sectionRefs.current["farmer-segments"] = el; }}>
-              <DashboardFarmerSegments
-                segments={data.farmerSegments}
-                activeSegment={activeSegment}
-                onSegmentClick={handleSegmentClick}
-                onClear={clearSegment}
-                segmentRowRefs={segmentRowRefs}
-              />
-            </div>
-            <div ref={(el) => { sectionRefs.current["bugs-ux"] = el; }}>
-              <AlertCard alerts={data.alerts} />
-            </div>
-          </div>
-
-          {/* Geo + Health */}
-          <div ref={(el) => { sectionRefs.current["geo-intelligence"] = el; }}
-            className="grid grid-cols-1 lg:grid-cols-2 gap-3 mb-4">
-            <GeoCard states={data.geoStates} />
-            <div ref={(el) => { sectionRefs.current["app-health"] = el; }}>
-              <HealthScoreCard pillars={data.healthPillars} />
-            </div>
-          </div>
-        </div>
-        )}
-      </div>
-
-        <StatusBar
-          lastSync={data.meta.lastSync}
-          datasetVersion={data.meta.datasetVersion}
-          llmVersion={data.meta.llmVersion}
-          p0Bugs={data.meta.p0Bugs}
-        />
+          <StatusBar
+            lastSync={data.meta.lastSync}
+            datasetVersion={data.meta.datasetVersion}
+            llmVersion={data.meta.llmVersion}
+            p0Bugs={data.meta.p0Bugs}
+          />
         </>
       )}
     </div>

--- a/frontend/src/features/chatbotDashboard/DashboardSidebar.tsx
+++ b/frontend/src/features/chatbotDashboard/DashboardSidebar.tsx
@@ -10,7 +10,8 @@ export type DashboardView =
     | "feedback-sentiment"
     | "bugs-ux"
     | "query-analysis"
-    | "app-health";
+    | "app-health"
+    | "user-details";
 
 interface NavItemConfig {
     label: string;
@@ -81,6 +82,14 @@ const ListIcon: React.FC = () => (
         <path d="M3 4h10M3 8h7M3 12h5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
     </svg>
 );
+const UsersIcon: React.FC = () => (
+    <svg width={16} height={16} viewBox="0 0 16 16" fill="none">
+        <circle cx="6" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.2" />
+        <path d="M1 14c0-2.8 2.2-5 5-5s5 2.2 5 5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        <circle cx="11.5" cy="5.5" r="2" stroke="currentColor" strokeWidth="1" opacity="0.6" />
+        <path d="M12 9c1.7.4 3 1.8 3 3.5" stroke="currentColor" strokeWidth="1" strokeLinecap="round" opacity="0.6" />
+    </svg>
+);
 const SunIcon: React.FC = () => (
     <svg width={16} height={16} viewBox="0 0 16 16" fill="none">
         <path d="M8 2v2M8 12v2M2 8h2M12 8h2M4.5 4.5l1.4 1.4M10.1 10.1l1.4 1.4M4.5 11.5l1.4-1.4M10.1 5.9l1.4-1.4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
@@ -121,6 +130,12 @@ const NAV_SECTIONS: SidebarSection[] = [
         items: [
             { label: "Query analysis", icon: <ListIcon />, view: "query-analysis", badge: "28%", badgeVariant: "amber" },
             { label: "App health score", icon: <SunIcon />, view: "app-health" },
+        ],
+    },
+    {
+        sectionLabel: "Management",
+        items: [
+            { label: "User details", icon: <UsersIcon />, view: "user-details" },
         ],
     },
 ];

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -37,11 +37,6 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
-  // Reset page when date filters change
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [startTime, endTime]);
-
   const { data, isLoading, error } = useUserDetails(
     startTime,
     endTime,
@@ -54,8 +49,8 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
   const { users, totalUsers, totalPages, activeUsers, totalQuestions } = data;
 
   const handleDateChange = (key: string, value: any) => {
-    if (key === "startTime") setStartTime(value);
-    if (key === "endTime") setEndTime(value);
+    if (key === "startTime") { setStartTime(value); setCurrentPage(1); }
+    if (key === "endTime") { setEndTime(value); setCurrentPage(1); }
   };
 
   const dateLabel = startTime && endTime

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -1,0 +1,74 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/atoms/card";
+
+export function UserDetailsView() {
+  return (
+    <div style={{ padding: "0px 20px 20px 20px", flex: 1, overflowY: "auto" }}>
+      {/* Page header */}
+      <div style={{ marginBottom: 20 }}>
+        <h2
+          className="text-lg font-semibold text-(--foreground)"
+          style={{ margin: 0 }}
+        >
+          User Details
+        </h2>
+        <p
+          className="text-xs text-(--muted-foreground)"
+          style={{ marginTop: 4 }}
+        >
+          View and manage all registered users and their activity
+        </p>
+      </div>
+
+      {/* Placeholder cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
+        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
+          <CardContent className="p-4 flex flex-col items-center gap-1">
+            <span className="text-2xl font-semibold text-[#3AAA5A]">—</span>
+            <span className="text-xs text-(--muted-foreground)">Total Users</span>
+          </CardContent>
+        </Card>
+        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
+          <CardContent className="p-4 flex flex-col items-center gap-1">
+            <span className="text-2xl font-semibold text-[#3AAA5A]">—</span>
+            <span className="text-xs text-(--muted-foreground)">Active Today</span>
+          </CardContent>
+        </Card>
+        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
+          <CardContent className="p-4 flex flex-col items-center gap-1">
+            <span className="text-2xl font-semibold text-[#3AAA5A]">—</span>
+            <span className="text-xs text-(--muted-foreground)">New This Month</span>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">User List</CardTitle>
+          <CardDescription>
+            This section is under development. User details, activity logs, and management tools will appear here.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div
+            className="flex flex-col items-center justify-center py-16 text-(--muted-foreground)"
+            style={{ gap: 12 }}
+          >
+            <svg width={48} height={48} viewBox="0 0 48 48" fill="none">
+              <circle cx="24" cy="20" r="8" stroke="currentColor" strokeWidth="2" />
+              <path
+                d="M8 42c0-8.8 7.2-16 16-16s16 7.2 16 16"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+            <span className="text-sm font-medium">Coming soon</span>
+            <span className="text-xs" style={{ maxWidth: 320, textAlign: "center" }}>
+              User details, search, filters, and individual activity breakdowns will be available here.
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/atoms/card";
 import { Spinner } from "@/components/atoms/spinner";
 import { useUserDetails } from "./hooks/useUserDetails";
@@ -8,6 +8,9 @@ export function UserDetailsView() {
   const [startTime, setStartTime] = useState<Date | undefined>(undefined);
   const [endTime, setEndTime] = useState<Date | undefined>(undefined);
   const [searchQuery, setSearchQuery] = useState("");
+  const PAGE_SIZE = 30;
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const sentinelRef = useRef<HTMLTableRowElement | null>(null);
 
   const { data: users, isLoading, error } = useUserDetails(startTime, endTime);
 
@@ -25,6 +28,34 @@ export function UserDetailsView() {
         u.email.toLowerCase().includes(q)
     );
   }, [users, searchQuery]);
+
+  // Reset visible count when filters change
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [searchQuery, startTime, endTime]);
+
+  const visibleUsers = useMemo(
+    () => filteredUsers.slice(0, visibleCount),
+    [filteredUsers, visibleCount]
+  );
+
+  const hasMore = visibleCount < filteredUsers.length;
+
+  // IntersectionObserver for infinite scroll
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore) {
+          setVisibleCount((prev) => Math.min(prev + PAGE_SIZE, filteredUsers.length));
+        }
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, filteredUsers.length]);
 
   const totalQuestions = useMemo(
     () => filteredUsers.reduce((sum, u) => sum + u.totalQuestions, 0),
@@ -167,36 +198,49 @@ export function UserDetailsView() {
                       </td>
                     </tr>
                   ) : (
-                    filteredUsers.map((user, idx) => (
-                      <tr
-                        key={user.userId}
-                        className="border-b border-gray-50 dark:border-gray-800/50 hover:bg-gray-50/50 dark:hover:bg-[#1e1e1e] transition-colors"
-                      >
-                        <td className="px-4 py-2.5 text-(--muted-foreground) tabular-nums">
-                          {idx + 1}
-                        </td>
-                        <td className="px-4 py-2.5 font-medium text-(--foreground) whitespace-nowrap">
-                          {user.name}
-                        </td>
-                        <td className="px-4 py-2.5 text-(--muted-foreground) whitespace-nowrap">
-                          {user.email}
-                        </td>
-                        <td className="px-4 py-2.5 text-right tabular-nums">
-                          <span
-                            className={`inline-flex items-center justify-center min-w-[32px] px-2 py-0.5 rounded-full text-xs font-semibold ${
-                              user.totalQuestions > 0
-                                ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300"
-                                : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
-                            }`}
-                          >
-                            {user.totalQuestions.toLocaleString()}
-                          </span>
-                        </td>
+                    <>
+                      {visibleUsers.map((user, idx) => (
+                        <tr
+                          key={user.userId}
+                          className="border-b border-gray-50 dark:border-gray-800/50 hover:bg-gray-50/50 dark:hover:bg-[#1e1e1e] transition-colors"
+                        >
+                          <td className="px-4 py-2.5 text-(--muted-foreground) tabular-nums">
+                            {idx + 1}
+                          </td>
+                          <td className="px-4 py-2.5 font-medium text-(--foreground) whitespace-nowrap">
+                            {user.name}
+                          </td>
+                          <td className="px-4 py-2.5 text-(--muted-foreground) whitespace-nowrap">
+                            {user.email}
+                          </td>
+                          <td className="px-4 py-2.5 text-right tabular-nums">
+                            <span
+                              className={`inline-flex items-center justify-center min-w-[32px] px-2 py-0.5 rounded-full text-xs font-semibold ${
+                                user.totalQuestions > 0
+                                  ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300"
+                                  : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+                              }`}
+                            >
+                              {user.totalQuestions.toLocaleString()}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                      {/* Scroll sentinel — triggers loading more rows */}
+                      <tr ref={sentinelRef} style={{ height: 1 }}>
+                        <td colSpan={4} />
                       </tr>
-                    ))
+                    </>
                   )}
                 </tbody>
               </table>
+              {/* Showing X of Y indicator */}
+              {filteredUsers.length > 0 && (
+                <div className="px-4 py-2.5 text-center text-xs text-(--muted-foreground) border-t border-gray-100 dark:border-gray-800">
+                  Showing {Math.min(visibleCount, filteredUsers.length)} of {filteredUsers.length} users
+                  {hasMore && " · scroll for more"}
+                </div>
+              )}
             </div>
           )}
         </CardContent>

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -131,7 +131,7 @@ export function UserDetailsView() {
         <CardHeader className="pb-3">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
             <CardTitle className="text-sm font-medium">All Farmers</CardTitle>
-            <div className="flex items-center gap-2 w-full sm:w-auto">
+            <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 w-full sm:w-auto">
               <div className="relative flex-1 sm:w-56">
                 <svg
                   width={14}
@@ -151,7 +151,7 @@ export function UserDetailsView() {
                   className="w-full h-9 pl-9 pr-3 text-sm border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-[#222] text-(--foreground) placeholder:text-(--muted-foreground) outline-none focus:border-[#3AAA5A] transition-colors"
                 />
               </div>
-              <div className="shrink-0 [&_label]:hidden [&_#date-toggle]:!whitespace-nowrap [&_#date-toggle_span]:!whitespace-nowrap [&_#date-toggle]:!h-9">
+              <div className="w-full sm:w-auto [&_label]:hidden [&_#date-toggle]:!whitespace-nowrap [&_#date-toggle_span]:!whitespace-nowrap [&_#date-toggle]:!h-9 [&_.absolute]:!left-0 [&_.absolute]:sm:!left-auto [&_.absolute]:sm:!right-0">
                 <DateRangeFilter
                   customName=""
                   advanceFilter={{ startTime, endTime }}

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -137,7 +137,7 @@ export function UserDetailsView() {
                   className="w-full h-9 pl-9 pr-3 text-sm border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-[#222] text-(--foreground) placeholder:text-(--muted-foreground) outline-none focus:border-[#3AAA5A] transition-colors"
                 />
               </div>
-              <div className="w-full sm:w-auto [&_label]:hidden [&_#date-toggle]:!whitespace-nowrap [&_#date-toggle_span]:!whitespace-nowrap [&_#date-toggle]:!h-9 [&_.absolute]:!left-0 [&_.absolute]:sm:!left-auto [&_.absolute]:sm:!right-0">
+              <div className="w-full sm:w-auto [&_label]:hidden [&_#date-toggle]:!whitespace-nowrap [&_#date-toggle_span]:!whitespace-nowrap [&_#date-toggle]:!h-9 [&_.absolute]:!left-0 [&_.absolute]:md:!left-auto [&_.absolute]:md:!right-0">
                 <DateRangeFilter
                   customName=""
                   advanceFilter={{ startTime, endTime }}

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -1,72 +1,207 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/atoms/card";
+import { useState, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/atoms/card";
+import { Spinner } from "@/components/atoms/spinner";
+import { useUserDetails } from "./hooks/useUserDetails";
+import { DateRangeFilter } from "@/components/DateRangeFilter";
 
 export function UserDetailsView() {
+  const [startTime, setStartTime] = useState<Date | undefined>(undefined);
+  const [endTime, setEndTime] = useState<Date | undefined>(undefined);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const { data: users, isLoading, error } = useUserDetails(startTime, endTime);
+
+  const handleDateChange = (key: string, value: any) => {
+    if (key === "startTime") setStartTime(value);
+    if (key === "endTime") setEndTime(value);
+  };
+
+  const filteredUsers = useMemo(() => {
+    if (!searchQuery.trim()) return users;
+    const q = searchQuery.toLowerCase();
+    return users.filter(
+      (u) =>
+        u.name.toLowerCase().includes(q) ||
+        u.email.toLowerCase().includes(q)
+    );
+  }, [users, searchQuery]);
+
+  const totalQuestions = useMemo(
+    () => filteredUsers.reduce((sum, u) => sum + u.totalQuestions, 0),
+    [filteredUsers]
+  );
+
+  const activeUsers = useMemo(
+    () => filteredUsers.filter((u) => u.totalQuestions > 0).length,
+    [filteredUsers]
+  );
+
+  const dateLabel = startTime && endTime
+    ? `${startTime.toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })} – ${endTime.toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })}`
+    : "All time";
+
   return (
     <div style={{ padding: "0px 20px 20px 20px", flex: 1, overflowY: "auto" }}>
-      {/* Page header */}
-      <div style={{ marginBottom: 20 }}>
-        <h2
-          className="text-lg font-semibold text-(--foreground)"
-          style={{ margin: 0 }}
-        >
-          User Details
-        </h2>
-        <p
-          className="text-xs text-(--muted-foreground)"
-          style={{ marginTop: 4 }}
-        >
-          View and manage all registered users and their activity
-        </p>
-      </div>
-
-      {/* Placeholder cards */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
-        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
-          <CardContent className="p-4 flex flex-col items-center gap-1">
-            <span className="text-2xl font-semibold text-[#3AAA5A]">—</span>
-            <span className="text-xs text-(--muted-foreground)">Total Users</span>
-          </CardContent>
-        </Card>
-        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
-          <CardContent className="p-4 flex flex-col items-center gap-1">
-            <span className="text-2xl font-semibold text-[#3AAA5A]">—</span>
-            <span className="text-xs text-(--muted-foreground)">Active Today</span>
-          </CardContent>
-        </Card>
-        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
-          <CardContent className="p-4 flex flex-col items-center gap-1">
-            <span className="text-2xl font-semibold text-[#3AAA5A]">—</span>
-            <span className="text-xs text-(--muted-foreground)">New This Month</span>
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
-        <CardHeader>
-          <CardTitle className="text-sm font-medium">User List</CardTitle>
-          <CardDescription>
-            This section is under development. User details, activity logs, and management tools will appear here.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div
-            className="flex flex-col items-center justify-center py-16 text-(--muted-foreground)"
-            style={{ gap: 12 }}
+      {/* Header + filter row */}
+      <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-3 mb-5">
+        <div>
+          <h2
+            className="text-base font-semibold text-(--foreground)"
+            style={{ margin: 0 }}
           >
-            <svg width={48} height={48} viewBox="0 0 48 48" fill="none">
-              <circle cx="24" cy="20" r="8" stroke="currentColor" strokeWidth="2" />
-              <path
-                d="M8 42c0-8.8 7.2-16 16-16s16 7.2 16 16"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
-            </svg>
-            <span className="text-sm font-medium">Coming soon</span>
-            <span className="text-xs" style={{ maxWidth: 320, textAlign: "center" }}>
-              User details, search, filters, and individual activity breakdowns will be available here.
-            </span>
+            User Details
+          </h2>
+          <p
+            className="text-xs text-(--muted-foreground)"
+            style={{ marginTop: 4 }}
+          >
+            {dateLabel} · {filteredUsers.length} users
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3 w-full sm:w-auto">
+          <div className="w-full sm:w-auto [&_label]:hidden [&_#date-toggle]:!w-full [&_#date-toggle]:!whitespace-nowrap [&_#date-toggle_span]:!whitespace-nowrap [&_#date-toggle]:!h-9">
+            <DateRangeFilter
+              customName=""
+              advanceFilter={{ startTime, endTime }}
+              handleDialogChange={handleDateChange}
+              className={
+                startTime
+                  ? "!h-9 !text-sm !w-full !border-green-500 dark:!border-green-500 !bg-green-50 dark:!bg-[#1a1a1a] !text-green-700 dark:!text-green-400 !font-medium hover:!bg-green-100 dark:hover:!bg-[#2a2a2a]"
+                  : "!h-9 !text-sm !w-full !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-[#1a1a1a] !text-gray-700 dark:!text-gray-200 !font-normal hover:!bg-gray-50 dark:hover:!bg-[#2a2a2a]"
+              }
+            />
           </div>
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5">
+        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a] relative overflow-hidden">
+          <div className="absolute inset-x-0 top-0 h-1" style={{ background: "#3AAA5A" }} />
+          <CardContent className="p-4 flex flex-col gap-0.5">
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Total Users
+            </span>
+            <span className="text-2xl font-semibold dark:text-slate-100">
+              {isLoading ? "—" : filteredUsers.length.toLocaleString()}
+            </span>
+          </CardContent>
+        </Card>
+        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a] relative overflow-hidden">
+          <div className="absolute inset-x-0 top-0 h-1" style={{ background: "#3B82F6" }} />
+          <CardContent className="p-4 flex flex-col gap-0.5">
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Active Users
+            </span>
+            <span className="text-2xl font-semibold dark:text-slate-100">
+              {isLoading ? "—" : activeUsers.toLocaleString()}
+            </span>
+          </CardContent>
+        </Card>
+        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a] relative overflow-hidden">
+          <div className="absolute inset-x-0 top-0 h-1" style={{ background: "#EF9F27" }} />
+          <CardContent className="p-4 flex flex-col gap-0.5">
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Total Questions
+            </span>
+            <span className="text-2xl font-semibold dark:text-slate-100">
+              {isLoading ? "—" : totalQuestions.toLocaleString()}
+            </span>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Users table */}
+      <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
+        <CardHeader className="pb-3">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+            <CardTitle className="text-sm font-medium">All Farmers</CardTitle>
+            <div className="relative w-full sm:w-64">
+              <svg
+                width={14}
+                height={14}
+                viewBox="0 0 16 16"
+                fill="none"
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-(--muted-foreground)"
+              >
+                <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.3" />
+                <path d="M11 11l3.5 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+              </svg>
+              <input
+                type="text"
+                placeholder="Search by name or email..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full h-9 pl-9 pr-3 text-sm border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-[#222] text-(--foreground) placeholder:text-(--muted-foreground) outline-none focus:border-[#3AAA5A] transition-colors"
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading && (
+            <div className="py-12">
+              <Spinner text="Fetching user details..." fullScreen={false} />
+            </div>
+          )}
+
+          {error && (
+            <div className="px-4 py-8 text-center text-red-500 text-sm">
+              Failed to load user details. Please try again.
+            </div>
+          )}
+
+          {!isLoading && !error && (
+            <div style={{ overflowX: "auto" }}>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-[#151515]">
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-(--muted-foreground)">#</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-(--muted-foreground)">Name</th>
+                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-(--muted-foreground)">Email</th>
+                    <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-(--muted-foreground)">Questions Asked</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredUsers.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-10 text-center text-(--muted-foreground) text-sm">
+                        {searchQuery ? "No users match your search." : "No users found."}
+                      </td>
+                    </tr>
+                  ) : (
+                    filteredUsers.map((user, idx) => (
+                      <tr
+                        key={user.userId}
+                        className="border-b border-gray-50 dark:border-gray-800/50 hover:bg-gray-50/50 dark:hover:bg-[#1e1e1e] transition-colors"
+                      >
+                        <td className="px-4 py-2.5 text-(--muted-foreground) tabular-nums">
+                          {idx + 1}
+                        </td>
+                        <td className="px-4 py-2.5 font-medium text-(--foreground) whitespace-nowrap">
+                          {user.name}
+                        </td>
+                        <td className="px-4 py-2.5 text-(--muted-foreground) whitespace-nowrap">
+                          {user.email}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums">
+                          <span
+                            className={`inline-flex items-center justify-center min-w-[32px] px-2 py-0.5 rounded-full text-xs font-semibold ${
+                              user.totalQuestions > 0
+                                ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300"
+                                : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+                            }`}
+                          >
+                            {user.totalQuestions.toLocaleString()}
+                          </span>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -1,9 +1,19 @@
 import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/atoms/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/atoms/card";
 import { Spinner } from "@/components/atoms/spinner";
 import { useUserDetails } from "./hooks/useUserDetails";
 import { DateRangeFilter } from "@/components/DateRangeFilter";
 import { Pagination } from "@/components/pagination";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/atoms/table";
 
 const PAGE_SIZE = 10;
 
@@ -139,6 +149,21 @@ export function UserDetailsView() {
                   }
                 />
               </div>
+              {(searchQuery || startTime || endTime) && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setSearchQuery("");
+                    setStartTime(undefined);
+                    setEndTime(undefined);
+                    setCurrentPage(1);
+                  }}
+                >
+                  <X />
+                  Reset
+                </Button>
+              )}
             </div>
           </div>
         </CardHeader>
@@ -156,39 +181,36 @@ export function UserDetailsView() {
           )}
 
           {!isLoading && !error && (
-            <div style={{ overflowX: "auto" }}>
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-[#151515]">
-                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-(--muted-foreground)">#</th>
-                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-(--muted-foreground)">Name</th>
-                    <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-(--muted-foreground)">Email</th>
-                    <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-(--muted-foreground)">Questions Asked</th>
-                  </tr>
-                </thead>
-                <tbody>
+            <div className="rounded-lg border bg-card overflow-x-auto">
+              <Table className="min-w-[600px]">
+                <TableHeader className="bg-card sticky top-0 z-10">
+                  <TableRow>
+                    <TableHead className="text-center w-12">S.No</TableHead>
+                    <TableHead className="text-center">Name</TableHead>
+                    <TableHead className="text-center">Email</TableHead>
+                    <TableHead className="text-center">Questions Asked</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {users.length === 0 ? (
-                    <tr>
-                      <td colSpan={4} className="px-4 py-10 text-center text-(--muted-foreground) text-sm">
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center py-10 text-muted-foreground">
                         {debouncedSearch ? "No users match your search." : "No users found."}
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   ) : (
                     users.map((user, idx) => (
-                      <tr
-                        key={user.userId}
-                        className="border-b border-gray-50 dark:border-gray-800/50 hover:bg-gray-50/50 dark:hover:bg-[#1e1e1e] transition-colors"
-                      >
-                        <td className="px-4 py-2.5 text-(--muted-foreground) tabular-nums">
+                      <TableRow key={user.userId} className="text-center">
+                        <TableCell className="align-middle">
                           {(currentPage - 1) * PAGE_SIZE + idx + 1}
-                        </td>
-                        <td className="px-4 py-2.5 font-medium text-(--foreground) whitespace-nowrap">
+                        </TableCell>
+                        <TableCell className="align-middle font-medium whitespace-nowrap">
                           {user.name}
-                        </td>
-                        <td className="px-4 py-2.5 text-(--muted-foreground) whitespace-nowrap">
+                        </TableCell>
+                        <TableCell className="align-middle whitespace-nowrap">
                           {user.email}
-                        </td>
-                        <td className="px-4 py-2.5 text-right tabular-nums">
+                        </TableCell>
+                        <TableCell className="align-middle">
                           <span
                             className={`inline-flex items-center justify-center min-w-[32px] px-2 py-0.5 rounded-full text-xs font-semibold ${
                               user.totalQuestions > 0
@@ -198,12 +220,12 @@ export function UserDetailsView() {
                           >
                             {user.totalQuestions.toLocaleString()}
                           </span>
-                        </td>
-                      </tr>
+                        </TableCell>
+                      </TableRow>
                     ))
                   )}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
               {/* Pagination footer */}
               {totalPages > 0 && (
                 <div className="px-4 py-3 border-t border-gray-100 dark:border-gray-800">

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -17,7 +17,11 @@ import {
 
 const PAGE_SIZE = 10;
 
-export function UserDetailsView() {
+interface UserDetailsViewProps {
+  source?: 'vicharanashala' | 'annam';
+}
+
+export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewProps) {
   const [startTime, setStartTime] = useState<Date | undefined>(undefined);
   const [endTime, setEndTime] = useState<Date | undefined>(undefined);
   const [searchQuery, setSearchQuery] = useState("");
@@ -44,6 +48,7 @@ export function UserDetailsView() {
     currentPage,
     PAGE_SIZE,
     debouncedSearch,
+    source,
   );
 
   const { users, totalUsers, totalPages, activeUsers, totalQuestions } = data;

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -1,71 +1,47 @@
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/atoms/card";
 import { Spinner } from "@/components/atoms/spinner";
 import { useUserDetails } from "./hooks/useUserDetails";
 import { DateRangeFilter } from "@/components/DateRangeFilter";
+import { Pagination } from "@/components/pagination";
+
+const PAGE_SIZE = 10;
 
 export function UserDetailsView() {
   const [startTime, setStartTime] = useState<Date | undefined>(undefined);
   const [endTime, setEndTime] = useState<Date | undefined>(undefined);
   const [searchQuery, setSearchQuery] = useState("");
-  const PAGE_SIZE = 30;
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
-  const sentinelRef = useRef<HTMLTableRowElement | null>(null);
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
 
-  const { data: users, isLoading, error } = useUserDetails(startTime, endTime);
+  // Debounce the search input so we don't fire a request on every keystroke
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchQuery);
+      setCurrentPage(1); // reset to page 1 on new search
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Reset page when date filters change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [startTime, endTime]);
+
+  const { data, isLoading, error } = useUserDetails(
+    startTime,
+    endTime,
+    currentPage,
+    PAGE_SIZE,
+    debouncedSearch,
+  );
+
+  const { users, totalUsers, totalPages, activeUsers, totalQuestions } = data;
 
   const handleDateChange = (key: string, value: any) => {
     if (key === "startTime") setStartTime(value);
     if (key === "endTime") setEndTime(value);
   };
-
-  const filteredUsers = useMemo(() => {
-    if (!searchQuery.trim()) return users;
-    const q = searchQuery.toLowerCase();
-    return users.filter(
-      (u) =>
-        u.name.toLowerCase().includes(q) ||
-        u.email.toLowerCase().includes(q)
-    );
-  }, [users, searchQuery]);
-
-  // Reset visible count when filters change
-  useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
-  }, [searchQuery, startTime, endTime]);
-
-  const visibleUsers = useMemo(
-    () => filteredUsers.slice(0, visibleCount),
-    [filteredUsers, visibleCount]
-  );
-
-  const hasMore = visibleCount < filteredUsers.length;
-
-  // IntersectionObserver for infinite scroll
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasMore) {
-          setVisibleCount((prev) => Math.min(prev + PAGE_SIZE, filteredUsers.length));
-        }
-      },
-      { rootMargin: "200px" }
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [hasMore, filteredUsers.length]);
-
-  const totalQuestions = useMemo(
-    () => filteredUsers.reduce((sum, u) => sum + u.totalQuestions, 0),
-    [filteredUsers]
-  );
-
-  const activeUsers = useMemo(
-    () => filteredUsers.filter((u) => u.totalQuestions > 0).length,
-    [filteredUsers]
-  );
 
   const dateLabel = startTime && endTime
     ? `${startTime.toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })} – ${endTime.toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })}`
@@ -85,7 +61,7 @@ export function UserDetailsView() {
           className="text-xs text-(--muted-foreground)"
           style={{ marginTop: 4 }}
         >
-          {dateLabel} · {filteredUsers.length} users
+          {dateLabel} · {totalUsers} users
         </p>
       </div>
 
@@ -98,7 +74,7 @@ export function UserDetailsView() {
               Total Users
             </span>
             <span className="text-2xl font-semibold dark:text-slate-100">
-              {isLoading ? "—" : filteredUsers.length.toLocaleString()}
+              {isLoading ? "—" : totalUsers.toLocaleString()}
             </span>
           </CardContent>
         </Card>
@@ -191,54 +167,56 @@ export function UserDetailsView() {
                   </tr>
                 </thead>
                 <tbody>
-                  {filteredUsers.length === 0 ? (
+                  {users.length === 0 ? (
                     <tr>
                       <td colSpan={4} className="px-4 py-10 text-center text-(--muted-foreground) text-sm">
-                        {searchQuery ? "No users match your search." : "No users found."}
+                        {debouncedSearch ? "No users match your search." : "No users found."}
                       </td>
                     </tr>
                   ) : (
-                    <>
-                      {visibleUsers.map((user, idx) => (
-                        <tr
-                          key={user.userId}
-                          className="border-b border-gray-50 dark:border-gray-800/50 hover:bg-gray-50/50 dark:hover:bg-[#1e1e1e] transition-colors"
-                        >
-                          <td className="px-4 py-2.5 text-(--muted-foreground) tabular-nums">
-                            {idx + 1}
-                          </td>
-                          <td className="px-4 py-2.5 font-medium text-(--foreground) whitespace-nowrap">
-                            {user.name}
-                          </td>
-                          <td className="px-4 py-2.5 text-(--muted-foreground) whitespace-nowrap">
-                            {user.email}
-                          </td>
-                          <td className="px-4 py-2.5 text-right tabular-nums">
-                            <span
-                              className={`inline-flex items-center justify-center min-w-[32px] px-2 py-0.5 rounded-full text-xs font-semibold ${
-                                user.totalQuestions > 0
-                                  ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300"
-                                  : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
-                              }`}
-                            >
-                              {user.totalQuestions.toLocaleString()}
-                            </span>
-                          </td>
-                        </tr>
-                      ))}
-                      {/* Scroll sentinel — triggers loading more rows */}
-                      <tr ref={sentinelRef} style={{ height: 1 }}>
-                        <td colSpan={4} />
+                    users.map((user, idx) => (
+                      <tr
+                        key={user.userId}
+                        className="border-b border-gray-50 dark:border-gray-800/50 hover:bg-gray-50/50 dark:hover:bg-[#1e1e1e] transition-colors"
+                      >
+                        <td className="px-4 py-2.5 text-(--muted-foreground) tabular-nums">
+                          {(currentPage - 1) * PAGE_SIZE + idx + 1}
+                        </td>
+                        <td className="px-4 py-2.5 font-medium text-(--foreground) whitespace-nowrap">
+                          {user.name}
+                        </td>
+                        <td className="px-4 py-2.5 text-(--muted-foreground) whitespace-nowrap">
+                          {user.email}
+                        </td>
+                        <td className="px-4 py-2.5 text-right tabular-nums">
+                          <span
+                            className={`inline-flex items-center justify-center min-w-[32px] px-2 py-0.5 rounded-full text-xs font-semibold ${
+                              user.totalQuestions > 0
+                                ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300"
+                                : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+                            }`}
+                          >
+                            {user.totalQuestions.toLocaleString()}
+                          </span>
+                        </td>
                       </tr>
-                    </>
+                    ))
                   )}
                 </tbody>
               </table>
-              {/* Showing X of Y indicator */}
-              {filteredUsers.length > 0 && (
-                <div className="px-4 py-2.5 text-center text-xs text-(--muted-foreground) border-t border-gray-100 dark:border-gray-800">
-                  Showing {Math.min(visibleCount, filteredUsers.length)} of {filteredUsers.length} users
-                  {hasMore && " · scroll for more"}
+              {/* Pagination footer */}
+              {totalPages > 0 && (
+                <div className="px-4 py-3 border-t border-gray-100 dark:border-gray-800">
+                  <div className="flex flex-col sm:flex-row items-center justify-between gap-2">
+                    <span className="text-xs text-(--muted-foreground)">
+                      Showing {users.length > 0 ? (currentPage - 1) * PAGE_SIZE + 1 : 0}–{(currentPage - 1) * PAGE_SIZE + users.length} of {totalUsers} users
+                    </span>
+                    <Pagination
+                      currentPage={currentPage}
+                      totalPages={totalPages}
+                      onPageChange={(page) => setCurrentPage(page)}
+                    />
+                  </div>
                 </div>
               )}
             </div>

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -42,37 +42,20 @@ export function UserDetailsView() {
 
   return (
     <div style={{ padding: "0px 20px 20px 20px", flex: 1, overflowY: "auto" }}>
-      {/* Header + filter row */}
-      <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-3 mb-5">
-        <div>
-          <h2
-            className="text-base font-semibold text-(--foreground)"
-            style={{ margin: 0 }}
-          >
-            User Details
-          </h2>
-          <p
-            className="text-xs text-(--muted-foreground)"
-            style={{ marginTop: 4 }}
-          >
-            {dateLabel} · {filteredUsers.length} users
-          </p>
-        </div>
-
-        <div className="flex items-center gap-3 w-full sm:w-auto">
-          <div className="w-full sm:w-auto [&_label]:hidden [&_#date-toggle]:!w-full [&_#date-toggle]:!whitespace-nowrap [&_#date-toggle_span]:!whitespace-nowrap [&_#date-toggle]:!h-9">
-            <DateRangeFilter
-              customName=""
-              advanceFilter={{ startTime, endTime }}
-              handleDialogChange={handleDateChange}
-              className={
-                startTime
-                  ? "!h-9 !text-sm !w-full !border-green-500 dark:!border-green-500 !bg-green-50 dark:!bg-[#1a1a1a] !text-green-700 dark:!text-green-400 !font-medium hover:!bg-green-100 dark:hover:!bg-[#2a2a2a]"
-                  : "!h-9 !text-sm !w-full !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-[#1a1a1a] !text-gray-700 dark:!text-gray-200 !font-normal hover:!bg-gray-50 dark:hover:!bg-[#2a2a2a]"
-              }
-            />
-          </div>
-        </div>
+      {/* Header */}
+      <div className="mb-5">
+        <h2
+          className="text-base font-semibold text-(--foreground)"
+          style={{ margin: 0 }}
+        >
+          User Details
+        </h2>
+        <p
+          className="text-xs text-(--muted-foreground)"
+          style={{ marginTop: 4 }}
+        >
+          {dateLabel} · {filteredUsers.length} users
+        </p>
       </div>
 
       {/* Summary cards */}
@@ -117,24 +100,38 @@ export function UserDetailsView() {
         <CardHeader className="pb-3">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
             <CardTitle className="text-sm font-medium">All Farmers</CardTitle>
-            <div className="relative w-full sm:w-64">
-              <svg
-                width={14}
-                height={14}
-                viewBox="0 0 16 16"
-                fill="none"
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-(--muted-foreground)"
-              >
-                <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.3" />
-                <path d="M11 11l3.5 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-              </svg>
-              <input
-                type="text"
-                placeholder="Search by name or email..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full h-9 pl-9 pr-3 text-sm border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-[#222] text-(--foreground) placeholder:text-(--muted-foreground) outline-none focus:border-[#3AAA5A] transition-colors"
-              />
+            <div className="flex items-center gap-2 w-full sm:w-auto">
+              <div className="relative flex-1 sm:w-56">
+                <svg
+                  width={14}
+                  height={14}
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-(--muted-foreground)"
+                >
+                  <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.3" />
+                  <path d="M11 11l3.5 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                </svg>
+                <input
+                  type="text"
+                  placeholder="Search by name or email..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="w-full h-9 pl-9 pr-3 text-sm border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-[#222] text-(--foreground) placeholder:text-(--muted-foreground) outline-none focus:border-[#3AAA5A] transition-colors"
+                />
+              </div>
+              <div className="shrink-0 [&_label]:hidden [&_#date-toggle]:!whitespace-nowrap [&_#date-toggle_span]:!whitespace-nowrap [&_#date-toggle]:!h-9">
+                <DateRangeFilter
+                  customName=""
+                  advanceFilter={{ startTime, endTime }}
+                  handleDialogChange={handleDateChange}
+                  className={
+                    startTime
+                      ? "!h-9 !text-sm !border-green-500 dark:!border-green-500 !bg-green-50 dark:!bg-[#1a1a1a] !text-green-700 dark:!text-green-400 !font-medium hover:!bg-green-100 dark:hover:!bg-[#2a2a2a]"
+                      : "!h-9 !text-sm !border-gray-200 dark:!border-gray-700 !bg-white dark:!bg-[#1a1a1a] !text-gray-700 dark:!text-gray-200 !font-normal hover:!bg-gray-50 dark:hover:!bg-[#2a2a2a]"
+                  }
+                />
+              </div>
             </div>
           </div>
         </CardHeader>

--- a/frontend/src/features/chatbotDashboard/hooks/useDailyUserTrend.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDailyUserTrend.ts
@@ -8,13 +8,13 @@ interface DailyUserTrendEntry {
   count: number;
 }
 
-export function useDailyUserTrend(days = 30) {
+export function useDailyUserTrend(days = 30, source: 'vicharanashala' | 'annam' = 'vicharanashala') {
   const { data: rawData, isLoading, error } = useQuery<DailyUserTrendEntry[], Error>({
-    queryKey: ['daily-user-trend', days],
+    queryKey: ['daily-user-trend', days, source],
     queryFn: async () => {
       const API_BASE_URL = env.apiBaseUrl();
       const result = await apiFetch<DailyUserTrendEntry[]>(
-        `${API_BASE_URL}/analytics/user-trend?days=${days}`,
+        `${API_BASE_URL}/analytics/user-trend?days=${days}&source=${source}`,
       );
       return result ?? [];
     },

--- a/frontend/src/features/chatbotDashboard/hooks/useDailyUserTrend.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDailyUserTrend.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/hooks/api/api-fetch';
 import { env } from '@/config/env';
 
@@ -8,46 +9,40 @@ interface DailyUserTrendEntry {
 }
 
 export function useDailyUserTrend(days = 30) {
-  const [data, setData] = useState<number[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const { data: rawData, isLoading, error } = useQuery<DailyUserTrendEntry[], Error>({
+    queryKey: ['daily-user-trend', days],
+    queryFn: async () => {
+      const API_BASE_URL = env.apiBaseUrl();
+      const result = await apiFetch<DailyUserTrendEntry[]>(
+        `${API_BASE_URL}/analytics/user-trend?days=${days}`,
+      );
+      return result ?? [];
+    },
+  });
 
-  useEffect(() => {
-    async function fetchData() {
-      setIsLoading(true);
-      try {
-        const API_BASE_URL = env.apiBaseUrl();
-        const result = await apiFetch<DailyUserTrendEntry[]>(
-          `${API_BASE_URL}/analytics/user-trend?days=${days}`,
-        );
-        if (result) {
-          // Build a lookup from the sparse API response (only days with activity)
-          const countByDay: Record<string, number> = {};
-          for (const entry of result) {
-            countByDay[entry.day] = entry.count;
-          }
+  // Transform sparse API response into a filled array of counts (one per day)
+  const data = useMemo(() => {
+    if (!rawData || rawData.length === 0) return [];
 
-          // Generate the full date range (last `days` days) in YYYY-MM-DD IST,
-          // matching the timezone used by the backend aggregation (+05:30)
-          const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
-          const filled: number[] = [];
-          for (let i = days - 1; i >= 0; i--) {
-            const d = new Date();
-            d.setDate(d.getDate() - i);
-            const istDate = new Date(d.getTime() + IST_OFFSET_MS);
-            const key = istDate.toISOString().slice(0, 10); // YYYY-MM-DD in IST
-            filled.push(countByDay[key] ?? 0);
-          }
-          setData(filled);
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error(String(err)));
-      } finally {
-        setIsLoading(false);
-      }
+    // Build a lookup from the sparse API response (only days with activity)
+    const countByDay: Record<string, number> = {};
+    for (const entry of rawData) {
+      countByDay[entry.day] = entry.count;
     }
-    fetchData();
-  }, [days]);
 
-  return { data, isLoading, error };
+    // Generate the full date range (last `days` days) in YYYY-MM-DD IST,
+    // matching the timezone used by the backend aggregation (+05:30)
+    const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
+    const filled: number[] = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date();
+      d.setDate(d.getDate() - i);
+      const istDate = new Date(d.getTime() + IST_OFFSET_MS);
+      const key = istDate.toISOString().slice(0, 10); // YYYY-MM-DD in IST
+      filled.push(countByDay[key] ?? 0);
+    }
+    return filled;
+  }, [rawData, days]);
+
+  return { data, isLoading, error: error ?? null };
 }

--- a/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/hooks/api/api-fetch';
 import { env } from '@/config/env';
 import { DASHBOARD_DATA } from '../mockData';
@@ -100,147 +101,141 @@ function weeklyRange(entries: Array<{ week: string }>): string {
   )}`;
 }
 
+// ── Transform raw API response into dashboard shape ─────────────────────────
+
+function transformApiResponse(result: DashboardApiResponse): DashboardDataType {
+  const updatedData = { ...DASHBOARD_DATA };
+
+  // Use the real month-over-month % from the backend
+  const pct = result.kpi.dauLastMonthPct;
+  const delta = pct > 0
+    ? { text: `+${pct}% vs last month`, dir: 'up' as const }
+    : pct < 0
+    ? { text: `${pct}% vs last month`, dir: 'down' as const }
+    : { text: 'Stable vs last month', dir: 'neutral' as const };
+
+  // Build sparkline from all DAU data points (up to 30 days)
+  const sparkPoints = result.dau.length > 0
+    ? result.dau.map(d => d.count)
+    : DASHBOARD_DATA.kpiRow1[0].sparkPoints; // fallback to mock sparkline
+  // Session duration: compare current week vs last week
+  const sessionWeekly = result.weeklySessionDuration ?? [];
+  const thisWeek = sessionWeekly.at(-1)?.avgSessionDurationMin ?? 0;
+  const lastWeek = sessionWeekly.at(-2)?.avgSessionDurationMin ?? 0;
+  const sessionDelta: { text: string; dir: 'up' | 'down' | 'neutral' } =
+    lastWeek === 0 || sessionWeekly.length < 2
+      ? { text: 'Not enough data', dir: 'neutral' }
+      : (() => {
+        const pct = Math.round(((thisWeek - lastWeek) / lastWeek) * 100);
+        if (pct > 0) return { text: `+${pct}% vs last week`, dir: 'up' as const };
+        if (pct < 0) return { text: `${pct}% vs last week`, dir: 'down' as const };
+        return { text: 'Stable vs last week', dir: 'neutral' as const };
+      })();
+  const sessionSparkPoints = sessionWeekly.length > 0
+    ? sessionWeekly.map(w => w.avgSessionDurationMin)
+    : DASHBOARD_DATA.kpiRow1.find(c => c.id === 'session')?.sparkPoints ?? [];
+
+  // Daily queries: true week-over-week delta (last 7 days vs prior 7 days)
+  const queryTrend = result.dailyQueries ?? [];
+  const queryDelta = calcWeeklyDelta(queryTrend);
+  // Sparkline: use all-time weekly totals as data points
+  const weeklyQueryData = result.weeklyQueries ?? [];
+  const querySparkPoints = weeklyQueryData.length > 0
+    ? weeklyQueryData.map(w => w.count)
+    : DASHBOARD_DATA.kpiRow1.find(c => c.id === 'queries')?.sparkPoints ?? [];
+
+  const dauRange = monthlyRange(result.dau);
+  const queryRange = dailyRange(queryTrend);
+  const sessionRange = weeklyRange(sessionWeekly);
+
+  // parse handles both YYYY-MM (monthly DAU) and YYYY-MM-DD (daily queries)
+  const parseDay = (s: string) => new Date((s.length === 7 ? s + '-01' : s) + 'T00:00:00');
+  const dauLabels = result.dau.map(d => fmtMonthYear(parseDay(d.day)));
+  const queryLabels = queryTrend.map(d => fmtDayWithWeek(parseDay(d.day)));
+  const sessionLabels = sessionWeekly.map(w => fmtWeekLabel(w.week));
+
+  updatedData.kpiRow1 = DASHBOARD_DATA.kpiRow1.map(card => {
+    if (card.id === 'dau') {
+      return {
+        ...card,
+        value: result.kpi.dau.toString(), // raw number, no formatting
+        delta: delta.text,
+        deltaDir: delta.dir,
+        sparkPoints,
+        sparkLabels: dauLabels,
+        dateRange: dauRange,
+      };
+    }
+    if (card.id === 'queries') {
+      return {
+        ...card,
+        value: formatIndian(result.kpi.dailyQueries),
+        delta: queryDelta.text,
+        deltaDir: queryDelta.dir,
+        sparkPoints: querySparkPoints,
+        sparkLabels: queryLabels,
+        dateRange: queryRange,
+      };
+    }
+    if (card.id === 'session') {
+      return {
+        ...card,
+        value: `${result.kpi.avgSessionDurationMin.toFixed(1)} min`,
+        delta: sessionDelta.text,
+        deltaDir: sessionDelta.dir,
+        sparkPoints: sessionSparkPoints,
+        sparkLabels: sessionLabels,
+        dateRange: sessionRange,
+      };
+    }
+    return card;
+  });
+
+  return updatedData;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 export function useDashboardData(filters?: DashboardFilterValues) {
-  const [data, setData] = useState<DashboardDataType>(DASHBOARD_DATA);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<Error | null>(null);
+  const startISO = filters?.startTime?.toISOString();
+  const endISO = filters?.endTime?.toISOString();
 
-  useEffect(() => {
-    let isMounted = true;
+  const { data, isLoading, error } = useQuery<DashboardDataType, Error>({
+    queryKey: [
+      'dashboard-data',
+      filters?.village ?? 'all',
+      filters?.crop ?? 'all',
+      filters?.season ?? 'all',
+      startISO,
+      endISO,
+    ],
+    queryFn: async () => {
+      const API_BASE_URL = env.apiBaseUrl();
 
-    async function fetchData() {
-      try {
-        setIsLoading(true);
+      // Build query params from filters
+      const params = new URLSearchParams();
+      if (filters?.village && filters.village !== 'all') params.set('village', filters.village);
+      if (filters?.crop && filters.crop !== 'all') params.set('crop', filters.crop);
+      if (filters?.season && filters.season !== 'all') params.set('season', filters.season);
+      if (startISO) params.set('startTime', startISO);
+      if (endISO) params.set('endTime', endISO);
+      const queryString = params.toString();
 
-        const API_BASE_URL = env.apiBaseUrl();
+      const result = await apiFetch<DashboardApiResponse>(
+        `${API_BASE_URL}/analytics${queryString ? `?${queryString}` : ''}`
+      );
 
-        // Build query params from filters
-        const params = new URLSearchParams();
-        if (filters?.village && filters.village !== 'all') params.set('village', filters.village);
-        if (filters?.crop && filters.crop !== 'all') params.set('crop', filters.crop);
-        if (filters?.season && filters.season !== 'all') params.set('season', filters.season);
-        if (filters?.startTime) params.set('startTime', filters.startTime.toISOString());
-        if (filters?.endTime) params.set('endTime', filters.endTime.toISOString());
-        const queryString = params.toString();
-
-        const result = await apiFetch<DashboardApiResponse>(
-          `${API_BASE_URL}/analytics${queryString ? `?${queryString}` : ''}`
-        );
-
-        if (isMounted && result) {
-          const updatedData = { ...DASHBOARD_DATA };
-
-          // Use the real month-over-month % from the backend
-          const pct = result.kpi.dauLastMonthPct;
-          const delta = pct > 0
-            ? { text: `+${pct}% vs last month`, dir: 'up' as const }
-            : pct < 0
-            ? { text: `${pct}% vs last month`, dir: 'down' as const }
-            : { text: 'Stable vs last month', dir: 'neutral' as const };
-
-          // Build sparkline from all DAU data points (up to 30 days)
-          const sparkPoints = result.dau.length > 0
-            ? result.dau.map(d => d.count)
-            : DASHBOARD_DATA.kpiRow1[0].sparkPoints; // fallback to mock sparkline
-          // Session duration: compare current week vs last week
-          const sessionWeekly = result.weeklySessionDuration ?? [];
-          const thisWeek = sessionWeekly.at(-1)?.avgSessionDurationMin ?? 0;
-          const lastWeek = sessionWeekly.at(-2)?.avgSessionDurationMin ?? 0;
-          const sessionDelta: { text: string; dir: 'up' | 'down' | 'neutral' } =
-            lastWeek === 0 || sessionWeekly.length < 2
-              ? { text: 'Not enough data', dir: 'neutral' }
-              : (() => {
-                const pct = Math.round(((thisWeek - lastWeek) / lastWeek) * 100);
-                if (pct > 0) return { text: `+${pct}% vs last week`, dir: 'up' };
-                if (pct < 0) return { text: `${pct}% vs last week`, dir: 'down' };
-                return { text: 'Stable vs last week', dir: 'neutral' };
-              })();
-          const sessionSparkPoints = sessionWeekly.length > 0
-            ? sessionWeekly.map(w => w.avgSessionDurationMin)
-            : DASHBOARD_DATA.kpiRow1.find(c => c.id === 'session')?.sparkPoints ?? [];
-
-          // Daily queries: true week-over-week delta (last 7 days vs prior 7 days)
-          const queryTrend = result.dailyQueries ?? [];
-          const queryDelta = calcWeeklyDelta(queryTrend);
-          // Sparkline: use all-time weekly totals as data points
-          const weeklyQueryData = result.weeklyQueries ?? [];
-          const querySparkPoints = weeklyQueryData.length > 0
-            ? weeklyQueryData.map(w => w.count)
-            : DASHBOARD_DATA.kpiRow1.find(c => c.id === 'queries')?.sparkPoints ?? [];
-
-          const dauRange = monthlyRange(result.dau);
-          const queryRange = dailyRange(queryTrend);
-          const sessionRange = weeklyRange(sessionWeekly);
-
-          // parse handles both YYYY-MM (monthly DAU) and YYYY-MM-DD (daily queries)
-          const parseDay = (s: string) => new Date((s.length === 7 ? s + '-01' : s) + 'T00:00:00');
-          const dauLabels = result.dau.map(d => fmtMonthYear(parseDay(d.day)));
-          const queryLabels = queryTrend.map(d => fmtDayWithWeek(parseDay(d.day)));
-          const sessionLabels = sessionWeekly.map(w => fmtWeekLabel(w.week));
-
-          updatedData.kpiRow1 = DASHBOARD_DATA.kpiRow1.map(card => {
-            if (card.id === 'dau') {
-              return {
-                ...card,
-                value: result.kpi.dau.toString(), // raw number, no formatting
-                delta: delta.text,
-                deltaDir: delta.dir,
-                sparkPoints,
-                sparkLabels: dauLabels,
-                dateRange: dauRange,
-              };
-            }
-            if (card.id === 'queries') {
-              return {
-                ...card,
-                value: formatIndian(result.kpi.dailyQueries),
-                delta: queryDelta.text,
-                deltaDir: queryDelta.dir,
-                sparkPoints: querySparkPoints,
-                sparkLabels: queryLabels,
-                dateRange: queryRange,
-              };
-            }
-            if (card.id === 'session') {
-              return {
-                ...card,
-                value: `${result.kpi.avgSessionDurationMin.toFixed(1)} min`,
-                delta: sessionDelta.text,
-                deltaDir: sessionDelta.dir,
-                sparkPoints: sessionSparkPoints,
-                sparkLabels: sessionLabels,
-                dateRange: sessionRange,
-              };
-            }
-            return card;
-          });
-
-          setData(updatedData);
-          setError(null);
-        } else if (isMounted) {
-          setData(DASHBOARD_DATA);
-        }
-      } catch (err) {
-        console.error('Dashboard API error, using mock data:', err);
-        if (isMounted) {
-          setData(DASHBOARD_DATA);
-          setError(err instanceof Error ? err : new Error('An unknown error occurred'));
-        }
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
+      if (result) {
+        return transformApiResponse(result);
       }
-    }
 
-    fetchData();
+      // Fallback to mock data if API returns nothing
+      return DASHBOARD_DATA;
+    },
+  });
 
-    return () => {
-      isMounted = false;
-    };
-  }, [filters?.village, filters?.crop, filters?.season, filters?.startTime, filters?.endTime]);
+  // Use memoized fallback so consumers always get a stable reference
+  const safeData = useMemo(() => data ?? DASHBOARD_DATA, [data]);
 
-  return { data, isLoading, error };
+  return { data: safeData, isLoading, error: error ?? null };
 }

--- a/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
@@ -196,7 +196,7 @@ function transformApiResponse(result: DashboardApiResponse): DashboardDataType {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-export function useDashboardData(filters?: DashboardFilterValues) {
+export function useDashboardData(filters?: DashboardFilterValues, source: 'vicharanashala' | 'annam' = 'vicharanashala') {
   const startISO = filters?.startTime?.toISOString();
   const endISO = filters?.endTime?.toISOString();
 
@@ -208,6 +208,7 @@ export function useDashboardData(filters?: DashboardFilterValues) {
       filters?.season ?? 'all',
       startISO,
       endISO,
+      source,
     ],
     queryFn: async () => {
       const API_BASE_URL = env.apiBaseUrl();
@@ -219,6 +220,7 @@ export function useDashboardData(filters?: DashboardFilterValues) {
       if (filters?.season && filters.season !== 'all') params.set('season', filters.season);
       if (startISO) params.set('startTime', startISO);
       if (endISO) params.set('endTime', endISO);
+      params.set('source', source);
       const queryString = params.toString();
 
       const result = await apiFetch<DashboardApiResponse>(

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/hooks/api/api-fetch';
 import { env } from '@/config/env';
 
@@ -10,45 +10,25 @@ export interface UserDetail {
 }
 
 export function useUserDetails(startDate?: Date, endDate?: Date) {
-  const [data, setData] = useState<UserDetail[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const startISO = startDate?.toISOString();
+  const endISO = endDate?.toISOString();
 
-  useEffect(() => {
-    let isMounted = true;
+  const { data, isLoading, error } = useQuery<UserDetail[], Error>({
+    queryKey: ['user-details', startISO, endISO],
+    queryFn: async () => {
+      const API_BASE_URL = env.apiBaseUrl();
+      const params = new URLSearchParams();
+      if (startISO) params.set('startDate', startISO);
+      if (endISO) params.set('endDate', endISO);
+      const qs = params.toString();
 
-    async function fetchData() {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const API_BASE_URL = env.apiBaseUrl();
-        const params = new URLSearchParams();
-        if (startDate) params.set('startDate', startDate.toISOString());
-        if (endDate) params.set('endDate', endDate.toISOString());
-        const qs = params.toString();
+      const result = await apiFetch<UserDetail[]>(
+        `${API_BASE_URL}/analytics/user-details${qs ? `?${qs}` : ''}`,
+      );
 
-        const result = await apiFetch<UserDetail[]>(
-          `${API_BASE_URL}/analytics/user-details${qs ? `?${qs}` : ''}`,
-        );
+      return result ?? [];
+    },
+  });
 
-        if (isMounted && result) {
-          setData(result);
-        }
-      } catch (err) {
-        if (isMounted) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      } finally {
-        if (isMounted) setIsLoading(false);
-      }
-    }
-
-    fetchData();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [startDate?.toISOString(), endDate?.toISOString()]);
-
-  return { data, isLoading, error };
+  return { data: data ?? [], isLoading, error };
 }

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import { apiFetch } from '@/hooks/api/api-fetch';
+import { env } from '@/config/env';
+
+export interface UserDetail {
+  userId: string;
+  name: string;
+  email: string;
+  totalQuestions: number;
+}
+
+export function useUserDetails(startDate?: Date, endDate?: Date) {
+  const [data, setData] = useState<UserDetail[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchData() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const API_BASE_URL = env.apiBaseUrl();
+        const params = new URLSearchParams();
+        if (startDate) params.set('startDate', startDate.toISOString());
+        if (endDate) params.set('endDate', endDate.toISOString());
+        const qs = params.toString();
+
+        const result = await apiFetch<UserDetail[]>(
+          `${API_BASE_URL}/analytics/user-details${qs ? `?${qs}` : ''}`,
+        );
+
+        if (isMounted && result) {
+          setData(result);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    }
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [startDate?.toISOString(), endDate?.toISOString()]);
+
+  return { data, isLoading, error };
+}

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -34,6 +34,7 @@ export function useUserDetails(
 
   const { data, isLoading, error } = useQuery<PaginatedUserDetailsResponse, Error>({
     queryKey: ['user-details', startISO, endISO, page, limit, search, source],
+    staleTime: 30 * 1000,
     queryFn: async () => {
       const API_BASE_URL = env.apiBaseUrl();
       const params = new URLSearchParams();

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -25,7 +25,11 @@ export function useUserDetails(
   search = '',
 ) {
   const startISO = startDate?.toISOString();
-  const endISO = endDate?.toISOString();
+  // Extend endDate to end of day (23:59:59.999) so the selected day is fully included.
+  // react-day-picker sets the date to midnight, which would exclude the entire selected day.
+  const endISO = endDate
+    ? new Date(endDate.getTime() + 24 * 60 * 60 * 1000 - 1).toISOString()
+    : undefined;
 
   const { data, isLoading, error } = useQuery<PaginatedUserDetailsResponse, Error>({
     queryKey: ['user-details', startISO, endISO, page, limit, search],

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -9,26 +9,46 @@ export interface UserDetail {
   totalQuestions: number;
 }
 
-export function useUserDetails(startDate?: Date, endDate?: Date) {
+export interface PaginatedUserDetailsResponse {
+  users: UserDetail[];
+  totalUsers: number;
+  totalPages: number;
+  activeUsers: number;
+  totalQuestions: number;
+}
+
+export function useUserDetails(
+  startDate?: Date,
+  endDate?: Date,
+  page = 1,
+  limit = 10,
+  search = '',
+) {
   const startISO = startDate?.toISOString();
   const endISO = endDate?.toISOString();
 
-  const { data, isLoading, error } = useQuery<UserDetail[], Error>({
-    queryKey: ['user-details', startISO, endISO],
+  const { data, isLoading, error } = useQuery<PaginatedUserDetailsResponse, Error>({
+    queryKey: ['user-details', startISO, endISO, page, limit, search],
     queryFn: async () => {
       const API_BASE_URL = env.apiBaseUrl();
       const params = new URLSearchParams();
       if (startISO) params.set('startDate', startISO);
       if (endISO) params.set('endDate', endISO);
-      const qs = params.toString();
+      params.set('page', String(page));
+      params.set('limit', String(limit));
+      if (search.trim()) params.set('search', search.trim());
 
-      const result = await apiFetch<UserDetail[]>(
-        `${API_BASE_URL}/analytics/user-details${qs ? `?${qs}` : ''}`,
+      const result = await apiFetch<PaginatedUserDetailsResponse>(
+        `${API_BASE_URL}/analytics/user-details?${params.toString()}`,
       );
 
-      return result ?? [];
+      return result ?? { users: [], totalUsers: 0, totalPages: 1, activeUsers: 0, totalQuestions: 0 };
     },
   });
 
-  return { data: data ?? [], isLoading, error };
+  return {
+    data: data ?? { users: [], totalUsers: 0, totalPages: 1, activeUsers: 0, totalQuestions: 0 },
+    isLoading,
+    error,
+  };
 }

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -23,6 +23,7 @@ export function useUserDetails(
   page = 1,
   limit = 10,
   search = '',
+  source: 'vicharanashala' | 'annam' = 'vicharanashala',
 ) {
   const startISO = startDate?.toISOString();
   // Extend endDate to end of day (23:59:59.999) so the selected day is fully included.
@@ -32,7 +33,7 @@ export function useUserDetails(
     : undefined;
 
   const { data, isLoading, error } = useQuery<PaginatedUserDetailsResponse, Error>({
-    queryKey: ['user-details', startISO, endISO, page, limit, search],
+    queryKey: ['user-details', startISO, endISO, page, limit, search, source],
     queryFn: async () => {
       const API_BASE_URL = env.apiBaseUrl();
       const params = new URLSearchParams();
@@ -41,6 +42,7 @@ export function useUserDetails(
       params.set('page', String(page));
       params.set('limit', String(limit));
       if (search.trim()) params.set('search', search.trim());
+      params.set('source', source);
 
       const result = await apiFetch<PaginatedUserDetailsResponse>(
         `${API_BASE_URL}/analytics/user-details?${params.toString()}`,


### PR DESCRIPTION
Description:                                   
                                                                          
  ## Summary                                                              
                                                 
  - Added `/analytics/user-details` backend endpoint with pagination,     
  search, and date range filtering                                        
  - Built `UserDetailsView` with summary cards (Total Users, Active Users,
   Total Questions), searchable farmer table, and date filter             
  - Migrated dashboard and user-details hooks to React Query to eliminate
  duplicate network calls                                                 
  - Fixed endDate off-by-one bug — selected end day was being excluded due
   to midnight UTC conversion; extended to end-of-day before passing to
  backend                                                                 
                                                                                                           
                                          