### PR TITLE
feat(dashboard): Enable AlertCard with dynamic Inactive Users metric and User Details navigation

### DIFF
--- a/backend/src/modules/chatbot/classes/validators/ChatbotQueryValidators.ts
+++ b/backend/src/modules/chatbot/classes/validators/ChatbotQueryValidators.ts
@@ -72,4 +72,9 @@ export class UserDetailsQueryDto {
   @IsOptional()
   @IsIn(['yes', 'no', 'all'])
   profileCompleted: 'yes' | 'no' | 'all' = 'all';
+
+  @JSONSchema({ example: 'false', description: 'If true, return only users with zero questions in the date range' })
+  @IsOptional()
+  @IsString()
+  inactiveOnly?: string;
 }

--- a/backend/src/modules/chatbot/classes/validators/ChatbotResponseValidators.ts
+++ b/backend/src/modules/chatbot/classes/validators/ChatbotResponseValidators.ts
@@ -81,6 +81,15 @@ export class KpiSummaryResponse {
   })
   @IsNumber()
   voiceUsageSharePct: number;
+
+  @JSONSchema({
+    description: 'Number of users with zero messages in the last 3 days',
+    example: 980,
+    type: 'number',
+    readOnly: true,
+  })
+  @IsNumber()
+  inactiveUsersLast3Days: number;
 }
 
 // ─── Daily Active Users Entry ─────────────────────────────────────────────────

