### PR TITLE
Fix avg session duration logic and improve dashboard UI highlighting

### DIFF
--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -38,5 +38,7 @@ export interface IChatbotService {
   getWeeklyQueryCounts(source?: string): Promise<WeeklyQueryCountEntry[]>;
   getDailyUserTrend(days?: number, source?: string): Promise<DailyActiveUsersEntry[]>;
   getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string, source?: string): Promise<PaginatedUserDetails>;
+  getAvgSessionDurationV2(source?: string): Promise<number>;
+  getWeeklyAvgSessionDurationV2(weeks?: number, source?: string): Promise<WeeklySessionDurationEntry[]>;
 }
 

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -13,7 +13,7 @@ export class ChatbotService implements IChatbotService {
 
   async getDashboard(days = 30, source = 'vicharanashala'): Promise<DashboardResponse> {
     try {
-      const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, weeklySessionDuration, dailyQueries, todayQueryCount, weeklyQueries] =
+      const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, dailyQueries, todayQueryCount, weeklyQueries, avgSessionDurationMin, weeklySessionDuration] =
         await Promise.all([
           this.chatbotRepository.getKpiSummary(source),
           this.chatbotRepository.getDailyActiveUsers(days, source),
@@ -21,14 +21,18 @@ export class ChatbotService implements IChatbotService {
           this.chatbotRepository.getVoiceAccuracyByLanguage(source),
           this.chatbotRepository.getGeoDistribution(source),
           this.chatbotRepository.getQueryCategories(source),
-          this.chatbotRepository.getWeeklyAvgSessionDuration(Math.ceil(days / 7), source),
           this.chatbotRepository.getDailyQueryCounts(days, source),
           this.chatbotRepository.getTodayQueryCount(source),
           this.chatbotRepository.getWeeklyQueryCounts(source),
+          // V2: inactivity-gap based session duration replaces the old value from getKpiSummary
+          this.chatbotRepository.getAvgSessionDurationV2(source),
+          // V2: inactivity-gap based weekly breakdown replaces the old getWeeklyAvgSessionDuration
+          this.chatbotRepository.getWeeklyAvgSessionDurationV2(Math.ceil(days / 7), source),
         ]);
 
       return {
-        kpi: { ...kpi, dailyQueries: todayQueryCount },
+        // Override avgSessionDurationMin in the KPI with the V2 value
+        kpi: { ...kpi, dailyQueries: todayQueryCount, avgSessionDurationMin },
         dau,
         channelSplit,
         voiceAccuracy,
@@ -138,6 +142,22 @@ export class ChatbotService implements IChatbotService {
       return await this.chatbotRepository.getUserDetails(start, end, page, limit, search, source);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch user details: ${error}`);
+    }
+  }
+
+  async getAvgSessionDurationV2(source = 'vicharanashala') {
+    try {
+      return await this.chatbotRepository.getAvgSessionDurationV2(source);
+    } catch (error) {
+      throw new InternalServerError(`Failed to fetch avg session duration v2: ${error}`);
+    }
+  }
+
+  async getWeeklyAvgSessionDurationV2(weeks = 52, source = 'vicharanashala') {
+    try {
+      return await this.chatbotRepository.getWeeklyAvgSessionDurationV2(weeks, source);
+    } catch (error) {
+      throw new InternalServerError(`Failed to fetch weekly avg session duration v2: ${error}`);
     }
   }
 }

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -127,6 +127,16 @@ export interface IChatbotRepository {
   findMatchingMessages(data: {question: string; details: any; createdAt: Date; questionId: string});
   findFromSecondDb(data: {question: string; details: any; createdAt: Date; questionId: string});
 
+  /** Inactivity-gap based avg session duration in minutes (KPI number). Requires MongoDB 5.0+. */
+  getAvgSessionDurationV2(source?: string, session?: ClientSession): Promise<number>;
+
+  /** Inactivity-gap based weekly avg session duration for sparkline/delta. Requires MongoDB 5.0+. */
+  getWeeklyAvgSessionDurationV2(
+    weeks?: number,
+    source?: string,
+    session?: ClientSession,
+  ): Promise<WeeklySessionDurationEntry[]>;
+
   /** Get all users with their question counts, optionally filtered by date range, with server-side pagination. */
   getUserDetails(
     startDate?: Date,

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -115,96 +115,20 @@ export class ChatbotRepository implements IChatbotRepository {
             )
             .toArray(),
 
-          // ── CHANGED: Avg session duration (v2 — inactivity-gap approach) ────────
-          // ORIGINAL LOGIC (v0 — unreliable, conversations.updatedAt is a metadata
-          // timestamp touched by system events, not real user activity):
-          //
-          //   this.conversations.aggregate([
-          //     { $project: { durationMs: { $subtract: ['$updatedAt', '$createdAt'] } } },
-          //     { $group: { _id: null, avg: { $avg: '$durationMs' } } },
-          //   ], { session }).toArray()
-          //
-          // INTERMEDIATE ATTEMPT (v1 — also wrong: max - min of messages still
-          // counts idle time, e.g. user asks at 9 AM, comes back 5 hrs later in
-          // the same conversation → reported as a 5-hour session):
-          //
-          //   this.messagesCollection.aggregate([
-          //     { $group: { _id: '$conversationId', firstMsg: { $min: '$createdAt' },
-          //                 lastMsg: { $max: '$createdAt' }, msgCount: { $sum: 1 } } },
-          //     { $match: { msgCount: { $gt: 1 } } },
-          //     { $addFields: { durationMs: { $max: [0, { $subtract: ['$lastMsg', '$firstMsg'] }] } } },
-          //     { $group: { _id: null, avg: { $avg: '$durationMs' } } },
-          //   ], { session }).toArray()
-          //
-          // CURRENT LOGIC (v2 — inactivity-gap detection, requires MongoDB 5.0+):
-          // Sort messages per conversation by time, compute the gap between each
-          // consecutive pair. If gap > 30 min (INACTIVITY_THRESHOLD_MS) the user
-          // was away — skip that gap. Sum only the "active" gaps per conversation,
-          // then average across all conversations. This gives true engagement time.
-          this.messagesCollection
+          // Avg session duration from conversations (original logic — untouched)
+          this.conversations
             .aggregate(
               [
-                // Step 1: sort messages within each conversation by time
-                // ($setWindowFields requires a sort; we also need $sort before it
-                //  so that $shift looks at the chronologically previous message)
-                {$sort: {conversationId: 1, createdAt: 1}},
-                // Step 2: for each message, pull in the previous message's createdAt
-                // within the same conversation (lag by 1 position)
                 {
-                  $setWindowFields: {
-                    partitionBy: '$conversationId',
-                    sortBy: {createdAt: 1},
-                    output: {
-                      prevCreatedAt: {
-                        $shift: {output: '$createdAt', by: -1},
-                      },
-                    },
+                  $project: {
+                    durationMs: {$subtract: ['$updatedAt', '$createdAt']},
                   },
                 },
-                // Step 3: compute the gap from the previous message.
-                // First message in each conversation has no prev → gap = 0.
-                // INACTIVITY_THRESHOLD_MS = 30 minutes = 1,800,000 ms
-                {
-                  $addFields: {
-                    gapMs: {
-                      $cond: [
-                        {$ifNull: ['$prevCreatedAt', false]},
-                        {$subtract: ['$createdAt', '$prevCreatedAt']},
-                        0,
-                      ],
-                    },
-                  },
-                },
-                // Step 4: only keep gaps within the inactivity threshold.
-                // Gaps > 30 min mean the user walked away — don't count them.
-                {
-                  $addFields: {
-                    activeGapMs: {
-                      $cond: [
-                        {$lte: ['$gapMs', 1800000]},
-                        '$gapMs',
-                        0,
-                      ],
-                    },
-                  },
-                },
-                // Step 5: sum active gaps per conversation + count messages
-                {
-                  $group: {
-                    _id: '$conversationId',
-                    activeSessionMs: {$sum: '$activeGapMs'},
-                    msgCount: {$sum: 1},
-                  },
-                },
-                // Step 6: skip single-message conversations (no gaps at all)
-                {$match: {msgCount: {$gt: 1}}},
-                // Step 7: average real session time across all conversations
-                {$group: {_id: null, avg: {$avg: '$activeSessionMs'}}},
+                {$group: {_id: null, avg: {$avg: '$durationMs'}}},
               ],
               {session},
             )
             .toArray(),
-          // ── END CHANGED ───────────────────────────────────────────────────────
 
           // Today's query count from messages
           this.getTodayQueryCount(source, session),
@@ -309,99 +233,22 @@ export class ChatbotRepository implements IChatbotRepository {
       const since = new Date();
       since.setDate(since.getDate() - weeks * 7);
 
-      // ── CHANGED: Weekly avg session duration (v2 — inactivity-gap approach) ──
-      // ORIGINAL LOGIC (v0 — used conversations.updatedAt - createdAt, skewed
-      // by system-level metadata updates):
-      //
-      //   const result = await this.conversations.aggregate([
-      //     { $match: { createdAt: { $gte: since } } },
-      //     { $addFields: { durationMs: { $max: [0, { $subtract: ['$updatedAt', '$createdAt'] }] } } },
-      //     { $group: { _id: { $dateToString: { format: '%G-W%V', date: '$createdAt' } }, avgDurationMs: { $avg: '$durationMs' } } },
-      //     { $project: { week: '$_id', avgSessionDurationMin: { $round: [{ $divide: ['$avgDurationMs', 60000] }, 1] }, _id: 0 } },
-      //     { $sort: { week: 1 } },
-      //   ], { session }).toArray();
-      //
-      // INTERMEDIATE ATTEMPT (v1 — max - min of messages per conversation,
-      // still wrong because idle time within a conversation inflates duration):
-      //
-      //   messages → group by conversationId → max(createdAt) - min(createdAt) → avg per week
-      //
-      // CURRENT LOGIC (v2 — inactivity-gap detection, requires MongoDB 5.0+):
-      // Same gap-detection logic as getKpiSummary, but after computing each
-      // conversation's real active duration we bucket it into its ISO week
-      // (based on the first message of that conversation) and average per week.
-      const result = await this.messagesCollection
+      // Original logic — untouched
+      const result = await this.conversations
         .aggregate(
           [
-            // Only look at messages within the requested window
             {$match: {createdAt: {$gte: since}}},
-            // Step 1: sort messages within each conversation by time
-            {$sort: {conversationId: 1, createdAt: 1}},
-            // Step 2: pull in the previous message's createdAt (lag) per conversation
-            {
-              $setWindowFields: {
-                partitionBy: '$conversationId',
-                sortBy: {createdAt: 1},
-                output: {
-                  prevCreatedAt: {
-                    $shift: {output: '$createdAt', by: -1},
-                  },
-                  // also carry forward the first message time for week bucketing
-                  firstMsgInConv: {
-                    $first: '$createdAt',
-                    window: {documents: ['unbounded', 'current']},
-                  },
-                },
-              },
-            },
-            // Step 3: compute gap; cap at 0 for the first message (no prev)
             {
               $addFields: {
-                gapMs: {
-                  $cond: [
-                    {$ifNull: ['$prevCreatedAt', false]},
-                    {$subtract: ['$createdAt', '$prevCreatedAt']},
-                    0,
-                  ],
+                durationMs: {
+                  $max: [0, {$subtract: ['$updatedAt', '$createdAt']}],
                 },
               },
             },
-            // Step 4: discard gaps > 30 min (user was idle/away)
-            {
-              $addFields: {
-                activeGapMs: {
-                  $cond: [{$lte: ['$gapMs', 1800000]}, '$gapMs', 0],
-                },
-              },
-            },
-            // Step 5: sum active gaps per conversation; keep firstMsgInConv for week
             {
               $group: {
-                _id: '$conversationId',
-                activeSessionMs: {$sum: '$activeGapMs'},
-                firstMsg: {$min: '$firstMsgInConv'},
-                msgCount: {$sum: 1},
-              },
-            },
-            // Step 6: skip single-message conversations
-            {$match: {msgCount: {$gt: 1}}},
-            // Step 7: assign each conversation to its ISO week (IST timezone)
-            {
-              $addFields: {
-                week: {
-                  $dateToString: {
-                    format: '%G-W%V',
-                    date: '$firstMsg',
-                    timezone: '+05:30',
-                  },
-                },
-              },
-            },
-            // Step 8: average real session time per week
-            {
-              $group: {
-                _id: '$week',
-                avgDurationMs: {$avg: '$activeSessionMs'},
+                _id: {$dateToString: {format: '%G-W%V', date: '$createdAt'}},
+                avgDurationMs: {$avg: '$durationMs'},
               },
             },
             {
@@ -418,7 +265,6 @@ export class ChatbotRepository implements IChatbotRepository {
           {session},
         )
         .toArray();
-      // ── END CHANGED ───────────────────────────────────────────────────────────
 
       return result as WeeklySessionDurationEntry[];
     } catch (error) {
@@ -845,6 +691,165 @@ export class ChatbotRepository implements IChatbotRepository {
       };
     } catch (error) {
       throw new InternalServerError(`Failed to get user details: ${error}`);
+    }
+  }
+
+  // ── NEW: Inactivity-gap based avg session duration (KPI number) ──────────────
+  // Uses the messages collection instead of conversations.
+  // For each conversation: sums only the gaps between consecutive messages that
+  // are ≤ 30 minutes. Gaps > 30 min are treated as the user being away and are
+  // excluded. Single-message conversations are also excluded.
+  // Requires MongoDB 5.0+ ($setWindowFields).
+  async getAvgSessionDurationV2(source = 'vicharanashala', session?: ClientSession): Promise<number> {
+    try {
+      await this.init(source);
+
+      const result = await this.messagesCollection
+        .aggregate(
+          [
+            {$sort: {conversationId: 1, createdAt: 1}},
+            {
+              $setWindowFields: {
+                partitionBy: '$conversationId',
+                sortBy: {createdAt: 1},
+                output: {
+                  prevCreatedAt: {$shift: {output: '$createdAt', by: -1}},
+                },
+              },
+            },
+            {
+              $addFields: {
+                gapMs: {
+                  $cond: [
+                    {$ifNull: ['$prevCreatedAt', false]},
+                    {$subtract: ['$createdAt', '$prevCreatedAt']},
+                    0,
+                  ],
+                },
+              },
+            },
+            // Discard gaps > 30 minutes (1,800,000 ms) — user was idle/away
+            {
+              $addFields: {
+                activeGapMs: {
+                  $cond: [{$lte: ['$gapMs', 1800000]}, '$gapMs', 0],
+                },
+              },
+            },
+            {
+              $group: {
+                _id: '$conversationId',
+                activeSessionMs: {$sum: '$activeGapMs'},
+                msgCount: {$sum: 1},
+              },
+            },
+            // Skip conversations with only 1 message — no gaps, nothing to measure
+            {$match: {msgCount: {$gt: 1}}},
+            {$group: {_id: null, avg: {$avg: '$activeSessionMs'}}},
+          ],
+          {session},
+        )
+        .toArray();
+
+      const avgMs = result[0]?.avg ?? 0;
+      return Math.round((avgMs / 60000) * 10) / 10;
+    } catch (error) {
+      throw new InternalServerError(`Failed to get avg session duration v2: ${error}`);
+    }
+  }
+
+  // ── NEW: Inactivity-gap based weekly avg session duration (sparkline/delta) ──
+  // Same gap-detection logic as getAvgSessionDurationV2, but groups results by
+  // ISO week (based on the first message of each conversation) so the frontend
+  // can render the sparkline and week-over-week % delta.
+  async getWeeklyAvgSessionDurationV2(weeks = 52, source = 'vicharanashala', session?: ClientSession): Promise<WeeklySessionDurationEntry[]> {
+    try {
+      await this.init(source);
+
+      const since = new Date();
+      since.setDate(since.getDate() - weeks * 7);
+
+      const result = await this.messagesCollection
+        .aggregate(
+          [
+            {$match: {createdAt: {$gte: since}}},
+            {$sort: {conversationId: 1, createdAt: 1}},
+            {
+              $setWindowFields: {
+                partitionBy: '$conversationId',
+                sortBy: {createdAt: 1},
+                output: {
+                  prevCreatedAt: {$shift: {output: '$createdAt', by: -1}},
+                  firstMsgInConv: {
+                    $first: '$createdAt',
+                    window: {documents: ['unbounded', 'current']},
+                  },
+                },
+              },
+            },
+            {
+              $addFields: {
+                gapMs: {
+                  $cond: [
+                    {$ifNull: ['$prevCreatedAt', false]},
+                    {$subtract: ['$createdAt', '$prevCreatedAt']},
+                    0,
+                  ],
+                },
+              },
+            },
+            // Discard gaps > 30 minutes (1,800,000 ms) — user was idle/away
+            {
+              $addFields: {
+                activeGapMs: {
+                  $cond: [{$lte: ['$gapMs', 1800000]}, '$gapMs', 0],
+                },
+              },
+            },
+            {
+              $group: {
+                _id: '$conversationId',
+                activeSessionMs: {$sum: '$activeGapMs'},
+                firstMsg: {$min: '$firstMsgInConv'},
+                msgCount: {$sum: 1},
+              },
+            },
+            {$match: {msgCount: {$gt: 1}}},
+            {
+              $addFields: {
+                week: {
+                  $dateToString: {
+                    format: '%G-W%V',
+                    date: '$firstMsg',
+                    timezone: '+05:30',
+                  },
+                },
+              },
+            },
+            {
+              $group: {
+                _id: '$week',
+                avgDurationMs: {$avg: '$activeSessionMs'},
+              },
+            },
+            {
+              $project: {
+                week: '$_id',
+                avgSessionDurationMin: {
+                  $round: [{$divide: ['$avgDurationMs', 60000]}, 1],
+                },
+                _id: 0,
+              },
+            },
+            {$sort: {week: 1}},
+          ],
+          {session},
+        )
+        .toArray();
+
+      return result as WeeklySessionDurationEntry[];
+    } catch (error) {
+      throw new InternalServerError(`Failed to get weekly avg session duration v2: ${error}`);
     }
   }
 }

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -115,20 +115,96 @@ export class ChatbotRepository implements IChatbotRepository {
             )
             .toArray(),
 
-          // Avg session duration from conversations
-          this.conversations
+          // ── CHANGED: Avg session duration (v2 — inactivity-gap approach) ────────
+          // ORIGINAL LOGIC (v0 — unreliable, conversations.updatedAt is a metadata
+          // timestamp touched by system events, not real user activity):
+          //
+          //   this.conversations.aggregate([
+          //     { $project: { durationMs: { $subtract: ['$updatedAt', '$createdAt'] } } },
+          //     { $group: { _id: null, avg: { $avg: '$durationMs' } } },
+          //   ], { session }).toArray()
+          //
+          // INTERMEDIATE ATTEMPT (v1 — also wrong: max - min of messages still
+          // counts idle time, e.g. user asks at 9 AM, comes back 5 hrs later in
+          // the same conversation → reported as a 5-hour session):
+          //
+          //   this.messagesCollection.aggregate([
+          //     { $group: { _id: '$conversationId', firstMsg: { $min: '$createdAt' },
+          //                 lastMsg: { $max: '$createdAt' }, msgCount: { $sum: 1 } } },
+          //     { $match: { msgCount: { $gt: 1 } } },
+          //     { $addFields: { durationMs: { $max: [0, { $subtract: ['$lastMsg', '$firstMsg'] }] } } },
+          //     { $group: { _id: null, avg: { $avg: '$durationMs' } } },
+          //   ], { session }).toArray()
+          //
+          // CURRENT LOGIC (v2 — inactivity-gap detection, requires MongoDB 5.0+):
+          // Sort messages per conversation by time, compute the gap between each
+          // consecutive pair. If gap > 30 min (INACTIVITY_THRESHOLD_MS) the user
+          // was away — skip that gap. Sum only the "active" gaps per conversation,
+          // then average across all conversations. This gives true engagement time.
+          this.messagesCollection
             .aggregate(
               [
+                // Step 1: sort messages within each conversation by time
+                // ($setWindowFields requires a sort; we also need $sort before it
+                //  so that $shift looks at the chronologically previous message)
+                {$sort: {conversationId: 1, createdAt: 1}},
+                // Step 2: for each message, pull in the previous message's createdAt
+                // within the same conversation (lag by 1 position)
                 {
-                  $project: {
-                    durationMs: {$subtract: ['$updatedAt', '$createdAt']},
+                  $setWindowFields: {
+                    partitionBy: '$conversationId',
+                    sortBy: {createdAt: 1},
+                    output: {
+                      prevCreatedAt: {
+                        $shift: {output: '$createdAt', by: -1},
+                      },
+                    },
                   },
                 },
-                {$group: {_id: null, avg: {$avg: '$durationMs'}}},
+                // Step 3: compute the gap from the previous message.
+                // First message in each conversation has no prev → gap = 0.
+                // INACTIVITY_THRESHOLD_MS = 30 minutes = 1,800,000 ms
+                {
+                  $addFields: {
+                    gapMs: {
+                      $cond: [
+                        {$ifNull: ['$prevCreatedAt', false]},
+                        {$subtract: ['$createdAt', '$prevCreatedAt']},
+                        0,
+                      ],
+                    },
+                  },
+                },
+                // Step 4: only keep gaps within the inactivity threshold.
+                // Gaps > 30 min mean the user walked away — don't count them.
+                {
+                  $addFields: {
+                    activeGapMs: {
+                      $cond: [
+                        {$lte: ['$gapMs', 1800000]},
+                        '$gapMs',
+                        0,
+                      ],
+                    },
+                  },
+                },
+                // Step 5: sum active gaps per conversation + count messages
+                {
+                  $group: {
+                    _id: '$conversationId',
+                    activeSessionMs: {$sum: '$activeGapMs'},
+                    msgCount: {$sum: 1},
+                  },
+                },
+                // Step 6: skip single-message conversations (no gaps at all)
+                {$match: {msgCount: {$gt: 1}}},
+                // Step 7: average real session time across all conversations
+                {$group: {_id: null, avg: {$avg: '$activeSessionMs'}}},
               ],
               {session},
             )
             .toArray(),
+          // ── END CHANGED ───────────────────────────────────────────────────────
 
           // Today's query count from messages
           this.getTodayQueryCount(source, session),
@@ -233,21 +309,99 @@ export class ChatbotRepository implements IChatbotRepository {
       const since = new Date();
       since.setDate(since.getDate() - weeks * 7);
 
-      const result = await this.conversations
+      // ── CHANGED: Weekly avg session duration (v2 — inactivity-gap approach) ──
+      // ORIGINAL LOGIC (v0 — used conversations.updatedAt - createdAt, skewed
+      // by system-level metadata updates):
+      //
+      //   const result = await this.conversations.aggregate([
+      //     { $match: { createdAt: { $gte: since } } },
+      //     { $addFields: { durationMs: { $max: [0, { $subtract: ['$updatedAt', '$createdAt'] }] } } },
+      //     { $group: { _id: { $dateToString: { format: '%G-W%V', date: '$createdAt' } }, avgDurationMs: { $avg: '$durationMs' } } },
+      //     { $project: { week: '$_id', avgSessionDurationMin: { $round: [{ $divide: ['$avgDurationMs', 60000] }, 1] }, _id: 0 } },
+      //     { $sort: { week: 1 } },
+      //   ], { session }).toArray();
+      //
+      // INTERMEDIATE ATTEMPT (v1 — max - min of messages per conversation,
+      // still wrong because idle time within a conversation inflates duration):
+      //
+      //   messages → group by conversationId → max(createdAt) - min(createdAt) → avg per week
+      //
+      // CURRENT LOGIC (v2 — inactivity-gap detection, requires MongoDB 5.0+):
+      // Same gap-detection logic as getKpiSummary, but after computing each
+      // conversation's real active duration we bucket it into its ISO week
+      // (based on the first message of that conversation) and average per week.
+      const result = await this.messagesCollection
         .aggregate(
           [
+            // Only look at messages within the requested window
             {$match: {createdAt: {$gte: since}}},
+            // Step 1: sort messages within each conversation by time
+            {$sort: {conversationId: 1, createdAt: 1}},
+            // Step 2: pull in the previous message's createdAt (lag) per conversation
             {
-              $addFields: {
-                durationMs: {
-                  $max: [0, {$subtract: ['$updatedAt', '$createdAt']}],
+              $setWindowFields: {
+                partitionBy: '$conversationId',
+                sortBy: {createdAt: 1},
+                output: {
+                  prevCreatedAt: {
+                    $shift: {output: '$createdAt', by: -1},
+                  },
+                  // also carry forward the first message time for week bucketing
+                  firstMsgInConv: {
+                    $first: '$createdAt',
+                    window: {documents: ['unbounded', 'current']},
+                  },
                 },
               },
             },
+            // Step 3: compute gap; cap at 0 for the first message (no prev)
+            {
+              $addFields: {
+                gapMs: {
+                  $cond: [
+                    {$ifNull: ['$prevCreatedAt', false]},
+                    {$subtract: ['$createdAt', '$prevCreatedAt']},
+                    0,
+                  ],
+                },
+              },
+            },
+            // Step 4: discard gaps > 30 min (user was idle/away)
+            {
+              $addFields: {
+                activeGapMs: {
+                  $cond: [{$lte: ['$gapMs', 1800000]}, '$gapMs', 0],
+                },
+              },
+            },
+            // Step 5: sum active gaps per conversation; keep firstMsgInConv for week
             {
               $group: {
-                _id: {$dateToString: {format: '%G-W%V', date: '$createdAt'}},
-                avgDurationMs: {$avg: '$durationMs'},
+                _id: '$conversationId',
+                activeSessionMs: {$sum: '$activeGapMs'},
+                firstMsg: {$min: '$firstMsgInConv'},
+                msgCount: {$sum: 1},
+              },
+            },
+            // Step 6: skip single-message conversations
+            {$match: {msgCount: {$gt: 1}}},
+            // Step 7: assign each conversation to its ISO week (IST timezone)
+            {
+              $addFields: {
+                week: {
+                  $dateToString: {
+                    format: '%G-W%V',
+                    date: '$firstMsg',
+                    timezone: '+05:30',
+                  },
+                },
+              },
+            },
+            // Step 8: average real session time per week
+            {
+              $group: {
+                _id: '$week',
+                avgDurationMs: {$avg: '$activeSessionMs'},
               },
             },
             {
@@ -264,6 +418,7 @@ export class ChatbotRepository implements IChatbotRepository {
           {session},
         )
         .toArray();
+      // ── END CHANGED ───────────────────────────────────────────────────────────
 
       return result as WeeklySessionDurationEntry[];
     } catch (error) {

--- a/frontend/src/components/play-ground.tsx
+++ b/frontend/src/components/play-ground.tsx
@@ -401,11 +401,23 @@ export const PlaygroundPage = () => {
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="start">
-                      <DropdownMenuItem onClick={() => { setChatbotSource('vicharanashala'); handleTabChange('chatbotanalytics'); }}>
+                      <DropdownMenuItem
+                        onClick={() => { setChatbotSource('vicharanashala'); handleTabChange('chatbotanalytics'); }}
+                        className={activeTab === 'chatbotanalytics' && chatbotSource === 'vicharanashala' ? 'bg-primary/10 text-primary font-medium' : ''}
+                      >
                         Vicharanashala
+                        {activeTab === 'chatbotanalytics' && chatbotSource === 'vicharanashala' && (
+                          <span className="ml-auto w-1.5 h-1.5 rounded-full bg-primary" />
+                        )}
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => { setChatbotSource('annam'); handleTabChange('chatbotanalytics'); }}>
+                      <DropdownMenuItem
+                        onClick={() => { setChatbotSource('annam'); handleTabChange('chatbotanalytics'); }}
+                        className={activeTab === 'chatbotanalytics' && chatbotSource === 'annam' ? 'bg-primary/10 text-primary font-medium' : ''}
+                      >
                         Annam
+                        {activeTab === 'chatbotanalytics' && chatbotSource === 'annam' && (
+                          <span className="ml-auto w-1.5 h-1.5 rounded-full bg-primary" />
+                        )}
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>


### PR DESCRIPTION
Updated the logic for calculating average session duration:
Now based on actual message activity instead of conversation timestamps
Ignores gaps greater than 30 minutes to ensure accurate active session tracking
Added UI improvements:
Fixed dashboard highlighting to clearly indicate the selected section