### PR TITLE
Add Sorting Support for Question Details Columns

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -765,9 +765,12 @@ export class QuestionRepository implements IQuestionRepository {
       // Determine sort order
       let sortStage: any = { createdAt: -1, _id: -1 };
       let needsPriorityMapping = false;
+      let needsReviewLevelSort = false;
 
       if (sort) {
-        const [field, order] = sort.split('_');
+        const lastUnderscore = sort.lastIndexOf('_');
+        const field = lastUnderscore === -1 ? sort : sort.slice(0, lastUnderscore);
+        const order = lastUnderscore === -1 ? 'desc' : sort.slice(lastUnderscore + 1);
         const sortOrder = order === 'asc' ? 1 : -1;
 
         if (field === 'question') {
@@ -781,6 +784,15 @@ export class QuestionRepository implements IQuestionRepository {
         } else if (field === 'priority') {
           needsPriorityMapping = true;
           sortStage = { priorityOrder: sortOrder, _id: -1 };
+        } else if (field === 'status') {
+          sortStage = { status: sortOrder, _id: -1 };
+        } else if (field === 'answers') {
+          sortStage = { totalAnswersCount: sortOrder, _id: -1 };
+        } else if (field === 'created') {
+          sortStage = { createdAt: sortOrder, _id: -1 };
+        } else if (field === 'review_level') {
+          needsReviewLevelSort = true;
+          sortStage = { review_level_sort_value: sortOrder, _id: -1 };
         }
       }
 
@@ -817,6 +829,45 @@ export class QuestionRepository implements IQuestionRepository {
             },
           },
         });
