### PR TITLE
 feat(analytics): add farmer demographics &   KCC/agri-app awareness to dashboard 

### DIFF
--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -26,6 +26,8 @@ export interface DashboardResponse {
   ageGroups: DemographicEntry[];
   genderSplit: DemographicEntry[];
   farmingExperience: DemographicEntry[];
+  kccAwareness: DemographicEntry[];
+  agriAppUsage: DemographicEntry[];
 }
 
 export interface IChatbotService {

--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -10,6 +10,7 @@ import type {
   WeeklyQueryCountEntry,
   UserDetailEntry,
   PaginatedUserDetails,
+  DemographicEntry,
 } from '#root/shared/database/interfaces/IChatbotRepository.js';
 
 export interface DashboardResponse {
@@ -22,6 +23,9 @@ export interface DashboardResponse {
   weeklySessionDuration: WeeklySessionDurationEntry[];
   dailyQueries: DailyQueryCountEntry[];
   weeklyQueries: WeeklyQueryCountEntry[];
+  ageGroups: DemographicEntry[];
+  genderSplit: DemographicEntry[];
+  farmingExperience: DemographicEntry[];
 }
 
 export interface IChatbotService {

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -14,7 +14,7 @@ export class ChatbotService implements IChatbotService {
 
   async getDashboard(days = 30, source = 'vicharanashala'): Promise<DashboardResponse> {
     try {
-      const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, dailyQueries, todayQueryCount, weeklyQueries, avgSessionDurationMin, weeklySessionDuration] =
+      const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, dailyQueries, todayQueryCount, weeklyQueries, avgSessionDurationMin, weeklySessionDuration, demographics] =
         await Promise.all([
           this.chatbotRepository.getKpiSummary(source),
           this.chatbotRepository.getDailyActiveUsers(days, source),
@@ -29,6 +29,7 @@ export class ChatbotService implements IChatbotService {
           this.chatbotRepository.getAvgSessionDurationV2(source),
           // V2: inactivity-gap based weekly breakdown replaces the old getWeeklyAvgSessionDuration
           this.chatbotRepository.getWeeklyAvgSessionDurationV2(Math.ceil(days / 7), source),
+          this.chatbotRepository.getUserDemographics(source),
         ]);
 
       return {
@@ -42,6 +43,9 @@ export class ChatbotService implements IChatbotService {
         weeklySessionDuration,
         dailyQueries,
         weeklyQueries,
+        ageGroups: demographics.ageGroups,
+        genderSplit: demographics.genderSplit,
+        farmingExperience: demographics.farmingExperience,
       };
     } catch (error) {
       throw new InternalServerError(`Failed to fetch dashboard data: ${error}`);

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -14,7 +14,7 @@ export class ChatbotService implements IChatbotService {
 
   async getDashboard(days = 30, source = 'vicharanashala'): Promise<DashboardResponse> {
     try {
-      const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, dailyQueries, todayQueryCount, weeklyQueries, avgSessionDurationMin, weeklySessionDuration, demographics] =
+      const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, dailyQueries, todayQueryCount, weeklyQueries, avgSessionDurationMin, weeklySessionDuration, demographics, kccAndAgri] =
         await Promise.all([
           this.chatbotRepository.getKpiSummary(source),
           this.chatbotRepository.getDailyActiveUsers(days, source),
@@ -30,6 +30,7 @@ export class ChatbotService implements IChatbotService {
           // V2: inactivity-gap based weekly breakdown replaces the old getWeeklyAvgSessionDuration
           this.chatbotRepository.getWeeklyAvgSessionDurationV2(Math.ceil(days / 7), source),
           this.chatbotRepository.getUserDemographics(source),
+          this.chatbotRepository.getKccAndAgriAppStats(source),
         ]);
 
       return {
@@ -46,6 +47,8 @@ export class ChatbotService implements IChatbotService {
         ageGroups: demographics.ageGroups,
         genderSplit: demographics.genderSplit,
         farmingExperience: demographics.farmingExperience,
+        kccAwareness: kccAndAgri.kccAwareness,
+        agriAppUsage: kccAndAgri.agriAppUsage,
       };
     } catch (error) {
       throw new InternalServerError(`Failed to fetch dashboard data: ${error}`);

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -100,6 +100,11 @@ export interface UserDemographics {
   farmingExperience: DemographicEntry[];
 }
 
+export interface KccAndAgriAppStats {
+  kccAwareness: DemographicEntry[];
+  agriAppUsage: DemographicEntry[];
+}
+
 // ─── Single consolidated interface ───────────────────────────────────────────
 
 export interface IChatbotRepository {
@@ -194,6 +199,9 @@ export interface IChatbotRepository {
 
   /** Aggregate age group, gender split, and farming experience distributions from farmerProfile. */
   getUserDemographics(source?: string, session?: ClientSession): Promise<UserDemographics>;
+
+  /** Aggregate KCC policy awareness and agri app usage splits from farmerProfile. */
+  getKccAndAgriAppStats(source?: string, session?: ClientSession): Promise<KccAndAgriAppStats>;
 }
 
 export interface ChatbotConversationData {

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -88,6 +88,18 @@ export interface PaginatedUserDetails {
   totalQuestions: number;
 }
 
+export interface DemographicEntry {
+  label: string;
+  count: number;
+  pct: number;
+}
+
+export interface UserDemographics {
+  ageGroups: DemographicEntry[];
+  genderSplit: DemographicEntry[];
+  farmingExperience: DemographicEntry[];
+}
+
 // ─── Single consolidated interface ───────────────────────────────────────────
 
 export interface IChatbotRepository {
@@ -179,6 +191,9 @@ export interface IChatbotRepository {
     source?: string,
     session?: ClientSession,
   ): Promise<ChatbotConversationData[]>;
+
+  /** Aggregate age group, gender split, and farming experience distributions from farmerProfile. */
+  getUserDemographics(source?: string, session?: ClientSession): Promise<UserDemographics>;
 }
 
 export interface ChatbotConversationData {

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -20,6 +20,7 @@ import type {
   ChatbotConversationData,
   UserDemographics,
   DemographicEntry,
+  KccAndAgriAppStats,
 } from '#root/shared/database/interfaces/IChatbotRepository.js';
 import {IQuestion} from '#root/shared/interfaces/models.js';
 import {MongoDatabase} from '../MongoDatabase.js';
@@ -1009,6 +1010,57 @@ export class ChatbotRepository implements IChatbotRepository {
       return {ageGroups, genderSplit, farmingExperience};
     } catch (error) {
       throw new InternalServerError(`Failed to get user demographics: ${error}`);
+    }
+  }
+
+  async getKccAndAgriAppStats(source = 'vicharanashala', session?: ClientSession): Promise<KccAndAgriAppStats> {
+    try {
+      await this.init(source);
+
+      const [kccRaw, agriRaw] = await Promise.all([
+        // KCC awareness split
+        this.users.aggregate<{_id: boolean; count: number}>(
+          [
+            {$match: {'farmerProfile.awarenessOfKCC': {$exists: true, $ne: null}}},
+            {$group: {_id: '$farmerProfile.awarenessOfKCC', count: {$sum: 1}}},
+          ],
+          {session},
+        ).toArray(),
+
+        // Agri apps usage split
+        this.users.aggregate<{_id: boolean; count: number}>(
+          [
+            {$match: {'farmerProfile.usesAgriApps': {$exists: true, $ne: null}}},
+            {$group: {_id: '$farmerProfile.usesAgriApps', count: {$sum: 1}}},
+          ],
+          {session},
+        ).toArray(),
+      ]);
+
+      const toPct = (count: number, total: number) =>
+        total === 0 ? 0 : Math.round((count / total) * 100);
+
+      const kccTotal = kccRaw.reduce((s, r) => s + r.count, 0);
+      const kccAwareness: DemographicEntry[] = kccRaw
+        .sort((_, b) => (b._id ? 1 : -1))
+        .map(r => ({
+          label: r._id ? 'Aware' : 'Not Aware',
+          count: r.count,
+          pct: toPct(r.count, kccTotal),
+        }));
+
+      const agriTotal = agriRaw.reduce((s, r) => s + r.count, 0);
+      const agriAppUsage: DemographicEntry[] = agriRaw
+        .sort((_, b) => (b._id ? 1 : -1))
+        .map(r => ({
+          label: r._id ? 'Uses Apps' : 'Does Not Use',
+          count: r.count,
+          pct: toPct(r.count, agriTotal),
+        }));
+
+      return {kccAwareness, agriAppUsage};
+    } catch (error) {
+      throw new InternalServerError(`Failed to get KCC and agri app stats: ${error}`);
     }
   }
 

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -18,6 +18,8 @@ import type {
   UserDetailEntry,
   PaginatedUserDetails,
   ChatbotConversationData,
+  UserDemographics,
+  DemographicEntry,
 } from '#root/shared/database/interfaces/IChatbotRepository.js';
 import {IQuestion} from '#root/shared/interfaces/models.js';
 import {MongoDatabase} from '../MongoDatabase.js';
@@ -923,6 +925,90 @@ export class ChatbotRepository implements IChatbotRepository {
       return result as WeeklySessionDurationEntry[];
     } catch (error) {
       throw new InternalServerError(`Failed to get weekly avg session duration v2: ${error}`);
+    }
+  }
+
+  async getUserDemographics(source = 'vicharanashala', session?: ClientSession): Promise<UserDemographics> {
+    try {
+      await this.init(source);
+
+      const [ageRaw, genderRaw, expRaw] = await Promise.all([
+        // Age group buckets
+        this.users.aggregate<{_id: string | number; count: number}>(
+          [
+            {$match: {'farmerProfile.age': {$exists: true, $ne: null}}},
+            {
+              $bucket: {
+                groupBy: '$farmerProfile.age',
+                boundaries: [18, 26, 36, 46, 56],
+                default: '55+',
+                output: {count: {$sum: 1}},
+              },
+            },
+          ],
+          {session},
+        ).toArray(),
+
+        // Gender split
+        this.users.aggregate<{_id: string; count: number}>(
+          [
+            {$match: {'farmerProfile.gender': {$exists: true, $ne: null}}},
+            {$group: {_id: '$farmerProfile.gender', count: {$sum: 1}}},
+          ],
+          {session},
+        ).toArray(),
+
+        // Farming experience buckets
+        this.users.aggregate<{_id: number | string; count: number}>(
+          [
+            {$match: {'farmerProfile.yearsOfExperience': {$exists: true, $ne: null}}},
+            {
+              $bucket: {
+                groupBy: '$farmerProfile.yearsOfExperience',
+                boundaries: [0, 2, 5, 10, 20],
+                default: '20+',
+                output: {count: {$sum: 1}},
+              },
+            },
+          ],
+          {session},
+        ).toArray(),
+      ]);
+
+      const toPct = (count: number, total: number) =>
+        total === 0 ? 0 : Math.round((count / total) * 100);
+
+      const ageBoundaryLabel: Record<string | number, string> = {
+        18: '18-25', 26: '26-35', 36: '36-45', 46: '46-55', '55+': '55+',
+      };
+      const ageTotal = ageRaw.reduce((s, r) => s + r.count, 0);
+      const ageGroups: DemographicEntry[] = ageRaw.map(r => ({
+        label: ageBoundaryLabel[r._id] ?? String(r._id),
+        count: r.count,
+        pct: toPct(r.count, ageTotal),
+      }));
+
+      const genderTotal = genderRaw.reduce((s, r) => s + r.count, 0);
+      const genderMap: Record<string, string> = {male: 'Male', female: 'Female', other: 'Other'};
+      const genderSplit: DemographicEntry[] = genderRaw.map(r => ({
+        label: genderMap[(r._id ?? '').toLowerCase()] ?? r._id,
+        count: r.count,
+        pct: toPct(r.count, genderTotal),
+      }));
+
+      const expBoundaryLabel: Record<string | number, string> = {
+        0: 'Less than 2 yrs', 2: '2 - 5 yrs', 5: '5 - 10 yrs', 10: '10 - 20 yrs', '20+': '20+ yrs',
+      };
+      const expTotal = expRaw.reduce((s, r) => s + r.count, 0);
+      const farmingExperience: DemographicEntry[] = expRaw.map(r => ({
+        label: expBoundaryLabel[r._id] ?? String(r._id),
+        count: r.count,
+        pct: toPct(r.count, expTotal),
+      }));
+
+      return {ageGroups, genderSplit, farmingExperience};
+    } catch (error) {
+      throw new InternalServerError(`Failed to get user demographics: ${error}`);
     }
   }
 

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -19,6 +19,7 @@ import { HealthScoreCard } from "./HealthScoreCard";
 import { SegmentDetailBanner } from "./components/SegmentDetailBanner";
 import { StatusBar } from "./components/StatusBar";
 import { UserDetailsView } from "./UserDetailsView";
+import { UserDemographicsSection } from "./components/UserDemographicsSection";
 
 const DEFAULT_FILTERS: DashboardFilterValues = {
   village: "all",
@@ -115,6 +116,9 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                   <DailyActiveUsers data={dauTrend} isLoading={dauLoading} error={dauError} />
                   <ChannelSplitCard channelSplit={data.channelSplit} voiceAccuracy={data.voiceAccuracy} />
                 </div>
+
+                {/* Demographics */}
+                <UserDemographicsSection data={{ ageGroups: data.ageGroups, genderSplit: data.genderSplit, farmingExperience: data.farmingExperience }} />
 
                 {/* 3-col row */}
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 mb-4">

--- a/frontend/src/features/chatbotDashboard/components/UserDemographicsSection.tsx
+++ b/frontend/src/features/chatbotDashboard/components/UserDemographicsSection.tsx
@@ -1,0 +1,106 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/atoms/card";
+import type { UserDemographics } from "../types";
+
+const AGE_COLORS = ["#3AAA5A", "#378ADD", "#A0845C", "#EF9F27", "#6B7280"];
+const GENDER_COLORS: Record<string, string> = { Male: "#378ADD", Female: "#E879A0", Other: "#A0845C" };
+const EXP_COLORS = ["#1E3A5F", "#378ADD", "#60A5FA", "#38BDF8", "#94A3B8"];
+
+function DonutSegments({ segments }: { segments: { label: string; count: number; pct: number; color: string }[] }) {
+  const totalCount = segments.reduce((s, x) => s + x.count, 0) || 1;
+  const r = 32, cx = 44, cy = 44, circ = 2 * Math.PI * r;
+  let offset = 0;
+  return (
+    <div className="flex flex-col sm:flex-row items-center gap-4 w-full">
+      <svg width={88} height={88} viewBox="0 0 88 88" className="flex-shrink-0">
+        <circle cx={cx} cy={cy} r={r} fill="none" stroke="#e5e7eb" strokeWidth={14} strokeLinecap="butt" />
+        {segments.map((seg) => {
+          const dash = (seg.count / totalCount) * circ;
+          const el = (
+            <circle key={seg.label} cx={cx} cy={cy} r={r} fill="none" stroke={seg.color}
+              strokeWidth={14} strokeLinecap="butt"
+              strokeDasharray={`${dash} ${circ * 10}`}
+              strokeDashoffset={-offset} transform={`rotate(-90 ${cx} ${cy})`} />
+          );
+          offset += dash;
+          return el;
+        })}
+      </svg>
+      <div className="flex flex-col gap-1.5 w-full">
+        {segments.map((s) => (
+          <div key={s.label} className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+            <span className="w-2 h-2 rounded-sm flex-shrink-0" style={{ background: s.color }} />
+            <span className="flex-1 truncate">{s.label}</span>
+            <span className="font-medium text-gray-700 dark:text-gray-200">{s.pct}%</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+
+function HorizontalBars({ segments }: { segments: { label: string; pct: number; color: string }[] }) {
+  return (
+    <div className="flex flex-col gap-2.5 w-full">
+      {segments.map((s) => (
+        <div key={s.label} className="flex items-center gap-2">
+          <span className="text-xs text-gray-500 dark:text-gray-400 w-20 sm:w-24 flex-shrink-0 truncate">{s.label}</span>
+          <div className="flex-1 h-2.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+            <div className="h-full rounded-full transition-all duration-500"
+              style={{ width: `${s.pct}%`, background: s.color }} />
+          </div>
+          <span className="text-xs font-medium text-gray-700 dark:text-gray-200 w-7 text-right flex-shrink-0">
+            {s.pct}%
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface Props {
+  data: UserDemographics;
+}
+
+export function UserDemographicsSection({ data }: Props) {
+  const ageSegments = data.ageGroups.map((d, i) => ({ ...d, color: AGE_COLORS[i % AGE_COLORS.length] }));
+  const genderSegments = data.genderSplit.map((d) => ({ ...d, color: GENDER_COLORS[d.label] ?? "#6B7280" }));
+  const expSegments = data.farmingExperience.map((d, i) => ({ ...d, color: EXP_COLORS[i % EXP_COLORS.length] }));
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-5">
+      <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Age Group</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {ageSegments.length > 0
+            ? <DonutSegments segments={ageSegments} />
+            : <p className="text-xs text-gray-400 italic">No data</p>}
+        </CardContent>
+      </Card>
+
+      <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Gender Split</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {genderSegments.length > 0
+            ? <DonutSegments segments={genderSegments} />
+            : <p className="text-xs text-gray-400 italic">No data</p>}
+        </CardContent>
+      </Card>
+
+      <Card className="sm:col-span-2 lg:col-span-1 dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Farming Experience</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {expSegments.length > 0
+            ? <HorizontalBars segments={expSegments} />
+            : <p className="text-xs text-gray-400 italic">No data</p>}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
@@ -6,6 +6,7 @@ import { DASHBOARD_DATA } from '../mockData';
 import { formatIndian, calcWeeklyDelta } from '../utils/dashboardHelpers';
 import type { DailyEntry } from '../utils/dashboardHelpers';
 import type { DashboardFilterValues } from '../DashboardFilters';
+import type { DemographicEntry } from '../types';
 
 export type DashboardDataType = typeof DASHBOARD_DATA;
 
@@ -27,6 +28,9 @@ interface DashboardApiResponse {
   voiceAccuracy: any[];
   geo: any[];
   queryCategories: any[];
+  ageGroups: DemographicEntry[];
+  genderSplit: DemographicEntry[];
+  farmingExperience: DemographicEntry[];
 }
 
 // ── Date range label helpers ──────────────────────────────────────────────────
@@ -153,6 +157,10 @@ function transformApiResponse(result: DashboardApiResponse): DashboardDataType {
   const dauLabels = result.dau.map(d => fmtMonthYear(parseDay(d.day)));
   const queryLabels = queryTrend.map(d => fmtDayWithWeek(parseDay(d.day)));
   const sessionLabels = sessionWeekly.map(w => fmtWeekLabel(w.week));
+
+  updatedData.ageGroups = result.ageGroups ?? [];
+  updatedData.genderSplit = result.genderSplit ?? [];
+  updatedData.farmingExperience = result.farmingExperience ?? [];
 
   updatedData.kpiRow1 = DASHBOARD_DATA.kpiRow1.map(card => {
     if (card.id === 'dau') {

--- a/frontend/src/features/chatbotDashboard/mockData.ts
+++ b/frontend/src/features/chatbotDashboard/mockData.ts
@@ -1,4 +1,4 @@
-import type { Segment, KpiCard } from "./types";
+import type { Segment, KpiCard, DemographicEntry } from "./types";
 
 export const DASHBOARD_DATA = {
   meta: { season: "Kharif 2025", lastSync: "2 min ago", datasetVersion: "GD-2025-Q3.14", llmVersion: "v2.4.1", p0Bugs: 3 },
@@ -71,4 +71,7 @@ export const DASHBOARD_DATA = {
     { label: "Content coverage", score: 66, color: "#EF9F27" },
     { label: "UX satisfaction", score: 68, color: "#EF9F27" },
   ],
+  ageGroups: [] as DemographicEntry[],
+  genderSplit: [] as DemographicEntry[],
+  farmingExperience: [] as DemographicEntry[],
 };

--- a/frontend/src/features/chatbotDashboard/types.ts
+++ b/frontend/src/features/chatbotDashboard/types.ts
@@ -1,5 +1,17 @@
 export type BadgeVariant = "green" | "red" | "amber" | "blue";
 
+export interface DemographicEntry {
+  label: string;
+  count: number;
+  pct: number;
+}
+
+export interface UserDemographics {
+  ageGroups: DemographicEntry[];
+  genderSplit: DemographicEntry[];
+  farmingExperience: DemographicEntry[];
+}
+
 export interface Segment {
   id: string;
   label: string;


### PR DESCRIPTION
## Summary                                       
                                                     
  - Added `getUserDemographics` and                  
  `getKccAndAgriAppStats` repository methods that    
  aggregate farmer profile data (age, gender, years  
  of experience, KCC policy awareness, agri app    
  usage) from the `users` collection via MongoDB 
  `$bucket` and `$group` aggregations            
  - Wired both into the existing `getDashboard`
  Promise.all — no new API endpoint, all data comes  
  from `GET /analytics`
  - Extended `DashboardResponse` with 5 new     
  fields: `ageGroups`, `genderSplit`,                
  `farmingExperience`, `kccAwareness`, `agriAppUsage`
  - Built `UserDemographicsSection` component (donut 
  charts for age/gender, horizontal bars for farming 
  experience) following the existing dashboard data
  flow — `useDashboardData` → `AnnamDashboard_dev` → 
  component as prop, no self-fetching              
  - `kccAwareness` and `agriAppUsage` are
  backend-only additions; UI to be done separately  