### PR TITLE
feat: added the filter options by crop and village in user details page

### DIFF
--- a/backend/src/modules/chatbot/classes/validators/ChatbotQueryValidators.ts
+++ b/backend/src/modules/chatbot/classes/validators/ChatbotQueryValidators.ts
@@ -57,4 +57,14 @@ export class UserDetailsQueryDto {
   @IsOptional()
   @IsIn(['vicharanashala', 'annam'])
   source: 'vicharanashala' | 'annam' = 'vicharanashala';
+
+  @JSONSchema({ example: 'rice', description: 'Filter by crop (matches cropsCultivated, primaryCrop, secondaryCrop)' })
+  @IsOptional()
+  @IsString()
+  crop: string = '';
+
+  @JSONSchema({ example: 'Poonjar', description: 'Filter by village name' })
+  @IsOptional()
+  @IsString()
+  village: string = '';
 }

--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -257,6 +257,8 @@ export class ChatbotController {
       query.limit,
       query.search,
       query.source,
+      query.crop,
+      query.village,
     );
   }
 }

--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -37,7 +37,7 @@ export interface IChatbotService {
   getTodayQueryCount(source?: string): Promise<number>;
   getWeeklyQueryCounts(source?: string): Promise<WeeklyQueryCountEntry[]>;
   getDailyUserTrend(days?: number, source?: string): Promise<DailyActiveUsersEntry[]>;
-  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string, source?: string): Promise<PaginatedUserDetails>;
+  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string, source?: string, crop?: string, village?: string): Promise<PaginatedUserDetails>;
   getAvgSessionDurationV2(source?: string): Promise<number>;
   getWeeklyAvgSessionDurationV2(weeks?: number, source?: string): Promise<WeeklySessionDurationEntry[]>;
 }

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -135,11 +135,11 @@ export class ChatbotService implements IChatbotService {
     }
   }
 