+      }
+
+      if (needsReviewLevelSort) {
+        aggregationPipeline.push(
+          {
+            $lookup: {
+              from: 'question_submissions',
+              localField: '_id',
+              foreignField: 'questionId',
+              as: 'submissionData',
+            },
+          },
+          {
+            $addFields: {
+              review_level_sort_value: {
+                $let: {
+                  vars: {
+                    len: {
+                      $cond: {
+                        if: { $gt: [{ $size: '$submissionData' }, 0] },
+                        then: {
+                          $size: { $arrayElemAt: ['$submissionData.history', 0] },
+                        },
+                        else: 0,
+                      },
+                    },
+                  },
+                  in: {
+                    $cond: {
+                      if: { $lte: ['$$len', 1] },
+                      then: 0,
+                      else: { $subtract: ['$$len', 1] },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        );
       }
 
       aggregationPipeline.push(
@@ -890,6 +941,7 @@ export class QuestionRepository implements IQuestionRepository {
             embedding: 0,
             contextDoc: 0,
             priorityOrder: 0,
+            review_level_sort_value: 0,
           },
         },
       ]).toArray();

--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -792,7 +792,7 @@ export class QuestionRepository implements IQuestionRepository {
           needsPriorityMapping = true;
           sortStage = { statusOrder: 1, priorityOrder: sortOrder, _id: -1 };
         } else if (field === 'status') {
-          sortStage = { statusOrder: 1, status: sortOrder, _id: -1 };
+          sortStage = { statusOrder: sortOrder, _id: -1 };
         } else if (field === 'answers') {
           sortStage = { statusOrder: 1, totalAnswersCount: sortOrder, _id: -1 };
         } else if (field === 'created') {
@@ -818,13 +818,22 @@ export class QuestionRepository implements IQuestionRepository {
 
       const aggregationPipeline: any[] = [
         { $match: filter },
-        { 
-          $addFields: { 
-            statusOrder: { 
-              $cond: { if: { $eq: [{ $toLower: '$status' }, 'closed'] }, then: 1, else: 0 } 
-            } 
-          } 
-        }
+        {
+          $addFields: {
+            statusOrder: {
+              $switch: {
+                branches: [
+                  { case: { $eq: [{ $toLower: '$status' }, 'open'] }, then: 1 },
+                  { case: { $eq: [{ $toLower: '$status' }, 'delayed'] }, then: 2 },
+                  { case: { $eq: [{ $toLower: '$status' }, 're-routed'] }, then: 3 },
+                  { case: { $eq: [{ $toLower: '$status' }, 'in-review'] }, then: 4 },
+                  { case: { $eq: [{ $toLower: '$status' }, 'closed'] }, then: 5 },
+                ],
+                default: 6,
+              },
+            },
+          },
+        },
       ];
 
       // Add priority mapping if needed

--- a/frontend/src/features/question-table-page/questions-table.tsx
+++ b/frontend/src/features/question-table-page/questions-table.tsx
@@ -389,16 +389,68 @@ export const QuestionsTable = ({
                     <TableHead className="text-center">Source</TableHead>
                   )}
                   {visibleColumns.status && (
-                    <TableHead className="text-center">Status</TableHead>
+                    <TableHead className="text-center">
+                      <button
+                        onClick={() => onSort?.("status")}
+                        className="flex items-center gap-1 mx-auto select-none"
+                      >
+                        Status
+                        {sort === "status_asc" && (
+                          <span className="text-sm font-medium">↑</span>
+                        )}
+                        {sort === "status_desc" && (
+                          <span className="text-sm font-medium">↓</span>
+                        )}
+                      </button>
+                    </TableHead>
                   )}
                   {visibleColumns.answers && (
-                    <TableHead className="text-center">Answers</TableHead>
+                    <TableHead className="text-center">
+                      <button
+                        onClick={() => onSort?.("answers")}
+                        className="flex items-center gap-1 mx-auto select-none"
+                      >
+                        Answers
+                        {sort === "answers_asc" && (
+                          <span className="text-sm font-medium">↑</span>
+                        )}
+                        {sort === "answers_desc" && (
+                          <span className="text-sm font-medium">↓</span>
+                        )}
+                      </button>
+                    </TableHead>
                   )}
                   {visibleColumns.review_level && (
-                    <TableHead className="text-center">Review Level</TableHead>
+                    <TableHead className="text-center">
+                      <button
+                        onClick={() => onSort?.("review_level")}
+                        className="flex items-center gap-1 mx-auto select-none"
+                      >
+                        Review Level
+                        {sort === "review_level_asc" && (
+                          <span className="text-sm font-medium">↑</span>
+                        )}
+                        {sort === "review_level_desc" && (
+                          <span className="text-sm font-medium">↓</span>
+                        )}
+                      </button>
+                    </TableHead>
                   )}
                   {!showClosedAt && visibleColumns.created ? (
-                    <TableHead className="text-center">Created</TableHead>
+                    <TableHead className="text-center">
+                      <button
+                        onClick={() => onSort?.("created")}
+                        className="flex items-center gap-1 mx-auto select-none"
+                      >
+                        Created
+                        {sort === "created_asc" && (
+                          <span className="text-sm font-medium">↑</span>
+                        )}
+                        {sort === "created_desc" && (
+                          <span className="text-sm font-medium">↓</span>
+                        )}
+                      </button>
+                    </TableHead>
                   ) : null}
                   {showClosedAt && visibleColumns.closed ? (
                     <TableHead className="text-center">Closed</TableHead>


### PR DESCRIPTION
## Description
This PR introduces sorting functionality for key columns in the **Question Details** table, improving usability and clarity for users reviewing questions.

### Frontend (`questions-table.tsx`)
- Added clickable header buttons for the following columns:
  - **Status**
  - **Answers**
  - **Review Level**
  - **Created**
- Implemented ascending/descending arrow indicators to reflect the current sort state.
- Enabled smooth toggling between sort directions with clear visual feedback.

### Backend (`QuestionRepository.ts`)
- Extended backend sort parsing to support:
  - `status`
  - `answers`
  - `created`
  - `review_level`
- Added server-side review level sort support by computing review-level sort values before paging.

## Result
Users can now:
- Click on column headers to sort by **Status**, **Answers**, **Review Level**, or **Created**.
- Toggle between ascending and descending order with intuitive arrow indicators.
- Benefit from consistent server-side sorting, including computed values for review level.