### PR TITLE
chore: moderator dashboard UI enhanced

### DIFF
--- a/frontend/src/components/HeatMap.tsx
+++ b/frontend/src/components/HeatMap.tsx
@@ -119,13 +119,16 @@ export default function HeatMap({ heatMapDate }: { heatMapDate: DateRange }) {
     return "bg-green-900 dark:bg-green-200"; // for 12+ bucket
   };
 
+  const truncate = (str: string, max = 18) =>
+  str.length > max ? str.slice(0, max) + "…" : str;
+
   return (
     <div className="  min-w-[80vw] border rounded-lg overflow-auto text-gray-900 dark:text-white">
       {/* This inner div must NOT be flex centered. It must be inline-block. */}
       <div className="min-w-[80vw] min-h-[450px] hidden md:block text-black dark:text-white">
         <ResponsiveHeatMap
           data={data}
-          margin={{ top: 60, right: 80, bottom: 60, left: 190 }}
+          margin={{ top: 60, right: 80, bottom: 60, left: 220 }}
           colors={{ type: "sequential", scheme: "greens" }}
           emptyColor="#f5f5f5"
           enableLabels={true}
@@ -189,7 +192,8 @@ export default function HeatMap({ heatMapDate }: { heatMapDate: DateRange }) {
             tickRotation: 0,
             legend: "Experts",
             legendPosition: "middle",
-            legendOffset: -150,
+            legendOffset: -190,
+            format: (value) => truncate(value),
           }}
           legends={[
             {

--- a/frontend/src/components/dashboard/approval-rate.tsx
+++ b/frontend/src/components/dashboard/approval-rate.tsx
@@ -39,7 +39,7 @@ export const ApprovalRateCard: React.FC<ApprovalRateCardProps> = ({ data }) => {
               <span className="text-2xl font-bold text-primary">
                 <CountUp
                   key={`approvalRate-${key}`}
-                  end={data.approvalRate}
+                  end={Math.floor(data.approvalRate)}
                   duration={2}
                   suffix="%"
                   preserveValue
@@ -51,7 +51,7 @@ export const ApprovalRateCard: React.FC<ApprovalRateCardProps> = ({ data }) => {
               className="h-full bg-gradient-to-r from-primary to-primary/70 rounded-full"
               key={`approvalRate-${key}`}
               initial={{ width: 0 }}
-              animate={{ width: `${data.approvalRate}%` }}
+              animate={{ width: `${Math.floor(data.approvalRate)}%` }}
               transition={{ duration: 1.2, ease: "easeInOut" }}
             />
             </div>


### PR DESCRIPTION
Previously approval rate was showing 100% even if it was just above 99% but not 100%
<img width="886" height="844" alt="approval rate before" src="https://github.com/user-attachments/assets/dcf5c428-c94a-4407-b5c4-b46930152f73" />

Added Math.floor for the value to be shown and render.
<img width="885" height="807" alt="approval rate after" src="https://github.com/user-attachments/assets/c6e169f1-4b96-418b-868b-0c9eb55e853a" />

Y  label "Experts" was overlapping with the names
<img width="829" height="847" alt="heatmap before" src="https://github.com/user-attachments/assets/81ac1bb6-2ec8-4b7e-aa32-e80c475b30be" />

Added some gap between name and label, also truncated the names as we can see full name through hovering on any row.
<img width="885" height="834" alt="heatmap after" src="https://github.com/user-attachments/assets/1f497704-568f-48d0-8534-f3f6fa128a9b" />
