### PR TITLE
Fixed the referenceId mismatch issue in the duplicate question collec…

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -990,7 +990,8 @@ export class QuestionService extends BaseService implements IQuestionService {
               answer: item.answer,
               agri_specialist: item.source || "AGRI_EXPERT",
               referenceSource: "reviewer",
-              score: item.score * 100
+              score: item.score * 100,
+              id: item.id  // preserve the real reviewer question _id
             })),
 
             ...(questions.golden || []).map((item: any) => ({
@@ -998,7 +999,8 @@ export class QuestionService extends BaseService implements IQuestionService {
               answer: item.answer,
               agri_specialist: item.metadata?.["Agri Specialist"] || "Unknown",
               referenceSource: "golden",
-              score: item.score * 100
+              score: item.score * 100,
+              id: new ObjectId().toString()
             })),
 
 
@@ -1007,7 +1009,6 @@ export class QuestionService extends BaseService implements IQuestionService {
             new Map(merged.map(q => [q.question, q])).values(),
           ).map(q => ({
             ...q,
-            id: new ObjectId().toString()
           }));
 
 
@@ -1019,7 +1020,7 @@ export class QuestionService extends BaseService implements IQuestionService {
 
           // convert to topMatches
           topSimilar = bestFive.map(q => ({
-            questionId: new ObjectId().toString(),
+            questionId: q.id,
             question: q.question,
             similarityScore: q.score,
             referenceSource: q.referenceSource

--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -1000,7 +1000,7 @@ export class QuestionService extends BaseService implements IQuestionService {
               agri_specialist: item.metadata?.["Agri Specialist"] || "Unknown",
               referenceSource: "golden",
               score: item.score * 100,
-              id: new ObjectId().toString()
+              id: item.id ? item.id : new ObjectId().toString()
             })),
 
 


### PR DESCRIPTION
When a question was flagged as a duplicate of a reviewer question, the referenceQuestionId stored in duplicate_questions was a randomly generated ID instead of the actual reviewer question's _id. The AI service returns the real id with each reviewer result, but it was being overwritten by new ObjectId() before being saved. Fixed by preserving item.id from the reviewer response throughout the pipeline.