### PR TITLE
fix: correct review-level filter to show only in-review questions

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -585,14 +585,18 @@ export class QuestionRepository implements IQuestionRepository {
         if (!isNaN(numericLevel)) {
           let requiredSize = numericLevel + 1;
 
-          // Special rule: Level 1 → history.length = 0
-            if (numericLevel === 0) {
-      requiredSize = 0;
-    }
+          // Special rule: Level 0 (Author) → history.length = 0
+          if (numericLevel === 0) {
+            requiredSize = 0;
+          }
 
-          const submissions = await this.QuestionSubmissionCollection.find({
-            history: { $size: requiredSize },
-          })
+          const submissionQuery: any = { history: { $size: requiredSize } };
+          // For levels > 0, only include submissions where the current level is still in-review
+          if (numericLevel > 0) {
+            submissionQuery[`history.${numericLevel}.status`] = 'in-review';
+          }
+
+          const submissions = await this.QuestionSubmissionCollection.find(submissionQuery)
             .project({ questionId: 1 })
             .toArray();
 


### PR DESCRIPTION
Fixed the review-level filter logic to ensure only questions with
"in-review" status are displayed when the corresponding filter is selected.
Improves accuracy and consistency of moderator view.