### PR TITLE
 feat: show farmer profile details in chatbot analytics     user details table  

### DIFF
--- a/backend/src/modules/chatbot/classes/validators/ChatbotResponseValidators.ts
+++ b/backend/src/modules/chatbot/classes/validators/ChatbotResponseValidators.ts
@@ -297,6 +297,14 @@ export class UserDetailEntryResponse {
   })
   @IsNumber()
   totalQuestions: number;
+
+  @JSONSchema({
+    description: 'Farmer profile details (present only if the user has filled their profile)',
+    type: 'object',
+    nullable: true,
+    readOnly: true,
+  })
+  farmerProfile?: Record<string, any>;
 }
 
 // ─── Paginated User Details ───────────────────────────────────────────────────

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -52,11 +52,31 @@ export interface WeeklyQueryCountEntry {
   count: number;
 }
 
+export interface FarmerProfile {
+  age?: number;
+  gender?: string;
+  villageName?: string;
+  blockName?: string;
+  district?: string;
+  state?: string;
+  phoneNo?: string;
+  languagePreference?: string;
+  yearsOfExperience?: number;
+  cropsCultivated?: string[];
+  primaryCrop?: string;
+  secondaryCrop?: string;
+  awarenessOfKCC?: boolean;
+  usesAgriApps?: boolean;
+  highestEducatedPerson?: string;
+  numberOfSmartphones?: number;
+}
+
 export interface UserDetailEntry {
   userId: string;
   name: string;
   email: string;
   totalQuestions: number;
+  farmerProfile?: FarmerProfile;
 }
 
 export interface PaginatedUserDetails {

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -28,6 +28,24 @@ interface IUser {
   email?: string;
   createdAt: Date;
   updatedAt: Date;
+  farmerProfile?: {
+    age?: number;
+    gender?: string;
+    villageName?: string;
+    blockName?: string;
+    district?: string;
+    state?: string;
+    phoneNo?: string;
+    languagePreference?: string;
+    yearsOfExperience?: number;
+    cropsCultivated?: string[];
+    primaryCrop?: string;
+    secondaryCrop?: string;
+    awarenessOfKCC?: boolean;
+    usesAgriApps?: boolean;
+    highestEducatedPerson?: string;
+    numberOfSmartphones?: number;
+  };
 }
 
 interface IConversation {
@@ -667,6 +685,24 @@ export class ChatbotRepository implements IChatbotRepository {
         name: u.name || u.username || 'Unknown',
         email: u.email || '',
         totalQuestions: countMap.get(String(u._id)) ?? 0,
+        farmerProfile: u.farmerProfile ? {
+          age: u.farmerProfile.age,
+          gender: u.farmerProfile.gender,
+          villageName: u.farmerProfile.villageName,
+          blockName: u.farmerProfile.blockName,
+          district: u.farmerProfile.district,
+          state: u.farmerProfile.state,
+          phoneNo: u.farmerProfile.phoneNo,
+          languagePreference: u.farmerProfile.languagePreference,
+          yearsOfExperience: u.farmerProfile.yearsOfExperience,
+          cropsCultivated: u.farmerProfile.cropsCultivated,
+          primaryCrop: u.farmerProfile.primaryCrop,
+          secondaryCrop: u.farmerProfile.secondaryCrop,
+          awarenessOfKCC: u.farmerProfile.awarenessOfKCC,
+          usesAgriApps: u.farmerProfile.usesAgriApps,
+          highestEducatedPerson: u.farmerProfile.highestEducatedPerson,
+          numberOfSmartphones: u.farmerProfile.numberOfSmartphones,
+        } : undefined,
       }));
 
       // Sort by totalQuestions desc

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -198,47 +198,82 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
 
           {!isLoading && !error && (
             <div className="rounded-lg border bg-card overflow-x-auto">
-              <Table className="min-w-[600px]">
+              <Table className="min-w-[1600px]">
                 <TableHeader className="bg-card sticky top-0 z-10">
                   <TableRow>
                     <TableHead className="text-center w-12">S.No</TableHead>
+                    <TableHead className="text-center">Questions Asked</TableHead>
                     <TableHead className="text-center">Name</TableHead>
                     <TableHead className="text-center">Email</TableHead>
-                    <TableHead className="text-center">Questions Asked</TableHead>
+                    <TableHead className="text-center">Age</TableHead>
+                    <TableHead className="text-center">Gender</TableHead>
+                    <TableHead className="text-center">Village</TableHead>
+                    <TableHead className="text-center">Block</TableHead>
+                    <TableHead className="text-center">District</TableHead>
+                    <TableHead className="text-center">State</TableHead>
+                    <TableHead className="text-center">Phone</TableHead>
+                    <TableHead className="text-center">Language</TableHead>
+                    <TableHead className="text-center">Exp. (Yrs)</TableHead>
+                    <TableHead className="text-center">Crops</TableHead>
+                    <TableHead className="text-center">Primary Crop</TableHead>
+                    <TableHead className="text-center">Secondary Crop</TableHead>
+                    <TableHead className="text-center">KCC Aware</TableHead>
+                    <TableHead className="text-center">Agri Apps</TableHead>
+                    <TableHead className="text-center">Education</TableHead>
+                    <TableHead className="text-center">Smartphones</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {users.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={4} className="text-center py-10 text-muted-foreground">
+                      <TableCell colSpan={20} className="text-center py-10 text-muted-foreground">
                         {debouncedSearch ? "No users match your search." : "No users found."}
                       </TableCell>
                     </TableRow>
                   ) : (
-                    users.map((user, idx) => (
-                      <TableRow key={user.userId} className="text-center">
-                        <TableCell className="align-middle">
-                          {(currentPage - 1) * PAGE_SIZE + idx + 1}
-                        </TableCell>
-                        <TableCell className="align-middle font-medium whitespace-nowrap">
-                          {user.name}
-                        </TableCell>
-                        <TableCell className="align-middle whitespace-nowrap">
-                          {user.email}
-                        </TableCell>
-                        <TableCell className="align-middle">
-                          <span
-                            className={`inline-flex items-center justify-center min-w-[32px] px-2 py-0.5 rounded-full text-xs font-semibold ${
-                              user.totalQuestions > 0
-                                ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300"
-                                : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
-                            }`}
-                          >
-                            {user.totalQuestions.toLocaleString()}
-                          </span>
-                        </TableCell>
-                      </TableRow>
-                    ))
+                    users.map((user, idx) => {
+                      const fp = user.farmerProfile;
+                      return (
+                        <TableRow key={user.userId} className="text-center">
+                          <TableCell className="align-middle">
+                            {(currentPage - 1) * PAGE_SIZE + idx + 1}
+                          </TableCell>
+                          <TableCell className="align-middle">
+                            <span
+                              className={`inline-flex items-center justify-center min-w-[32px] px-2 py-0.5 rounded-full text-xs font-semibold ${
+                                user.totalQuestions > 0
+                                  ? "bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300"
+                                  : "bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+                              }`}
+                            >
+                              {user.totalQuestions.toLocaleString()}
+                            </span>
+                          </TableCell>
+                          <TableCell className="align-middle font-medium whitespace-nowrap">
+                            {user.name}
+                          </TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">
+                            {user.email}
+                          </TableCell>
+                          <TableCell className="align-middle">{fp?.age ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.gender ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.villageName ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.blockName ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.district ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.state ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.phoneNo ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.languagePreference ?? "—"}</TableCell>
+                          <TableCell className="align-middle">{fp?.yearsOfExperience ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.cropsCultivated?.join(", ") ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.primaryCrop ?? "—"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.secondaryCrop ?? "—"}</TableCell>
+                          <TableCell className="align-middle">{fp?.awarenessOfKCC == null ? "—" : fp.awarenessOfKCC ? "Yes" : "No"}</TableCell>
+                          <TableCell className="align-middle">{fp?.usesAgriApps == null ? "—" : fp.usesAgriApps ? "Yes" : "No"}</TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.highestEducatedPerson ?? "—"}</TableCell>
+                          <TableCell className="align-middle">{fp?.numberOfSmartphones ?? "—"}</TableCell>
+                        </TableRow>
+                      );
+                    })
                   )}
                 </TableBody>
               </Table>

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -2,11 +2,31 @@ import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/hooks/api/api-fetch';
 import { env } from '@/config/env';
 
+export interface FarmerProfile {
+  age?: number;
+  gender?: string;
+  villageName?: string;
+  blockName?: string;
+  district?: string;
+  state?: string;
+  phoneNo?: string;
+  languagePreference?: string;
+  yearsOfExperience?: number;
+  cropsCultivated?: string[];
+  primaryCrop?: string;
+  secondaryCrop?: string;
+  awarenessOfKCC?: boolean;
+  usesAgriApps?: boolean;
+  highestEducatedPerson?: string;
+  numberOfSmartphones?: number;
+}
+
 export interface UserDetail {
   userId: string;
   name: string;
   email: string;
   totalQuestions: number;
+  farmerProfile?: FarmerProfile;
 }
 
 export interface PaginatedUserDetailsResponse {


### PR DESCRIPTION
## Summary                                              
  - Added `farmerProfile` fields to the user details    
  response in chatbot analytics (backend + frontend)
  - Table now shows age, gender, village, block, district,
   state, phone, language, experience, crops,             
  primary/secondary crop, KCC awareness, agri apps usage, 
  education, and smartphones alongside existing name,    
  email, and questions asked                              