### PR TITLE
feat: add profile picture update

### DIFF
--- a/backend/src/modules/core/classes/validators/UserValidators.ts
+++ b/backend/src/modules/core/classes/validators/UserValidators.ts
@@ -144,6 +144,9 @@ class UpdateUserDto {
   @IsOptional()
   @IsEnum(['expert', 'moderator', 'admin'])
   role?: UserRole;
+  @IsOptional()
+  @IsString()
+  avatar?: string;
 }
 
 export {PreferenceDto, UsersNameResponseDto, UserDto,NotificationDeletePreferenceDTO,UpdatePenaltyAndIncentive,BlockUnblockBody,ExpertReviewLevelDto, UpdateUserDto};

--- a/backend/src/modules/core/services/UserService.ts
+++ b/backend/src/modules/core/services/UserService.ts
@@ -88,7 +88,7 @@ export class UserService extends BaseService {
     try {
       if (!userId) throw new NotFoundError('User ID is required');
 
-      if(!data.firstName.trim()) throw new BadRequestError("Firstname cannot be empty or blank space");
+      if(data.firstName !== undefined && !data.firstName.trim()) throw new BadRequestError("Firstname cannot be empty or blank space");
 
       const authService = getFromContainer(FirebaseAuthService);
 

--- a/frontend/src/routes/profile/index.tsx
+++ b/frontend/src/routes/profile/index.tsx
@@ -56,10 +56,12 @@ export default function ProfilePage() {
   const { data: user, isLoading } = useGetCurrentUser({});
   const { mutateAsync: updateUser, isPending: isUpdating } = useEditUser();
 
-  const handleSubmit = async (data: IUser) => {
+  const handleSubmit = async (data: IUser, showToast: boolean = true) => {
     try {
       await updateUser(data);
-      toast.success("Profile updated!");
+      if (showToast) {
+        toast.success("Profile updated!");
+      }
     } catch (error) {
       console.error(error);
     }
@@ -132,7 +134,7 @@ export default function ProfilePage() {
 
 type ProfileFormProps = {
   user: IUser;
-  onSubmit?: (data: IUser) => Promise<void> | void;
+  onSubmit?: (data: IUser, showToast?: boolean) => Promise<void> | void;
   isUpdating: boolean;
 };
 
@@ -172,6 +174,7 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
       userFromStore?.avatar || "",
     );
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
 
   const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -189,17 +192,19 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
       const base64 = reader.result as string;
       setAvatarPreview(base64);
       handleChange("avatar", base64);
+      setIsUploadingAvatar(true);
       try {
-        await onSubmit?.({ ...formData, avatar: base64 });
+        await onSubmit?.({ ...formData, avatar: base64 }, false);
         useAuthStore.getState().updateUser({ avatar: base64 });
         toast.success("Profile picture updated!");
       } catch (error) {
         toast.error("Failed to update profile picture");
+      } finally {
+        setIsUploadingAvatar(false);
       }
     };
     reader.readAsDataURL(file);
   };
-  
 
   const handleChange = useCallback((key: keyof IUser | string, value: any) => {
     if (key.startsWith("preference.")) {
@@ -427,8 +432,8 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
         <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 w-full md:w-auto">
           {/* Avatar */}
           <div
-            className="relative group cursor-pointer"
-            onClick={() => fileInputRef.current?.click()}
+              className={`relative group ${isUploadingAvatar ? "cursor-not-allowed opacity-70" : "cursor-pointer"}`}
+              onClick={() => !isUploadingAvatar && fileInputRef.current?.click()}
           >
             <Avatar className={`h-24 w-24 flex-shrink-0 ${avatarBg}`}>
               <AvatarImage src={avatarPreview || ""} alt={fullName} />

--- a/frontend/src/routes/profile/index.tsx
+++ b/frontend/src/routes/profile/index.tsx
@@ -17,7 +17,7 @@ import { useGetCurrentUser } from "@/hooks/api/user/useGetCurrentUser";
 import { useAuthStore } from "@/stores/auth-store";
 import type { IUser } from "@/types";
 import { createFileRoute } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { useCallback, useState, useRef } from "react";
 import { toast } from "sonner";
 import {
   Edit2,
@@ -35,6 +35,7 @@ import {
   Check,
   EyeOff,
   Eye,
+  Camera,
 } from "lucide-react";
 import {
   Dialog,
@@ -167,6 +168,38 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
 
   const [isEditMode, setIsEditMode] = useState(false);
   const { user: userFromStore } = useAuthStore();
+  const [avatarPreview, setAvatarPreview] = useState<string>(
+      userFromStore?.avatar || "",
+    );
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please select a valid image file");
+      return;
+    }
+    if (file.size > 2 * 1024 * 1024) {
+      toast.error("Image size must be less than 2MB");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onloadend = async () => {
+      const base64 = reader.result as string;
+      setAvatarPreview(base64);
+      handleChange("avatar", base64);
+      try {
+        await onSubmit?.({ ...formData, avatar: base64 });
+        useAuthStore.getState().updateUser({ avatar: base64 });
+        toast.success("Profile picture updated!");
+      } catch (error) {
+        toast.error("Failed to update profile picture");
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+  
 
   const handleChange = useCallback((key: keyof IUser | string, value: any) => {
     if (key.startsWith("preference.")) {
@@ -192,6 +225,9 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
         formData.preference.domain = "all";
       }
       await onSubmit?.(formData);
+      if (formData.avatar) {
+        useAuthStore.getState().updateUser({ avatar: formData.avatar });
+      }
       setIsEditMode(false);
     } catch (error) {
       console.error("Error while saving form data:", error);
@@ -390,12 +426,27 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
         {/* Avatar + Info */}
         <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6 w-full md:w-auto">
           {/* Avatar */}
-          <Avatar className={`h-24 w-24 flex-shrink-0 ${avatarBg}`}>
-            <AvatarImage src={userFromStore?.avatar || ""} alt={fullName} />
-            <AvatarFallback className="text-2xl font-semibold">
-              {getInitials()}
-            </AvatarFallback>
-          </Avatar>
+          <div
+            className="relative group cursor-pointer"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Avatar className={`h-24 w-24 flex-shrink-0 ${avatarBg}`}>
+              <AvatarImage src={avatarPreview || ""} alt={fullName} />
+              <AvatarFallback className="text-2xl font-semibold">
+                {getInitials()}
+              </AvatarFallback>
+            </Avatar>
+            <div className="absolute inset-0 bg-black/40 rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+              <Camera className="h-6 w-6 text-white" />
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleAvatarChange}
+            />
+          </div>
 
           {/* User Details */}
           <div className="space-y-2 text-center sm:text-left w-full">
@@ -413,10 +464,10 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
                 user.role === "expert"
                   ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
                   : user.role === "moderator"
-                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
-                  : user.role === "admin"
-                  ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
-                  : "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+                    ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+                    : user.role === "admin"
+                      ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+                      : "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
               }
             `}
                 >
@@ -431,7 +482,7 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
             </p>
 
             <p className="text-xs text-muted-foreground text-center sm:text-left">
-              Profile image is managed by your account provider
+              Click on the profile picture to update it
             </p>
           </div>
         </div>
@@ -890,7 +941,7 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
                         onChange={(e) =>
                           handlePasswordChange(
                             "currentPassword",
-                            e.target.value
+                            e.target.value,
                           )
                         }
                         className="pr-10"
@@ -963,7 +1014,7 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
                         onChange={(e) =>
                           handlePasswordChange(
                             "confirmPassword",
-                            e.target.value
+                            e.target.value,
                           )
                         }
                         className="pr-10"
@@ -1037,7 +1088,7 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
                           },
                           {
                             check: /[!@#$%^&*(),.?":{}|<>]/.test(
-                              passwordForm.newPassword
+                              passwordForm.newPassword,
                             ),
                             label: "Special chars",
                           },
@@ -1195,14 +1246,13 @@ const ProfileForm = ({ user, onSubmit, isUpdating }: ProfileFormProps) => {
                   type="button"
                   disabled={isUpdating}
                   className="flex items-center gap-2 w-full sm:w-auto"
-                  onClick={(e)=>{
-                      if(!formData.firstName.trim()){
-                        e.preventDefault();
-                        toast.error("First name cannot be blank space");
-                        return;
-                      }
+                  onClick={(e) => {
+                    if (!formData.firstName.trim()) {
+                      e.preventDefault();
+                      toast.error("First name cannot be blank space");
+                      return;
                     }
-                  }
+                  }}
                 >
                   <Save className="h-4 w-4" />
                   {isUpdating ? "Saving..." : "Save Changes"}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,6 +43,7 @@ export interface IUser {
   penaltyPercentage?: number;
   rankPosition?: number;
   status?: 'active' | 'in-active';
+  avatar?: string;
 }
 export interface ReviewLevelCount {
   Review_level: 'Author' | 'Level 1' | 'Level 2' | 'Level 3' | 'Level 4' | 'Level 5' | 'Level 6' | 'Level 7' | 'Level 8' | 'Level 9';


### PR DESCRIPTION
Added an option for users to update their profile picture from the profile settings page.

Changes:
- Added clickable avatar with camera hover effect
- Auto saves on image selection with base64 conversion
- Navbar updates immediately after upload
- Validations: image only, max 2MB