-  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '', source = 'vicharanashala') {
+  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '', source = 'vicharanashala', crop = '', village = '') {
     try {
       const start = startDate ? new Date(startDate) : undefined;
       const end = endDate ? new Date(endDate) : undefined;
-      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search, source);
+      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search, source, crop, village);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch user details: ${error}`);
     }

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -165,6 +165,8 @@ export interface IChatbotRepository {
     limit?: number,
     search?: string,
     source?: string,
+    crop?: string,
+    village?: string,
     session?: ClientSession,
   ): Promise<PaginatedUserDetails>;
 }

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -53,6 +53,7 @@ export interface WeeklyQueryCountEntry {
 }
 
 export interface FarmerProfile {
+  farmerName?: string;
   age?: number;
   gender?: string;
   villageName?: string;

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -630,6 +630,8 @@ export class ChatbotRepository implements IChatbotRepository {
     limit = 10,
     search = '',
     source = 'vicharanashala',
+    crop = '',
+    village = '',
     session?: ClientSession,
   ): Promise<PaginatedUserDetails> {
     try {
@@ -665,7 +667,7 @@ export class ChatbotRepository implements IChatbotRepository {
         countMap.set(String(entry._id), entry.totalQuestions);
       }
 
-      // Get users — optionally filtered by search
+      // Get users — optionally filtered by search, crop, village
       const userFilter: Record<string, any> = {};
       if (search && search.trim()) {
         const escaped = search.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -674,6 +676,26 @@ export class ChatbotRepository implements IChatbotRepository {
           { name: regex },
           { username: regex },
           { email: regex },
+        ];
+      }
+      if (crop && crop.trim()) {
+        const cropRegex = { $regex: crop.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), $options: 'i' };
+        userFilter.$and = [
+          ...(userFilter.$and ?? []),
+          {
+            $or: [
+              { 'farmerProfile.cropsCultivated': cropRegex },
+              { 'farmerProfile.primaryCrop': cropRegex },
+              { 'farmerProfile.secondaryCrop': cropRegex },
+            ],
+          },
+        ];
+      }
+      if (village && village.trim()) {
+        const villageRegex = { $regex: village.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), $options: 'i' };
+        userFilter.$and = [
+          ...(userFilter.$and ?? []),
+          { 'farmerProfile.villageName': villageRegex },
         ];
       }
 

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -29,6 +29,7 @@ interface IUser {
   createdAt: Date;
   updatedAt: Date;
   farmerProfile?: {
+    farmerName?: string;
     age?: number;
     gender?: string;
     villageName?: string;
@@ -708,6 +709,7 @@ export class ChatbotRepository implements IChatbotRepository {
         email: u.email || '',
         totalQuestions: countMap.get(String(u._id)) ?? 0,
         farmerProfile: u.farmerProfile ? {
+          farmerName: u.farmerProfile.farmerName,
           age: u.farmerProfile.age,
           gender: u.farmerProfile.gender,
           villageName: u.farmerProfile.villageName,

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -271,6 +271,7 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
                     <TableHead className="text-center">Questions Asked</TableHead>
                     <TableHead className="text-center">Name</TableHead>
                     <TableHead className="text-center">Email</TableHead>
+                    <TableHead className="text-center">Farmer Name</TableHead>
                     <TableHead className="text-center">Age</TableHead>
                     <TableHead className="text-center">Gender</TableHead>
                     <TableHead className="text-center">Village</TableHead>
@@ -292,7 +293,7 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
                 <TableBody>
                   {users.length === 0 ? (
                     <TableRow>
-                      <TableCell colSpan={20} className="text-center py-10 text-muted-foreground">
+                      <TableCell colSpan={21} className="text-center py-10 text-muted-foreground">
                         {debouncedSearch ? "No users match your search." : "No users found."}
                       </TableCell>
                     </TableRow>
@@ -321,6 +322,7 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
                           <TableCell className="align-middle whitespace-nowrap">
                             {user.email}
                           </TableCell>
+                          <TableCell className="align-middle whitespace-nowrap">{fp?.farmerName ?? "—"}</TableCell>
                           <TableCell className="align-middle">{fp?.age ?? "—"}</TableCell>
                           <TableCell className="align-middle whitespace-nowrap">{fp?.gender ?? "—"}</TableCell>
                           <TableCell className="align-middle whitespace-nowrap">{fp?.villageName ?? "—"}</TableCell>

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -27,16 +27,36 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
   const [endTime, setEndTime] = useState<Date | undefined>(undefined);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [cropQuery, setCropQuery] = useState("");
+  const [debouncedCrop, setDebouncedCrop] = useState("");
+  const [villageQuery, setVillageQuery] = useState("");
+  const [debouncedVillage, setDebouncedVillage] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
 
   // Debounce the search input so we don't fire a request on every keystroke
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedSearch(searchQuery);
-      setCurrentPage(1); // reset to page 1 on new search
+      setCurrentPage(1);
     }, 400);
     return () => clearTimeout(timer);
   }, [searchQuery]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedCrop(cropQuery);
+      setCurrentPage(1);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [cropQuery]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedVillage(villageQuery);
+      setCurrentPage(1);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [villageQuery]);
 
   const { data, isLoading, error } = useUserDetails(
     startTime,
@@ -45,6 +65,8 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
     PAGE_SIZE,
     debouncedSearch,
     source,
+    debouncedCrop,
+    debouncedVillage,
   );
 
   const { users, totalUsers, totalPages, activeUsers, totalQuestions } = data;
@@ -132,6 +154,7 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
         <CardHeader className="pb-3">
           <div className="flex flex-col gap-3 min-w-0 w-full">
             <CardTitle className="text-sm font-medium">All Farmers</CardTitle>
+            {/* Row 1: name search + date range */}
             <div className="flex flex-col sm:flex-row flex-wrap lg:flex-nowrap items-stretch gap-2 w-full min-w-0">
               <div className="relative w-full sm:flex-1 min-w-0">
                 <svg
@@ -164,7 +187,48 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
                   }
                 />
               </div>
-              {(searchQuery || startTime || endTime) && (
+            </div>
+            {/* Row 2: crop + village + reset */}
+            <div className="flex flex-col sm:flex-row flex-wrap lg:flex-nowrap items-stretch gap-2 w-full min-w-0">
+              <div className="relative w-full sm:flex-1 min-w-0">
+                <svg
+                  width={14}
+                  height={14}
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-(--muted-foreground)"
+                >
+                  <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.3" />
+                  <path d="M11 11l3.5 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                </svg>
+                <input
+                  type="text"
+                  placeholder="Filter by crop..."
+                  value={cropQuery}
+                  onChange={(e) => setCropQuery(e.target.value)}
+                  className="w-full h-9 pl-9 pr-3 text-sm border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-[#222] text-(--foreground) placeholder:text-(--muted-foreground) outline-none focus:border-[#3AAA5A] transition-colors"
+                />
+              </div>
+              <div className="relative w-full sm:flex-1 min-w-0">
+                <svg
+                  width={14}
+                  height={14}
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-(--muted-foreground)"
+                >
+                  <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.3" />
+                  <path d="M11 11l3.5 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+                </svg>
+                <input
+                  type="text"
+                  placeholder="Filter by village..."
+                  value={villageQuery}
+                  onChange={(e) => setVillageQuery(e.target.value)}
+                  className="w-full h-9 pl-9 pr-3 text-sm border border-gray-200 dark:border-gray-700 rounded-md bg-white dark:bg-[#222] text-(--foreground) placeholder:text-(--muted-foreground) outline-none focus:border-[#3AAA5A] transition-colors"
+                />
+              </div>
+              {(searchQuery || startTime || endTime || cropQuery || villageQuery) && (
                 <Button
                   variant="outline"
                   size="sm"
@@ -173,6 +237,8 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
                     setSearchQuery("");
                     setStartTime(undefined);
                     setEndTime(undefined);
+                    setCropQuery("");
+                    setVillageQuery("");
                     setCurrentPage(1);
                   }}
                 >

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -3,6 +3,7 @@ import { apiFetch } from '@/hooks/api/api-fetch';
 import { env } from '@/config/env';
 
 export interface FarmerProfile {
+  farmerName?: string;
   age?: number;
   gender?: string;
   villageName?: string;

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -44,6 +44,8 @@ export function useUserDetails(
   limit = 10,
   search = '',
   source: 'vicharanashala' | 'annam' = 'vicharanashala',
+  crop = '',
+  village = '',
 ) {
   const startISO = startDate?.toISOString();
   // Extend endDate to end of day (23:59:59.999) so the selected day is fully included.
@@ -53,7 +55,7 @@ export function useUserDetails(
     : undefined;
 
   const { data, isLoading, error } = useQuery<PaginatedUserDetailsResponse, Error>({
-    queryKey: ['user-details', startISO, endISO, page, limit, search, source],
+    queryKey: ['user-details', startISO, endISO, page, limit, search, source, crop, village],
     staleTime: 30 * 1000,
     queryFn: async () => {
       const API_BASE_URL = env.apiBaseUrl();
@@ -64,6 +66,8 @@ export function useUserDetails(
       params.set('limit', String(limit));
       if (search.trim()) params.set('search', search.trim());
       params.set('source', source);
+      if (crop.trim()) params.set('crop', crop.trim());
+      if (village.trim()) params.set('village', village.trim());
 
       const result = await apiFetch<PaginatedUserDetailsResponse>(
         `${API_BASE_URL}/analytics/user-details?${params.toString()}`,


### PR DESCRIPTION
## Summary                 
  - Added crop and village text
   filters to the User Details 
  page in chatbot analytics    
  - Filters appear in a second
  row below the existing       
  name/date filters, responsive
   on all screen sizes         
  - Backend filters by farmerPr
  ofile.cropsCultivated,       
  primaryCrop, secondaryCrop   
  (crop) and                
  farmerProfile.villageName    
  (village)                  
  - All filters are optional 
  and stack correctly — no
  impact on existing           
  search/date filter behaviour