--- a/backend/src/modules/chatbot/classes/validators/ChatbotResponseValidators.ts
+++ b/backend/src/modules/chatbot/classes/validators/ChatbotResponseValidators.ts
@@ -349,6 +349,15 @@ export class PaginatedUserDetailsResponse {
   activeUsers: number;
 
   @JSONSchema({
+    description: 'Number of inactive users (users with no questions)',
+    example: 6289,
+    type: 'number',
+    readOnly: true,
+  })
+  @IsNumber()
+  inactiveUsers: number;
+
+  @JSONSchema({
     description: 'Total number of questions across all users',
     example: 45678,
     type: 'number',

--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -252,6 +252,7 @@ export class ChatbotController {
   @HttpCode(200)
   @Authorized()
   async getUserDetails(@QueryParams() query: UserDetailsQueryDto) {
+    const inactiveOnly = query.inactiveOnly === 'true';
     return this.chatbotService.getUserDetails(
       query.startDate,
       query.endDate,
@@ -262,6 +263,7 @@ export class ChatbotController {
       query.crop,
       query.village,
       query.profileCompleted,
+      inactiveOnly,
     );
   }
 

--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -43,7 +43,7 @@ export interface IChatbotService {
   getTodayQueryCount(source?: string): Promise<number>;
   getWeeklyQueryCounts(source?: string): Promise<WeeklyQueryCountEntry[]>;
   getDailyUserTrend(days?: number, source?: string): Promise<DailyActiveUsersEntry[]>;
-  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string, source?: string, crop?: string, village?: string, profileCompleted?: string): Promise<PaginatedUserDetails>;
+  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string, source?: string, crop?: string, village?: string, profileCompleted?: string, inactiveOnly?: boolean): Promise<PaginatedUserDetails>;
   getAvgSessionDurationV2(source?: string): Promise<number>;
   getWeeklyAvgSessionDurationV2(weeks?: number, source?: string): Promise<WeeklySessionDurationEntry[]>;
   generateChatbotExcelReport(startDate: Date, endDate: Date, source?: string): Promise<ArrayBuffer | null>;

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -143,11 +143,11 @@ export class ChatbotService implements IChatbotService {
     }
   }
 
-  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '', source = 'vicharanashala', crop = '', village = '', profileCompleted = 'all') {
+  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '', source = 'vicharanashala', crop = '', village = '', profileCompleted = 'all', inactiveOnly = false) {
     try {
       const start = startDate ? new Date(startDate) : undefined;
       const end = endDate ? new Date(endDate) : undefined;
-      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search, source, crop, village, profileCompleted);
+      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search, source, crop, village, profileCompleted, inactiveOnly);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch user details: ${error}`);
     }

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -11,6 +11,7 @@ export interface KpiSummary {
   repeatQueryRatePct: number;
   voiceUsageSharePct: number;
   totalAppInstalls: number; // It will the count the user whose profile is completed or not.
+  inactiveUsersLast3Days: number; // users with zero messages in the last 3 days
 }
 
 export interface DailyActiveUsersEntry {

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -191,6 +191,7 @@ export interface IChatbotRepository {
     crop?: string,
     village?: string,
     profileCompleted?: string,
+    inactiveOnly?: boolean,
     session?: ClientSession,
   ): Promise<PaginatedUserDetails>;
 

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -90,6 +90,7 @@ export interface PaginatedUserDetails {
   totalUsers: number;
   totalPages: number;
   activeUsers: number;
+  inactiveUsers: number;
   totalQuestions: number;
 }
 

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -117,7 +117,12 @@ export class ChatbotRepository implements IChatbotRepository {
       const lastMonthDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
       const lastYearMonth = `${lastMonthDate.getFullYear()}-${String(lastMonthDate.getMonth() + 1).padStart(2, '0')}`;
 
-      const [totalUsers, monthlyActivity, sessionStats, todayQueryCount, totalAppInstalls] =
+      // 3 days ago at midnight for inactive-user calculation
+      const threeDaysAgo = new Date();
+      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+      threeDaysAgo.setHours(0, 0, 0, 0);
+
+      const [totalUsers, monthlyActivity, sessionStats, todayQueryCount, totalAppInstalls, activeUsersLast3Days] =
         await Promise.all([
           this.users.countDocuments({}, {session}),
 
@@ -166,6 +171,18 @@ export class ChatbotRepository implements IChatbotRepository {
             },
             { session },
           ),
+
+          // Count distinct users who sent messages in the last 3 days
+          this.messagesCollection
+            .aggregate(
+              [
+                { $match: { createdAt: { $gte: threeDaysAgo }, isCreatedByUser: true } },
+                { $group: { _id: '$user' } },
+                { $count: 'total' },
+              ],
+              { session },
+            )
+            .toArray(),
         ]);
 
       const monthMap = Object.fromEntries(
@@ -184,6 +201,7 @@ export class ChatbotRepository implements IChatbotRepository {
             );
 
       const avgMs = sessionStats[0]?.avg ?? 0;
+      const activeCount = (activeUsersLast3Days as any[])[0]?.total ?? 0;
 
       return {
         dau: totalUsers,
@@ -194,6 +212,7 @@ export class ChatbotRepository implements IChatbotRepository {
         repeatQueryRatePct: 0,
         voiceUsageSharePct: 0,
         totalAppInstalls,
+        inactiveUsersLast3Days: Math.max(0, totalUsers - activeCount),
       };
     } catch (error) {
       throw new InternalServerError(`Failed to get KPI summary: ${error}`);

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -650,6 +650,7 @@ export class ChatbotRepository implements IChatbotRepository {
     crop = '',
     village = '',
     profileCompleted = 'all',
+    inactiveOnly = false,
     session?: ClientSession,
   ): Promise<PaginatedUserDetails> {
     try {
@@ -758,18 +759,21 @@ export class ChatbotRepository implements IChatbotRepository {
         } : undefined,
       }));
 
+      // Filter to inactive users only if requested
+      const finalList = inactiveOnly ? merged.filter((u) => u.totalQuestions === 0) : merged;
+
       // Sort by totalQuestions desc
-      merged.sort((a, b) => b.totalQuestions - a.totalQuestions);
+      finalList.sort((a, b) => b.totalQuestions - a.totalQuestions);
 
       // Compute summary stats over the full filtered set
-      const totalUsers = merged.length;
-      const activeUsers = merged.filter((u) => u.totalQuestions > 0).length;
-      const totalQuestions = merged.reduce((sum, u) => sum + u.totalQuestions, 0);
+      const totalUsers = finalList.length;
+      const activeUsers = finalList.filter((u) => u.totalQuestions > 0).length;
+      const totalQuestions = finalList.reduce((sum, u) => sum + u.totalQuestions, 0);
       const totalPages = Math.max(1, Math.ceil(totalUsers / limit));
 
       // Paginate
       const startIdx = (page - 1) * limit;
-      const users = merged.slice(startIdx, startIdx + limit);
+      const users = finalList.slice(startIdx, startIdx + limit);
 
       return {
         users,

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -768,6 +768,7 @@ export class ChatbotRepository implements IChatbotRepository {
       // Compute summary stats over the full filtered set
       const totalUsers = finalList.length;
       const activeUsers = finalList.filter((u) => u.totalQuestions > 0).length;
+      const inactiveUsers = totalUsers - activeUsers;
       const totalQuestions = finalList.reduce((sum, u) => sum + u.totalQuestions, 0);
       const totalPages = Math.max(1, Math.ceil(totalUsers / limit));
 
@@ -780,6 +781,7 @@ export class ChatbotRepository implements IChatbotRepository {
         totalUsers,
         totalPages,
         activeUsers,
+        inactiveUsers,
         totalQuestions,
       };
     } catch (error) {

--- a/frontend/src/features/chatbotDashboard/AlertCard.tsx
+++ b/frontend/src/features/chatbotDashboard/AlertCard.tsx
@@ -7,71 +7,68 @@ interface Alert {
   desc: string;
 }
 
-function AlertItem({ level, title, desc }: Omit<Alert, "id">) {
-  const getAlertClasses = (alertLevel: string) => {
-    switch (alertLevel) {
-      case "critical":
-        return "bg-red-50 dark:bg-red-950/30 border-l-4 border-red-500";
-      case "warn":
-        return "bg-amber-50 dark:bg-amber-950/30 border-l-4 border-amber-500";
-      case "info":
-        return "bg-blue-50 dark:bg-blue-950/30 border-l-4 border-blue-500";
-      default:
-        return "";
-    }
-  };
-
-  return (
-    <div className={`${getAlertClasses(level)} rounded-lg p-2.5 mb-2.5`}>
-      <div className="text-xs font-medium text-gray-900 dark:text-gray-50">
-        {title}
-      </div>
-      <div className="text-xs text-gray-600 dark:text-gray-400 mt-0.5 leading-tight">
-        {desc}
-      </div>
-    </div>
-  );
+interface AlertCardProps {
+  alerts?: Alert[];
+  inactiveUsersLast3Days?: number;
+  onInactiveClick?: () => void;
 }
 
-export function AlertCard({ alerts = [] }: { alerts?: Alert[] }) {
-  
-  // Sort alerts by priority: critical > warn > info
-  const priorityOrder = { critical: 0, warn: 1, info: 2 };
-  const sortedAlerts = [...alerts].sort(
-    (a, b) => priorityOrder[a.level] - priorityOrder[b.level]
-  );
-  
-  const criticalCount = sortedAlerts.filter((a) => a.level === "critical").length;
-
+export function AlertCard({ alerts: _alerts = [], inactiveUsersLast3Days = 0, onInactiveClick }: AlertCardProps) {
   return (
-    
-        // Remove this div when data is dynamic
-    <div className="relative cursor-not-allowed">
     <div className="h-full flex flex-col bg-[var(--card)] border border-[var(--border)] rounded-xl p-4">
+      {/* Header */}
       <div className="flex items-start justify-between mb-3.5">
         <div className="min-w-0 flex-1 mr-2">
-          <div className="text-[13px] font-medium text-[var(--card-foreground)]">Active alerts</div>
-          <div className="text-[11px] text-[var(--muted-foreground)] mt-0.5">Requires leadership action</div>
+          <div className="text-[13px] font-medium text-[var(--card-foreground)]">
+            Alerts &amp; Notifications
+          </div>
+          <div className="text-[11px] text-[var(--muted-foreground)] mt-0.5">
+            Key metrics that need attention
+          </div>
         </div>
-        <Badge label={`${criticalCount} critical`} variant="red" />
       </div>
-      <div className="flex-1 overflow-y-auto pr-1 max-h-[260px]">
-        {sortedAlerts.map((a) => (
-          <AlertItem
-            key={a.id}
-            level={a.level}
-            title={a.title}
-            desc={a.desc}
-          />
-        ))}
+
+      {/* Inactive Users Row */}
+      <div
+        className="flex items-center justify-between rounded-lg p-3 mb-2.5 border border-amber-200 dark:border-amber-800/40 bg-amber-50 dark:bg-amber-950/30 cursor-pointer hover:bg-amber-100 dark:hover:bg-amber-950/50 transition-colors"
+        onClick={() => onInactiveClick?.()}
+      >
+        <div className="flex items-center gap-2.5">
+          <div className="flex items-center justify-center w-7 h-7 rounded-full bg-amber-100 dark:bg-amber-900/40">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-amber-600 dark:text-amber-400"
+            >
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <line x1="23" y1="11" x2="17" y2="11" />
+            </svg>
+          </div>
+          <div>
+            <div className="text-xs font-medium text-gray-900 dark:text-gray-50">
+              Inactive Users (last 3 days)
+            </div>
+            <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
+              Users with zero messages
+            </div>
+          </div>
+        </div>
+        <Badge
+          label={inactiveUsersLast3Days.toLocaleString()}
+          variant="amber"
+        />
       </div>
-    </div>
-    
-        {/* // Remove this div when data is dynamic */}
-    <div className="absolute inset-0 bg-black/30 backdrop-blur-[1px] rounded-lg flex items-center justify-center z-10">
-				<span className="text-white text-xs font-semibold tracking-wide">
-				</span>
-				</div>
+
+      {/* Future alert items can go here */}
+      <div className="flex-1" />
     </div>
   );
 }

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -162,22 +162,25 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                   <EightCardsComponent kpiRow1={kpiRow1WithOverlay} kpiRow2={kpiRow2WithOverlay} />
                 </div>
 
-                {/* DAU trend + Channel split */}
+                {/* DAU trend + Alerts */}
                 <div
                   ref={(el) => {
                     sectionRefs.current["usage-patterns"] = el;
                   }}
-                  className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-3 mb-4"
+                  className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-3 mb-4 items-stretch"
                 >
                   <DailyActiveUsers
                     data={dauTrend}
                     isLoading={dauLoading}
                     error={dauError}
                   />
-                  <ChannelSplitCard
-                    channelSplit={data.channelSplit}
-                    voiceAccuracy={data.voiceAccuracy}
-                  />
+                  <div
+                    ref={(el) => {
+                      sectionRefs.current["bugs-ux"] = el;
+                    }}
+                  >
+                    <AlertCard alerts={data.alerts} inactiveUsersLast3Days={(data as any).inactiveUsersLast3Days ?? 0} onInactiveClick={handleInactiveUsersClick} />
+                  </div>
                 </div>
 
                 {/* Demographics */}
@@ -325,10 +328,13 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                   </div>
                   <div
                     ref={(el) => {
-                      sectionRefs.current["bugs-ux"] = el;
+                      sectionRefs.current["feedback-sentiment"] = el;
                     }}
                   >
-                    <AlertCard alerts={data.alerts} inactiveUsersLast3Days={(data as any).inactiveUsersLast3Days ?? 0} onInactiveClick={handleInactiveUsersClick} />
+                    <ChannelSplitCard
+                      channelSplit={data.channelSplit}
+                      voiceAccuracy={data.voiceAccuracy}
+                    />
                   </div>
                 </div>
 

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -20,6 +20,7 @@ import { SegmentDetailBanner } from "./components/SegmentDetailBanner";
 import { StatusBar } from "./components/StatusBar";
 import { UserDetailsView } from "./UserDetailsView";
 import { UserDemographicsSection } from "./components/UserDemographicsSection";
+import type { UserDetailsFilters } from "./components/UserDetailsPreferenceFilter";
 
 const DEFAULT_FILTERS: DashboardFilterValues = {
   village: "all",
@@ -36,6 +37,7 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
   const segmentRowRefs = useRef<Record<string, HTMLTableRowElement | null>>({});
   const { data, isLoading, error } = useDashboardData(filters, source);
   const { data: dauTrend, isLoading: dauLoading, error: dauError } = useDailyUserTrend(30, source);
+  const [userDetailsInitialFilters, setUserDetailsInitialFilters] = useState<Partial<UserDetailsFilters> | undefined>(undefined);
 
   const sectionRefs = useRef<Partial<Record<DashboardView, HTMLDivElement | null>>>({});
 
@@ -53,6 +55,30 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
   }, [activeSegment]);
 
   const clearSegment = () => setActiveSegment(null);
+
+  // Navigate to User Details with inactive-only filter pre-applied
+  const handleInactiveUsersClick = useCallback(() => {
+    // Align to midnight to match the backend KPI calculation in getKpiSummary
+    const threeDaysAgo = new Date();
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+    threeDaysAgo.setHours(0, 0, 0, 0);
+
+    // End of today (the useUserDetails hook adds +24h to endDate internally,
+    // so we set this to the start of today to cover through end-of-today)
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    setUserDetailsInitialFilters({
+      inactiveOnly: true,
+      startTime: threeDaysAgo,
+      endTime: today,
+      search: "",
+      crop: "",
+      village: "",
+      profileCompleted: "all",
+    });
+    setActiveView("user-details");
+  }, []);
 
   // Patch the DAU card to show "today / total" instead of just total
   const patchedKpiRow1 = useMemo(() => {
@@ -111,7 +137,7 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
             />
 
             {activeView === "user-details" ? (
-              <UserDetailsView source={source} />
+              <UserDetailsView source={source} initialFilters={userDetailsInitialFilters} />
             ) : (
               <div className="flex-1 overflow-y-auto px-5 pb-5">
                 <DashboardFilters
@@ -300,7 +326,7 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                       sectionRefs.current["bugs-ux"] = el;
                     }}
                   >
-                    <AlertCard alerts={data.alerts} />
+                    <AlertCard alerts={data.alerts} inactiveUsersLast3Days={(data as any).inactiveUsersLast3Days ?? 0} onInactiveClick={handleInactiveUsersClick} />
                   </div>
                 </div>
 

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -129,6 +129,8 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
               activeView={activeView}
               onViewChange={(view) => {
                 setActiveView(view);
+                // Clear AlertCard's pre-set filters when navigating via sidebar
+                if (view === "user-details") setUserDetailsInitialFilters(undefined);
                 if (view !== "user-details") scrollTo(view);
               }}
               healthScore={70}

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -193,34 +193,18 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                 />
 
                 {/* 3-col row */}
-                <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 mb-4">
-                  <div
-                    ref={(el) => {
-                      sectionRefs.current["query-analysis"] = el;
-                    }}
-                  >
-                    <DashboardQueryCategories
-                      categories={data.queryCategories}
-                    />
-                  </div>
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 mb-4 items-stretch">
                   <div
                     ref={(el) => {
                       sectionRefs.current["farmer-segments"] = el;
                     }}
                   >
-                    {/* <DashboardFarmerSegments
-                      segments={data.farmerSegments}
-                      activeSegment={activeSegment}
-                      onSegmentClick={handleSegmentClick}
-                      onClear={clearSegment}
-                      segmentRowRefs={segmentRowRefs}
-                    /> */}
                     {/* Knowledge & Awareness */}
                     <div className="rounded-xl border border-gray-200 bg-white dark:border-[#2a2a2a] dark:bg-[#1a1a1a] p-4 h-full">
                       <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
                         Knowledge & Awareness
                       </div>
-                      <div className="flex gap-6 justify-center items-center h-[calc(100%-2rem)]">
+                      <div className="flex flex-wrap gap-4 justify-center items-center h-[calc(100%-2rem)] overflow-hidden">
                         {/* KCC Awareness Circle */}
                         {(() => {
                           const pct = data.kccAwareness?.[0]?.pct ?? 0;
@@ -230,11 +214,10 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                             circ = 2 * Math.PI * r;
                           const dash = (pct / 100) * circ;
                           return (
-                            <div className="flex flex-col items-center gap-2">
+                            <div className="flex flex-col items-center gap-2 min-w-0">
                               <svg
-                                width={120}
-                                height={120}
                                 viewBox="0 0 120 120"
+                                className="w-[100px] h-[100px] lg:w-[110px] lg:h-[110px] shrink-0"
                               >
                                 <circle
                                   cx={cx}
@@ -281,11 +264,10 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                             circ = 2 * Math.PI * r;
                           const dash = (pct / 100) * circ;
                           return (
-                            <div className="flex flex-col items-center gap-2">
+                            <div className="flex flex-col items-center gap-2 min-w-0">
                               <svg
-                                width={120}
-                                height={120}
                                 viewBox="0 0 120 120"
+                                className="w-[100px] h-[100px] lg:w-[110px] lg:h-[110px] shrink-0"
                               >
                                 <circle
                                   cx={cx}
@@ -325,6 +307,15 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                         })()}
                       </div>
                     </div>
+                  </div>
+                  <div
+                    ref={(el) => {
+                      sectionRefs.current["query-analysis"] = el;
+                    }}
+                  >
+                    <DashboardQueryCategories
+                      categories={data.queryCategories}
+                    />
                   </div>
                   <div
                     ref={(el) => {

--- a/frontend/src/features/chatbotDashboard/DashboardQueryCategories.tsx
+++ b/frontend/src/features/chatbotDashboard/DashboardQueryCategories.tsx
@@ -81,7 +81,7 @@ export const DashboardQueryCategories: React.FC<QueryCategoriesProps> = ({
 }) => {
     return (
         // Remove this div when data is dynamic
-        <div className="relative cursor-not-allowed">
+        <div className="relative cursor-not-allowed h-full">
         <div className="bg-white dark:bg-[#1a1a1a] border border-gray-200 dark:border-gray-800 rounded-xl p-4 flex flex-col h-full">
             {/* Header */}
             <div className="flex items-start justify-between mb-4">

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -85,11 +85,23 @@ const DEFAULT_FILTERS: UserDetailsFilters = {
 
 interface UserDetailsViewProps {
   source?: 'vicharanashala' | 'annam';
+  initialFilters?: Partial<UserDetailsFilters>;
 }
 
-export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewProps) {
-  const [filters, setFilters] = useState<UserDetailsFilters>(DEFAULT_FILTERS);
+export function UserDetailsView({ source = 'vicharanashala', initialFilters }: UserDetailsViewProps) {
+  const [filters, setFilters] = useState<UserDetailsFilters>(() => ({
+    ...DEFAULT_FILTERS,
+    ...initialFilters,
+  }));
   const [currentPage, setCurrentPage] = useState(1);
+
+  // Apply initialFilters when they change (e.g. clicking from AlertCard)
+  useEffect(() => {
+    if (initialFilters) {
+      setFilters(prev => ({ ...prev, ...initialFilters }));
+      setCurrentPage(1);
+    }
+  }, [initialFilters]);
 
   const { data, isLoading, error } = useUserDetails(
     filters.startTime,

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -73,12 +73,6 @@ function CropsCell({ crops }: { crops: string[] }) {
     </div>
   );
 }
-function defaultInactiveStart(): Date {
-  const d = new Date();
-  d.setDate(d.getDate() - 3);
-  return d;
-}
-
 const DEFAULT_FILTERS: UserDetailsFilters = {
   search: "",
   crop: "",
@@ -87,8 +81,6 @@ const DEFAULT_FILTERS: UserDetailsFilters = {
   endTime: undefined,
   profileCompleted: "all",
   inactiveOnly: false,
-  inactiveStartTime: defaultInactiveStart(),
-  inactiveEndTime: new Date(),
 };
 
 interface UserDetailsViewProps {
@@ -99,13 +91,9 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
   const [filters, setFilters] = useState<UserDetailsFilters>(DEFAULT_FILTERS);
   const [currentPage, setCurrentPage] = useState(1);
 
-  // When inactiveOnly is on, use the inactive date range for the query window
-  const queryStartDate = filters.inactiveOnly ? filters.inactiveStartTime : filters.startTime;
-  const queryEndDate = filters.inactiveOnly ? filters.inactiveEndTime : filters.endTime;
-
   const { data, isLoading, error } = useUserDetails(
-    queryStartDate,
-    queryEndDate,
+    filters.startTime,
+    filters.endTime,
     currentPage,
     PAGE_SIZE,
     filters.search,
@@ -124,11 +112,7 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
   };
 
   const handleResetFilters = () => {
-    setFilters({
-      ...DEFAULT_FILTERS,
-      inactiveStartTime: defaultInactiveStart(),
-      inactiveEndTime: new Date(),
-    });
+    setFilters(DEFAULT_FILTERS);
     setCurrentPage(1);
   };
 

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -194,7 +194,7 @@ export function UserDetailsView({ source = 'vicharanashala', initialFilters }: U
         </Card>
 
         {/* Bar graph — col 1 row 2 on sm+, after all 3 cards on mobile */}
-        {!isLoading && !error && users.length > 0 && (
+        {!isLoading && !error && users.length > 0 && !filters.inactiveOnly && (
           <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a] sm:col-start-1 sm:row-start-2">
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium">Questions per User</CardTitle>

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -73,6 +73,12 @@ function CropsCell({ crops }: { crops: string[] }) {
     </div>
   );
 }
+function defaultInactiveStart(): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - 3);
+  return d;
+}
+
 const DEFAULT_FILTERS: UserDetailsFilters = {
   search: "",
   crop: "",
@@ -80,6 +86,9 @@ const DEFAULT_FILTERS: UserDetailsFilters = {
   startTime: undefined,
   endTime: undefined,
   profileCompleted: "all",
+  inactiveOnly: false,
+  inactiveStartTime: defaultInactiveStart(),
+  inactiveEndTime: new Date(),
 };
 
 interface UserDetailsViewProps {
@@ -90,9 +99,13 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
   const [filters, setFilters] = useState<UserDetailsFilters>(DEFAULT_FILTERS);
   const [currentPage, setCurrentPage] = useState(1);
 
+  // When inactiveOnly is on, use the inactive date range for the query window
+  const queryStartDate = filters.inactiveOnly ? filters.inactiveStartTime : filters.startTime;
+  const queryEndDate = filters.inactiveOnly ? filters.inactiveEndTime : filters.endTime;
+
   const { data, isLoading, error } = useUserDetails(
-    filters.startTime,
-    filters.endTime,
+    queryStartDate,
+    queryEndDate,
     currentPage,
     PAGE_SIZE,
     filters.search,
@@ -100,6 +113,7 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
     filters.crop,
     filters.village,
     filters.profileCompleted,
+    filters.inactiveOnly,
   );
 
   const { users, totalUsers, totalPages, activeUsers, totalQuestions } = data;
@@ -110,7 +124,11 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
   };
 
   const handleResetFilters = () => {
-    setFilters(DEFAULT_FILTERS);
+    setFilters({
+      ...DEFAULT_FILTERS,
+      inactiveStartTime: defaultInactiveStart(),
+      inactiveEndTime: new Date(),
+    });
     setCurrentPage(1);
   };
 
@@ -119,7 +137,8 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
     filters.crop ||
     filters.village ||
     filters.startTime ||
-    filters.profileCompleted !== "all";
+    filters.profileCompleted !== "all" ||
+    filters.inactiveOnly;
 
   const dateLabel = filters.startTime && filters.endTime
     ? `${filters.startTime.toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })} – ${filters.endTime.toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })}`

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -116,7 +116,7 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
     filters.inactiveOnly,
   );
 
-  const { users, totalUsers, totalPages, activeUsers, totalQuestions } = data;
+  const { users, totalUsers, totalPages, activeUsers, inactiveUsers, totalQuestions } = data;
 
   const handleApplyFilters = (newFilters: UserDetailsFilters) => {
     setFilters(newFilters);
@@ -158,20 +158,7 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
 
       {/* Summary cards + graphs */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5">
-        {/* Total Users — col 1 row 1 */}
-        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a] relative overflow-hidden self-start">
-          <div className="absolute inset-x-0 top-0 h-1 bg-[#3AAA5A]" />
-          <CardContent className="p-4 flex flex-col gap-0.5">
-            <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-              Total Users
-            </span>
-            <span className="text-2xl font-semibold dark:text-slate-100">
-              {isLoading ? "—" : totalUsers.toLocaleString()}
-            </span>
-          </CardContent>
-        </Card>
-
-        {/* Active Users — col 2 row 1 */}
+        {/* Active Users — col 1 row 1 */}
         <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a] relative overflow-hidden self-start">
           <div className="absolute inset-x-0 top-0 h-1 bg-[#3B82F6]" />
           <CardContent className="p-4 flex flex-col gap-0.5">
@@ -180,6 +167,19 @@ export function UserDetailsView({ source = 'vicharanashala' }: UserDetailsViewPr
             </span>
             <span className="text-2xl font-semibold dark:text-slate-100">
               {isLoading ? "—" : activeUsers.toLocaleString()}
+            </span>
+          </CardContent>
+        </Card>
+
+        {/* Inactive Users — col 2 row 1 */}
+        <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a] relative overflow-hidden self-start">
+          <div className="absolute inset-x-0 top-0 h-1 bg-[#EF4444]" />
+          <CardContent className="p-4 flex flex-col gap-0.5">
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Inactive Users
+            </span>
+            <span className="text-2xl font-semibold dark:text-slate-100">
+              {isLoading ? "—" : inactiveUsers.toLocaleString()}
             </span>
           </CardContent>
         </Card>

--- a/frontend/src/features/chatbotDashboard/components/ChannelSplitCard.tsx
+++ b/frontend/src/features/chatbotDashboard/components/ChannelSplitCard.tsx
@@ -13,7 +13,7 @@ interface Props {
 export function ChannelSplitCard({ channelSplit, voiceAccuracy }: Props) {
   return (
     //  Remove this div when data is dynamic
-    <div className="relative cursor-not-allowed">
+    <div className="relative cursor-not-allowed h-full">
     <Card title="Channel split" subtitle="How farmers access ACE">
       <div className="max-h-[260px] overflow-y-auto pr-1">
         <DonutChart segments={channelSplit} />

--- a/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
+++ b/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
@@ -19,6 +19,11 @@ import {
 } from "@/components/atoms/select";
 import { Badge } from "@/components/atoms/badge";
 import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/atoms/tooltip";
+import {
   Filter,
   Search,
   Sprout,
@@ -27,8 +32,9 @@ import {
   UserCheck,
   RefreshCcw,
   UserX,
+  Info,
 } from "lucide-react";
-import { Checkbox } from "@/components/atoms/checkbox";
+import { cn } from "@/lib/utils";
 
 export interface UserDetailsFilters {
   search: string;
@@ -260,34 +266,58 @@ export function UserDetailsPreferenceFilter({
             )}
           </FilterSection>
 
-          {/* Profile Completed + Inactive Users inline */}
-          <div className="rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-[#161616] p-4 space-y-2">
-            <div className="flex items-center justify-between gap-3">
+          {/* Inactive Users */}
+          <div className="rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-[#161616] p-4">
+            <div className="flex items-center justify-between">
               <Label className="flex items-center gap-2 text-sm font-semibold text-(--foreground)">
                 <span className="flex items-center justify-center w-6 h-6 rounded-md bg-[#3AAA5A]/10 text-[#3AAA5A]">
-                  <UserCheck className="h-3.5 w-3.5" />
+                  <UserX className="h-3.5 w-3.5" />
                 </span>
-                Farmer Profile
+                Inactive Users
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="h-3.5 w-3.5 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-[200px] text-xs">
+                    Shows users who have not asked any questions in the selected date range
+                  </TooltipContent>
+                </Tooltip>
               </Label>
-              <div className="flex items-center gap-2">
-                <Checkbox
+              <label
+                htmlFor="inactive-only"
+                className={cn(
+                  "relative inline-flex h-[22px] w-[40px] shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200",
+                  draft.inactiveOnly
+                    ? "bg-[#3AAA5A]"
+                    : "bg-gray-300 dark:bg-gray-600"
+                )}
+              >
+                <input
+                  type="checkbox"
                   id="inactive-only"
+                  className="sr-only"
                   checked={draft.inactiveOnly}
-                  onCheckedChange={(checked) =>
+                  onChange={(e) =>
                     setDraft((d) => ({
                       ...d,
-                      inactiveOnly: !!checked,
-                      startTime: checked && !d.startTime ? defaultInactiveStart() : d.startTime,
-                      endTime: checked && !d.endTime ? defaultInactiveEnd() : d.endTime,
+                      inactiveOnly: e.target.checked,
+                      startTime: e.target.checked && !d.startTime ? defaultInactiveStart() : d.startTime,
+                      endTime: e.target.checked && !d.endTime ? defaultInactiveEnd() : d.endTime,
                     }))
                   }
                 />
-                <Label htmlFor="inactive-only" className="flex items-center gap-1.5 text-sm cursor-pointer select-none text-(--foreground)">
-                  <UserX className="h-3.5 w-3.5 text-[#3AAA5A]" />
-                  Inactive Users
-                </Label>
-              </div>
+                <span
+                  className={cn(
+                    "pointer-events-none inline-block h-[18px] w-[18px] rounded-full bg-white shadow transition-transform duration-200",
+                    draft.inactiveOnly ? "translate-x-[20px]" : "translate-x-[2px]"
+                  )}
+                />
+              </label>
             </div>
+          </div>
+
+          {/* Profile Completed */}
+          <FilterSection icon={<UserCheck className="h-3.5 w-3.5" />} label="Farmer Profile">
             <Select
               value={draft.profileCompleted}
               onValueChange={(v) =>
@@ -303,7 +333,7 @@ export function UserDetailsPreferenceFilter({
                 <SelectItem value="no">Profile Not Completed</SelectItem>
               </SelectContent>
             </Select>
-          </div>
+          </FilterSection>
         </div>
 
         {/* Footer */}

--- a/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
+++ b/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
@@ -67,6 +67,13 @@ function fromDateInputValue(s: string): Date | undefined {
 function defaultInactiveStart(): Date {
   const d = new Date();
   d.setDate(d.getDate() - 3);
+  d.setHours(0, 0, 0, 0); // midnight local — must match handleInactiveUsersClick
+  return d;
+}
+
+function defaultInactiveEnd(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0); // midnight today — useUserDetails adds +24h internally
   return d;
 }
 
@@ -271,7 +278,7 @@ export function UserDetailsPreferenceFilter({
                       ...d,
                       inactiveOnly: !!checked,
                       startTime: checked && !d.startTime ? defaultInactiveStart() : d.startTime,
-                      endTime: checked && !d.endTime ? new Date() : d.endTime,
+                      endTime: checked && !d.endTime ? defaultInactiveEnd() : d.endTime,
                     }))
                   }
                 />

--- a/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
+++ b/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
@@ -47,12 +47,21 @@ interface UserDetailsPreferenceFilterProps {
 
 function toDateInputValue(d: Date | undefined): string {
   if (!d) return "";
-  return d.toISOString().split("T")[0];
+  // Format using local time components to stay consistent with fromDateInputValue.
+  // d.toISOString() converts to UTC first, which can shift the date by a day for IST users.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
 function fromDateInputValue(s: string): Date | undefined {
   if (!s) return undefined;
-  return new Date(s);
+  // Parse as local midnight, NOT UTC.
+  // new Date("YYYY-MM-DD") treats the string as UTC which causes a timezone
+  // offset mismatch vs setHours(0,0,0,0) used elsewhere in the app.
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
 }
 
 function defaultInactiveStart(): Date {
@@ -236,10 +245,42 @@ export function UserDetailsPreferenceFilter({
                 />
               </div>
             </div>
+            {draft.inactiveOnly && inactiveDateError && (
+              <p className="text-xs text-destructive mt-2">{inactiveDateError}</p>
+            )}
+            {draft.inactiveOnly && !inactiveDateError && (
+              <p className="text-xs text-muted-foreground mt-2">Range: 3–30 days</p>
+            )}
           </FilterSection>
 
-          {/* Profile Completed */}
-          <FilterSection icon={<UserCheck className="h-3.5 w-3.5" />} label="Farmer Profile">
+          {/* Profile Completed + Inactive Users inline */}
+          <div className="rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-[#161616] p-4 space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <Label className="flex items-center gap-2 text-sm font-semibold text-(--foreground)">
+                <span className="flex items-center justify-center w-6 h-6 rounded-md bg-[#3AAA5A]/10 text-[#3AAA5A]">
+                  <UserCheck className="h-3.5 w-3.5" />
+                </span>
+                Farmer Profile
+              </Label>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="inactive-only"
+                  checked={draft.inactiveOnly}
+                  onCheckedChange={(checked) =>
+                    setDraft((d) => ({
+                      ...d,
+                      inactiveOnly: !!checked,
+                      startTime: checked && !d.startTime ? defaultInactiveStart() : d.startTime,
+                      endTime: checked && !d.endTime ? new Date() : d.endTime,
+                    }))
+                  }
+                />
+                <Label htmlFor="inactive-only" className="flex items-center gap-1.5 text-sm cursor-pointer select-none text-(--foreground)">
+                  <UserX className="h-3.5 w-3.5 text-[#3AAA5A]" />
+                  Inactive Users
+                </Label>
+              </div>
+            </div>
             <Select
               value={draft.profileCompleted}
               onValueChange={(v) =>
@@ -255,37 +296,7 @@ export function UserDetailsPreferenceFilter({
                 <SelectItem value="no">Profile Not Completed</SelectItem>
               </SelectContent>
             </Select>
-          </FilterSection>
-
-          {/* Inactive Users */}
-          <FilterSection icon={<UserX className="h-3.5 w-3.5" />} label="Inactive Users">
-            <div className="flex items-center gap-2.5 py-1">
-              <Checkbox
-                id="inactive-only"
-                checked={draft.inactiveOnly}
-                onCheckedChange={(checked) =>
-                  setDraft((d) => ({
-                    ...d,
-                    inactiveOnly: !!checked,
-                    // Auto-default to last 3 days if no date range is set
-                    startTime: checked && !d.startTime ? defaultInactiveStart() : d.startTime,
-                    endTime: checked && !d.endTime ? new Date() : d.endTime,
-                  }))
-                }
-              />
-              <Label htmlFor="inactive-only" className="text-sm cursor-pointer select-none">
-                Show only users with 0 questions in period
-              </Label>
-            </div>
-            {draft.inactiveOnly && (
-              <p className="text-xs mt-1 text-muted-foreground">
-                Uses the Date Range above · must be 3–30 days
-              </p>
-            )}
-            {draft.inactiveOnly && inactiveDateError && (
-              <p className="text-xs text-destructive mt-1">{inactiveDateError}</p>
-            )}
-          </FilterSection>
+          </div>
         </div>
 
         {/* Footer */}

--- a/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
+++ b/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
@@ -38,8 +38,6 @@ export interface UserDetailsFilters {
   endTime: Date | undefined;
   profileCompleted: "all" | "yes" | "no";
   inactiveOnly: boolean;
-  inactiveStartTime: Date | undefined;
-  inactiveEndTime: Date | undefined;
 }
 
 interface UserDetailsPreferenceFilterProps {
@@ -89,7 +87,7 @@ function FilterSection({
 }
 
 function getInactiveDateError(from: Date | undefined, to: Date | undefined): string {
-  if (!from || !to) return "";
+  if (!from || !to) return "A date range is required for inactive users filter";
   const diffDays = Math.round((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24));
   if (diffDays < 3) return "Range must be at least 3 days";
   if (diffDays > 30) return "Range cannot exceed 30 days";
@@ -103,7 +101,9 @@ export function UserDetailsPreferenceFilter({
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<UserDetailsFilters>(filters);
 
-  const inactiveDateError = getInactiveDateError(draft.inactiveStartTime, draft.inactiveEndTime);
+  const inactiveDateError = draft.inactiveOnly
+    ? getInactiveDateError(draft.startTime, draft.endTime)
+    : "";
 
   const handleOpen = (isOpen: boolean) => {
     if (isOpen) setDraft(filters);
@@ -124,8 +124,6 @@ export function UserDetailsPreferenceFilter({
       endTime: undefined,
       profileCompleted: "all",
       inactiveOnly: false,
-      inactiveStartTime: defaultInactiveStart(),
-      inactiveEndTime: new Date(),
     });
   };
 
@@ -269,8 +267,9 @@ export function UserDetailsPreferenceFilter({
                   setDraft((d) => ({
                     ...d,
                     inactiveOnly: !!checked,
-                    inactiveStartTime: d.inactiveStartTime ?? defaultInactiveStart(),
-                    inactiveEndTime: d.inactiveEndTime ?? new Date(),
+                    // Auto-default to last 3 days if no date range is set
+                    startTime: checked && !d.startTime ? defaultInactiveStart() : d.startTime,
+                    endTime: checked && !d.endTime ? new Date() : d.endTime,
                   }))
                 }
               />
@@ -278,43 +277,13 @@ export function UserDetailsPreferenceFilter({
                 Show only users with 0 questions in period
               </Label>
             </div>
-
             {draft.inactiveOnly && (
-              <div className="mt-2 space-y-2">
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1">
-                    <span className="text-xs text-muted-foreground font-medium">From</span>
-                    <input
-                      type="date"
-                      value={toDateInputValue(draft.inactiveStartTime)}
-                      max={toDateInputValue(draft.inactiveEndTime) || toDateInputValue(new Date())}
-                      onChange={(e) =>
-                        setDraft((d) => ({ ...d, inactiveStartTime: fromDateInputValue(e.target.value) }))
-                      }
-                      className={inputClass}
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <span className="text-xs text-muted-foreground font-medium">To</span>
-                    <input
-                      type="date"
-                      value={toDateInputValue(draft.inactiveEndTime)}
-                      min={toDateInputValue(draft.inactiveStartTime)}
-                      max={toDateInputValue(new Date())}
-                      onChange={(e) =>
-                        setDraft((d) => ({ ...d, inactiveEndTime: fromDateInputValue(e.target.value) }))
-                      }
-                      className={inputClass}
-                    />
-                  </div>
-                </div>
-                {inactiveDateError && (
-                  <p className="text-xs text-destructive">{inactiveDateError}</p>
-                )}
-                {!inactiveDateError && (
-                  <p className="text-xs text-muted-foreground">Range: 3–30 days</p>
-                )}
-              </div>
+              <p className="text-xs mt-1 text-muted-foreground">
+                Uses the Date Range above · must be 3–30 days
+              </p>
+            )}
+            {draft.inactiveOnly && inactiveDateError && (
+              <p className="text-xs text-destructive mt-1">{inactiveDateError}</p>
             )}
           </FilterSection>
         </div>

--- a/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
+++ b/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
@@ -26,7 +26,9 @@ import {
   Calendar,
   UserCheck,
   RefreshCcw,
+  UserX,
 } from "lucide-react";
+import { Checkbox } from "@/components/atoms/checkbox";
 
 export interface UserDetailsFilters {
   search: string;
@@ -35,6 +37,9 @@ export interface UserDetailsFilters {
   startTime: Date | undefined;
   endTime: Date | undefined;
   profileCompleted: "all" | "yes" | "no";
+  inactiveOnly: boolean;
+  inactiveStartTime: Date | undefined;
+  inactiveEndTime: Date | undefined;
 }
 
 interface UserDetailsPreferenceFilterProps {
@@ -50,6 +55,12 @@ function toDateInputValue(d: Date | undefined): string {
 function fromDateInputValue(s: string): Date | undefined {
   if (!s) return undefined;
   return new Date(s);
+}
+
+function defaultInactiveStart(): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - 3);
+  return d;
 }
 
 const inputClass =
@@ -77,12 +88,22 @@ function FilterSection({
   );
 }
 
+function getInactiveDateError(from: Date | undefined, to: Date | undefined): string {
+  if (!from || !to) return "";
+  const diffDays = Math.round((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays < 3) return "Range must be at least 3 days";
+  if (diffDays > 30) return "Range cannot exceed 30 days";
+  return "";
+}
+
 export function UserDetailsPreferenceFilter({
   filters,
   onApply,
 }: UserDetailsPreferenceFilterProps) {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<UserDetailsFilters>(filters);
+
+  const inactiveDateError = getInactiveDateError(draft.inactiveStartTime, draft.inactiveEndTime);
 
   const handleOpen = (isOpen: boolean) => {
     if (isOpen) setDraft(filters);
@@ -102,6 +123,9 @@ export function UserDetailsPreferenceFilter({
       startTime: undefined,
       endTime: undefined,
       profileCompleted: "all",
+      inactiveOnly: false,
+      inactiveStartTime: defaultInactiveStart(),
+      inactiveEndTime: new Date(),
     });
   };
 
@@ -110,7 +134,8 @@ export function UserDetailsPreferenceFilter({
     (filters.crop ? 1 : 0) +
     (filters.village ? 1 : 0) +
     (filters.startTime ? 1 : 0) +
-    (filters.profileCompleted !== "all" ? 1 : 0);
+    (filters.profileCompleted !== "all" ? 1 : 0) +
+    (filters.inactiveOnly ? 1 : 0);
 
   return (
     <Dialog open={open} onOpenChange={handleOpen}>
@@ -233,6 +258,65 @@ export function UserDetailsPreferenceFilter({
               </SelectContent>
             </Select>
           </FilterSection>
+
+          {/* Inactive Users */}
+          <FilterSection icon={<UserX className="h-3.5 w-3.5" />} label="Inactive Users">
+            <div className="flex items-center gap-2.5 py-1">
+              <Checkbox
+                id="inactive-only"
+                checked={draft.inactiveOnly}
+                onCheckedChange={(checked) =>
+                  setDraft((d) => ({
+                    ...d,
+                    inactiveOnly: !!checked,
+                    inactiveStartTime: d.inactiveStartTime ?? defaultInactiveStart(),
+                    inactiveEndTime: d.inactiveEndTime ?? new Date(),
+                  }))
+                }
+              />
+              <Label htmlFor="inactive-only" className="text-sm cursor-pointer select-none">
+                Show only users with 0 questions in period
+              </Label>
+            </div>
+
+            {draft.inactiveOnly && (
+              <div className="mt-2 space-y-2">
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <span className="text-xs text-muted-foreground font-medium">From</span>
+                    <input
+                      type="date"
+                      value={toDateInputValue(draft.inactiveStartTime)}
+                      max={toDateInputValue(draft.inactiveEndTime) || toDateInputValue(new Date())}
+                      onChange={(e) =>
+                        setDraft((d) => ({ ...d, inactiveStartTime: fromDateInputValue(e.target.value) }))
+                      }
+                      className={inputClass}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <span className="text-xs text-muted-foreground font-medium">To</span>
+                    <input
+                      type="date"
+                      value={toDateInputValue(draft.inactiveEndTime)}
+                      min={toDateInputValue(draft.inactiveStartTime)}
+                      max={toDateInputValue(new Date())}
+                      onChange={(e) =>
+                        setDraft((d) => ({ ...d, inactiveEndTime: fromDateInputValue(e.target.value) }))
+                      }
+                      className={inputClass}
+                    />
+                  </div>
+                </div>
+                {inactiveDateError && (
+                  <p className="text-xs text-destructive">{inactiveDateError}</p>
+                )}
+                {!inactiveDateError && (
+                  <p className="text-xs text-muted-foreground">Range: 3–30 days</p>
+                )}
+              </div>
+            )}
+          </FilterSection>
         </div>
 
         {/* Footer */}
@@ -255,7 +339,8 @@ export function UserDetailsPreferenceFilter({
             <Button
               size="sm"
               onClick={handleApply}
-              className="bg-[#3AAA5A] hover:bg-[#2e9449] text-white px-5"
+              disabled={draft.inactiveOnly && !!inactiveDateError}
+              className="bg-[#3AAA5A] hover:bg-[#2e9449] text-white px-5 disabled:opacity-50"
             >
               Apply Filters
             </Button>

--- a/frontend/src/features/chatbotDashboard/components/shared/Card.tsx
+++ b/frontend/src/features/chatbotDashboard/components/shared/Card.tsx
@@ -9,7 +9,7 @@ interface CardProps {
 
 export function Card({ title, subtitle, action, children }: CardProps) {
   return (
-    <div className="bg-[var(--card)] border border-[var(--border)] rounded-xl p-4 flex flex-col">
+    <div className="bg-[var(--card)] border border-[var(--border)] rounded-xl p-4 flex flex-col h-full">
       <div className="flex items-start justify-between mb-[14px]">
         <div className={`min-w-0 flex-1 ${action ? "mr-2" : ""}`}>
           <div className="text-[13px] font-medium text-[var(--card-foreground)]">{title}</div>

--- a/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
@@ -20,6 +20,7 @@ interface DashboardApiResponse {
     repeatQueryRatePct: number;
     voiceUsageSharePct: number;
     totalAppInstalls: number;
+    inactiveUsersLast3Days: number;
   };
   dau: DailyEntry[];
   weeklySessionDuration: Array<{ week: string; avgSessionDurationMin: number }>;
@@ -110,8 +111,8 @@ function weeklyRange(entries: Array<{ week: string }>): string {
 
 // ── Transform raw API response into dashboard shape ─────────────────────────
 
-function transformApiResponse(result: DashboardApiResponse): DashboardDataType {
-  const updatedData = { ...DASHBOARD_DATA };
+function transformApiResponse(result: DashboardApiResponse): DashboardDataType & { inactiveUsersLast3Days: number } {
+  const updatedData = { ...DASHBOARD_DATA } as DashboardDataType & { inactiveUsersLast3Days: number };
 
   // Use the real month-over-month % from the backend
   const pct = result.kpi.dauLastMonthPct;
@@ -176,6 +177,8 @@ function transformApiResponse(result: DashboardApiResponse): DashboardDataType {
     }
     return card;
   });
+
+  updatedData.inactiveUsersLast3Days = result.kpi.inactiveUsersLast3Days ?? 0;
 
   updatedData.kpiRow1 = DASHBOARD_DATA.kpiRow1.map(card => {
     if (card.id === 'dau') {

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -39,6 +39,7 @@ export interface PaginatedUserDetailsResponse {
   totalUsers: number;
   totalPages: number;
   activeUsers: number;
+  inactiveUsers: number;
   totalQuestions: number;
 }
 
@@ -82,12 +83,12 @@ export function useUserDetails(
         `${API_BASE_URL}/analytics/user-details?${params.toString()}`,
       );
 
-      return result ?? { users: [], totalUsers: 0, totalPages: 1, activeUsers: 0, totalQuestions: 0 };
+      return result ?? { users: [], totalUsers: 0, totalPages: 1, activeUsers: 0, inactiveUsers: 0, totalQuestions: 0 };
     },
   });
 
   return {
-    data: data ?? { users: [], totalUsers: 0, totalPages: 1, activeUsers: 0, totalQuestions: 0 },
+    data: data ?? { users: [], totalUsers: 0, totalPages: 1, activeUsers: 0, inactiveUsers: 0, totalQuestions: 0 },
     isLoading,
     error,
   };

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -52,6 +52,7 @@ export function useUserDetails(
   crop = '',
   village = '',
   profileCompleted: 'all' | 'yes' | 'no' = 'all',
+  inactiveOnly = false,
 ) {
   const startISO = startDate?.toISOString();
   // Extend endDate to end of day (23:59:59.999) so the selected day is fully included.
@@ -61,7 +62,7 @@ export function useUserDetails(
     : undefined;
 
   const { data, isLoading, error } = useQuery<PaginatedUserDetailsResponse, Error>({
-    queryKey: ['user-details', startISO, endISO, page, limit, search, source, crop, village, profileCompleted],
+    queryKey: ['user-details', startISO, endISO, page, limit, search, source, crop, village, profileCompleted, inactiveOnly],
     staleTime: 30 * 1000,
     queryFn: async () => {
       const API_BASE_URL = env.apiBaseUrl();
@@ -75,6 +76,7 @@ export function useUserDetails(
       if (crop.trim()) params.set('crop', crop.trim());
       if (village.trim()) params.set('village', village.trim());
       if (profileCompleted !== 'all') params.set('profileCompleted', profileCompleted);
+      if (inactiveOnly) params.set('inactiveOnly', 'true');
 
       const result = await apiFetch<PaginatedUserDetailsResponse>(
         `${API_BASE_URL}/analytics/user-details?${params.toString()}`,


### PR DESCRIPTION
## Overview
This PR enables the "Alerts & Notifications" card on the chatbot dashboard by removing its disabled state and populating it with a dynamic "Inactive Users (last 3 days)" metric. It also introduces seamless click-to-navigate functionality, allowing admins to instantly view the affected inactive users in the User Details table.
## Key Changes
### Backend
* **New KPI Metric:** Added `inactiveUsersLast3Days` to the `KpiSummary` interface and API response validator.
* **Metric Calculation:** Updated `ChatbotRepository.getKpiSummary()` to compute the inactive user count by finding distinct active users in the `messages` collection over the last 3 days and subtracting from total users.
### Frontend
* **AlertCard Redesign:** Removed the hardcoded disabled overlay. Replaced it with an interactive UI displaying the live "Inactive Users (last 3 days)" count.
* **Data Threading:** Updated the `useDashboardData` hook to pass the new metric down from the `/api/analytics` endpoint.
* **Seamless Navigation:** 
  * Wired up `AlertCard`'s onClick handler to transition the dashboard view to the `UserDetailsView`.
  * Added an `initialFilters` prop to `UserDetailsView` so that when navigating from the AlertCard, the table automatically pre-filters for `inactiveOnly = true` and sets the date range to the last 3 days.