### PR TITLE
feat: special_task_force and special_task_force_moderator while listing

### DIFF
--- a/backend/src/modules/core/classes/validators/UserValidators.ts
+++ b/backend/src/modules/core/classes/validators/UserValidators.ts
@@ -48,6 +48,8 @@ class UserDto {
   isBlocked:boolean
 
   special_task_force:boolean
+  
+  special_task_force_moderator: boolean
 }
 
 // Main Response DTO

--- a/backend/src/modules/core/services/UserService.ts
+++ b/backend/src/modules/core/services/UserService.ts
@@ -202,7 +202,8 @@ async getAllUsersforManualSelect(
           penaltyPercentage: u.penalty ?? 0,
           createdAt: u.createdAt ?? null,
           isBlocked:u.isBlocked,
-          special_task_force:u.special_task_force
+          special_task_force: u.special_task_force,
+          special_task_force_moderator: u.special_task_force_moderator
         })),
         totalUsers: users.length,
         totalPages: 5,

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -28,6 +28,7 @@ export interface IUser {
   updatedAt?: Date;
   status?: UserStatus;
   special_task_force?:boolean
+  special_task_force_moderator?: boolean
 }
 
 export type IQuestionPriority = 'low' | 'medium' | 'high';

--- a/frontend/src/components/user-table.tsx
+++ b/frontend/src/components/user-table.tsx
@@ -17,7 +17,11 @@
       Trash,
       Unlock,
       Gavel,
-    } from "lucide-react";
+  Zap,
+  ShieldCheck,
+} from "lucide-react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "./atoms/tooltip";
 
     import { Pagination } from "./pagination";
     import type { IUser, UserRole } from "@/types";
@@ -351,7 +355,7 @@
 
           {/* User name */}
           <TableCell className="align-middle w-36" title={u.firstName}>
-            <div>
+            <div className="flex items-center justify-center gap-1">
               <span
                 className={"hover:underline hover:cursor-pointer"}
                 onClick={() => {
@@ -360,6 +364,38 @@
               >
                 {truncate(u.firstName + " " + u.lastName, 60)}
               </span>
+              <div className="flex items-center gap-1 flex-shrink-0">
+                {u?.special_task_force && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Badge 
+                        variant="outline"
+                        className="bg-indigo-50/50 hover:bg-indigo-50 text-indigo-700 border-indigo-200 text-[9px] h-5 px-1.5 rounded-full flex items-center gap-1 transition-colors whitespace-nowrap"
+                      >
+                        <Zap className="w-2.5 h-2.5 fill-indigo-500" />
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Special Task Force
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                {u?.special_task_force_moderator && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Badge 
+                        variant="outline"
+                        className="bg-purple-50/50 hover:bg-purple-50 text-purple-700 border-purple-200 text-[9px] h-5 px-1.5 rounded-full flex items-center gap-1 transition-colors whitespace-nowrap"
+                      >
+                        <ShieldCheck className="w-2.5 h-2.5 fill-purple-500" />
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Special Task Force Moderator
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
             </div>
           </TableCell>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,6 +43,8 @@ export interface IUser {
   penaltyPercentage?: number;
   rankPosition?: number;
   status?: 'active' | 'in-active';
+  special_task_force?: boolean;
+  special_task_force_moderator?: boolean
 }
 export interface ReviewLevelCount {
   Review_level: 'Author' | 'Level 1' | 'Level 2' | 'Level 3' | 'Level 4' | 'Level 5' | 'Level 6' | 'Level 7' | 'Level 8' | 'Level 9';


### PR DESCRIPTION
<img width="1920" height="914" alt="image" src="https://github.com/user-attachments/assets/42961ca1-8130-469a-8b9f-98b26e41b5b9" />

This PR introduces visual indicators for users with special roles (special_task_force and special_task_force_moderator).
Backend & Types:
Added special_task_force_moderator to the IUser interface
Updated User DTO/validators to include the new field
Updated user service mapping to send the field to frontend
Frontend Updates:
Added special_task_force and special_task_force_moderator to user type definitions
Introduced role indicators in Expert Management table