### PR TITLE
Feat/show duplicate question count

### DIFF
--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -28,6 +28,7 @@ export interface DashboardResponse {
   farmingExperience: DemographicEntry[];
   kccAwareness: DemographicEntry[];
   agriAppUsage: DemographicEntry[];
+  duplicateQuestionCount: number;
 }
 
 export interface IChatbotService {

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -4,17 +4,21 @@ import { CHATBOT_TYPES } from '../types.js';
 import type { IChatbotService, DashboardResponse } from '../interfaces/IChatbotService.js';
 import type { IChatbotRepository, ChatbotConversationData } from '#root/shared/database/interfaces/IChatbotRepository.js';
 import ExcelJS from 'exceljs';
+import { IDuplicateQuestionRepository } from '#root/shared/database/interfaces/IDuplicateQuestionRepository.js';
+import { GLOBAL_TYPES } from '#root/types.js';
 
 @injectable()
 export class ChatbotService implements IChatbotService {
   constructor(
     @inject(CHATBOT_TYPES.ChatbotRepository)
     private readonly chatbotRepository: IChatbotRepository,
+    @inject(GLOBAL_TYPES.DuplicateQuestionRepository)
+    private readonly duplicateQuestionRepository: IDuplicateQuestionRepository,
   ) {}
 
   async getDashboard(days = 30, source = 'vicharanashala'): Promise<DashboardResponse> {
     try {
-      const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, dailyQueries, todayQueryCount, weeklyQueries, avgSessionDurationMin, weeklySessionDuration, demographics, kccAndAgri] =
+      const [kpi, dau, channelSplit, voiceAccuracy, geo, queryCategories, dailyQueries, todayQueryCount, weeklyQueries, avgSessionDurationMin, weeklySessionDuration, demographics, kccAndAgri, duplicateQuestionCount] =
         await Promise.all([
           this.chatbotRepository.getKpiSummary(source),
           this.chatbotRepository.getDailyActiveUsers(days, source),
@@ -31,6 +35,9 @@ export class ChatbotService implements IChatbotService {
           this.chatbotRepository.getWeeklyAvgSessionDurationV2(Math.ceil(days / 7), source),
           this.chatbotRepository.getUserDemographics(source),
           this.chatbotRepository.getKccAndAgriAppStats(source),
+
+          // get duplicate question count
+          this.duplicateQuestionRepository.getDuplicateQuestionCount(),
         ]);
 
       return {
@@ -49,6 +56,7 @@ export class ChatbotService implements IChatbotService {
         farmingExperience: demographics.farmingExperience,
         kccAwareness: kccAndAgri.kccAwareness,
         agriAppUsage: kccAndAgri.agriAppUsage,
+        duplicateQuestionCount,
       };
     } catch (error) {
       throw new InternalServerError(`Failed to fetch dashboard data: ${error}`);

--- a/backend/src/shared/database/interfaces/IDuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/interfaces/IDuplicateQuestionRepository.ts
@@ -43,4 +43,6 @@ export interface IDuplicateQuestionRepository {
  referenceQuestionId: string,
 session?: ClientSession,
  ): Promise<{deletedCount: number}>;
+
+   getDuplicateQuestionCount(): Promise<number>;
 }

--- a/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/DuplicateQuestionRepository.ts
@@ -121,4 +121,16 @@ throw new InternalServerError(
 }
 }
 
+//get duplicate question count
+async getDuplicateQuestionCount(): Promise<number> {
+  try {
+    await this.init();
+    return await this.DuplicateQuestionCollection.countDocuments() ?? 0;
+  } catch (error) {
+    throw new InternalServerError(
+      `Error while fetching duplicate question count: ${error}`
+    );
+  }
+}
+
 }

--- a/frontend/src/features/chatbotDashboard/AlertCard.tsx
+++ b/frontend/src/features/chatbotDashboard/AlertCard.tsx
@@ -10,10 +10,18 @@ interface Alert {
 interface AlertCardProps {
   alerts?: Alert[];
   inactiveUsersLast3Days?: number;
+  duplicateQuestions?: number;
   onInactiveClick?: () => void;
+  onDuplicateClick?: () => void;
 }
 
-export function AlertCard({ alerts: _alerts = [], inactiveUsersLast3Days = 0, onInactiveClick }: AlertCardProps) {
+export function AlertCard({
+  alerts: _alerts = [],
+  inactiveUsersLast3Days = 0,
+  duplicateQuestions = 0,
+  onInactiveClick,
+  onDuplicateClick,
+}: AlertCardProps) {
   return (
     <div className="h-full flex flex-col bg-[var(--card)] border border-[var(--border)] rounded-xl p-4">
       {/* Header */}
@@ -63,6 +71,44 @@ export function AlertCard({ alerts: _alerts = [], inactiveUsersLast3Days = 0, on
         </div>
         <Badge
           label={inactiveUsersLast3Days.toLocaleString()}
+          variant="amber"
+        />
+      </div>
+
+      {/* Duplicate Questions Row */}
+      <div
+        className="flex items-center justify-between rounded-lg p-3 mb-2.5 border border-amber-200 dark:border-amber-800/40 bg-amber-50 dark:bg-amber-950/30 cursor-pointer hover:bg-amber-100 dark:hover:bg-amber-950/50 transition-colors"
+        onClick={() => onDuplicateClick?.()}
+      >
+        <div className="flex items-center gap-2.5">
+          <div className="flex items-center justify-center w-7 h-7 rounded-full bg-amber-100 dark:bg-amber-900/40">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-amber-600 dark:text-amber-400"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+          </div>
+          <div>
+            <div className="text-xs font-medium text-gray-900 dark:text-gray-50">
+              Duplicate Questions
+            </div>
+            <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
+              Questions asked more than once
+            </div>
+          </div>
+        </div>
+        <Badge
+          label={duplicateQuestions.toLocaleString()}
           variant="amber"
         />
       </div>

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -21,6 +21,9 @@ import { StatusBar } from "./components/StatusBar";
 import { UserDetailsView } from "./UserDetailsView";
 import { UserDemographicsSection } from "./components/UserDemographicsSection";
 import type { UserDetailsFilters } from "./components/UserDetailsPreferenceFilter";
+import { QuestionService } from "@/hooks/services/questionService";
+import { formatDateLocal } from "@/utils/formatDate";
+import { toast } from "sonner";
 
 const DEFAULT_FILTERS: DashboardFilterValues = {
   village: "all",
@@ -38,6 +41,7 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
   const { data, isLoading, error } = useDashboardData(filters, source);
   const { data: dauTrend, isLoading: dauLoading, error: dauError } = useDailyUserTrend(30, source);
   const [userDetailsInitialFilters, setUserDetailsInitialFilters] = useState<Partial<UserDetailsFilters> | undefined>(undefined);
+  const questionService = useMemo(() => new QuestionService(), []);
 
   const sectionRefs = useRef<Partial<Record<DashboardView, HTMLDivElement | null>>>({});
 
@@ -79,6 +83,53 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
     });
     setActiveView("user-details");
   }, []);
+
+  const handleDuplicateQuestionsClick = useCallback(async () => {
+    try {
+      toast.info("Preparing duplicate questions report...");
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const earliestDate = new Date(2024, 0, 1);
+
+      let start = filters.startTime;
+      let end = filters.endTime;
+
+      if (!start && !end) {
+        start = earliestDate;
+        end = today;
+      } else if (start && !end) {
+        end = today;
+      } else if (!start && end) {
+        start = earliestDate;
+      }
+
+      const startDate = formatDateLocal(start as Date);
+      const endDate = formatDateLocal(end as Date);
+
+      const blob = await questionService.downloadDuplicateQuestionsReport(
+        startDate,
+        endDate
+      );
+
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `duplicate-questions-report-${startDate}-to-${endDate}.xlsx`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+
+      toast.success("Duplicate questions report downloaded successfully!");
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Failed to download duplicate questions report";
+      toast.error(errorMessage);
+    }
+  }, [filters.endTime, filters.startTime, questionService]);
 
   // Patch the DAU card to show "today / total" instead of just total
   const patchedKpiRow1 = useMemo(() => {
@@ -179,7 +230,13 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                       sectionRefs.current["bugs-ux"] = el;
                     }}
                   >
-                    <AlertCard alerts={data.alerts} inactiveUsersLast3Days={(data as any).inactiveUsersLast3Days ?? 0} onInactiveClick={handleInactiveUsersClick} />
+                    <AlertCard
+                      alerts={data.alerts}
+                      inactiveUsersLast3Days={(data as any).inactiveUsersLast3Days ?? 0}
+                      duplicateQuestions={(data as any).duplicateQuestions ?? 0}
+                      onInactiveClick={handleInactiveUsersClick}
+                      onDuplicateClick={handleDuplicateQuestionsClick}
+                    />
                   </div>
                 </div>
 

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -233,7 +233,7 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                     <AlertCard
                       alerts={data.alerts}
                       inactiveUsersLast3Days={(data as any).inactiveUsersLast3Days ?? 0}
-                      duplicateQuestions={(data as any).duplicateQuestions ?? 0}
+                      duplicateQuestions={(data as any).duplicateQuestionCount ?? 0}
                       onInactiveClick={handleInactiveUsersClick}
                       onDuplicateClick={handleDuplicateQuestionsClick}
                     />

--- a/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
@@ -21,6 +21,7 @@ interface DashboardApiResponse {
     voiceUsageSharePct: number;
     totalAppInstalls: number;
     inactiveUsersLast3Days: number;
+    duplicateQuestions?: number;
   };
   dau: DailyEntry[];
   weeklySessionDuration: Array<{ week: string; avgSessionDurationMin: number }>;
@@ -179,6 +180,8 @@ function transformApiResponse(result: DashboardApiResponse): DashboardDataType &
   });
 
   updatedData.inactiveUsersLast3Days = result.kpi.inactiveUsersLast3Days ?? 0;
+  (updatedData as DashboardDataType & { duplicateQuestions?: number }).duplicateQuestions =
+    result.kpi.duplicateQuestions ?? 0;
 
   updatedData.kpiRow1 = DASHBOARD_DATA.kpiRow1.map(card => {
     if (card.id === 'dau') {

--- a/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
@@ -21,7 +21,6 @@ interface DashboardApiResponse {
     voiceUsageSharePct: number;
     totalAppInstalls: number;
     inactiveUsersLast3Days: number;
-    duplicateQuestions?: number;
   };
   dau: DailyEntry[];
   weeklySessionDuration: Array<{ week: string; avgSessionDurationMin: number }>;
@@ -36,6 +35,7 @@ interface DashboardApiResponse {
   farmingExperience: DemographicEntry[];
   kccAwareness: DemographicEntry[];
   agriAppUsage: DemographicEntry[];
+  duplicateQuestionCount: number;
 }
 
 // ── Date range label helpers ──────────────────────────────────────────────────
@@ -112,8 +112,18 @@ function weeklyRange(entries: Array<{ week: string }>): string {
 
 // ── Transform raw API response into dashboard shape ─────────────────────────
 
-function transformApiResponse(result: DashboardApiResponse): DashboardDataType & { inactiveUsersLast3Days: number } {
-  const updatedData = { ...DASHBOARD_DATA } as DashboardDataType & { inactiveUsersLast3Days: number };
+function transformApiResponse(
+  result: DashboardApiResponse
+): DashboardDataType & {
+  inactiveUsersLast3Days: number;
+  duplicateQuestionCount: number;
+} {
+  const updatedData = {
+    ...DASHBOARD_DATA,
+  } as DashboardDataType & {
+    inactiveUsersLast3Days: number;
+    duplicateQuestionCount: number;
+  };
 
   // Use the real month-over-month % from the backend
   const pct = result.kpi.dauLastMonthPct;
@@ -180,8 +190,7 @@ function transformApiResponse(result: DashboardApiResponse): DashboardDataType &
   });
 
   updatedData.inactiveUsersLast3Days = result.kpi.inactiveUsersLast3Days ?? 0;
-  (updatedData as DashboardDataType & { duplicateQuestions?: number }).duplicateQuestions =
-    result.kpi.duplicateQuestions ?? 0;
+  updatedData.duplicateQuestionCount = result.duplicateQuestionCount ?? 0;
 
   updatedData.kpiRow1 = DASHBOARD_DATA.kpiRow1.map(card => {
     if (card.id === 'dau') {

--- a/frontend/src/hooks/services/questionService.ts
+++ b/frontend/src/hooks/services/questionService.ts
@@ -539,7 +539,16 @@ export class QuestionService {
     );
 
     if (!response.ok) {
-      throw new Error("Failed to download similar questions report");
+      let message = "Failed to download duplicate questions report";
+      try {
+        const errorJson = await response.json();
+        if (errorJson?.message) {
+          message = errorJson.message;
+        }
+      } catch {
+        
+      }
+      throw new Error(message);
     }
 
     // Check if response is JSON (no data case)
@@ -549,7 +558,7 @@ export class QuestionService {
       if (!jsonResponse.success) {
         throw new Error(
           jsonResponse.message ||
-            "No similar questions found for the selected date range",
+            "No duplicate questions found for the selected date range",
         );
       }
     }


### PR DESCRIPTION
**Description**

This PR introduces the ability to track and display the count of duplicate questions , providing better visibility into repeated user queries. It also adds a sheet download option, enabling  export data for further analysis, reporting, and performance optimization.