### PR TITLE
feat: request module optimization

### DIFF
--- a/backend/src/modules/request/classes/validators/RequestValidators.ts
+++ b/backend/src/modules/request/classes/validators/RequestValidators.ts
@@ -9,22 +9,15 @@ import {
 } from 'class-validator';
 import {Type} from 'class-transformer';
 import {ObjectId} from 'mongodb';
-import {IQuestion} from '#root/shared/index.js';
+import {IQuestion, RequestStatus} from '#root/shared/index.js';
 
-type RequestStatus = 'pending' | 'rejected' | 'approved' | 'in-review';
 
 class RequestParamsDto {
   @IsString()
   requestId!: string;
 }
 
-class RequestStatusBody {
-  @IsEnum(['pending', 'rejected', 'approved', 'in-review'])
-  status!: RequestStatus;
 
-  @IsString()
-  response: string;
-}
 
 class ModeratorResponseDto {
   @IsString()
@@ -120,7 +113,6 @@ export {
   RequestDetailsOtherDto,
   RequestDetailsQuestionDto,
   ModeratorResponseDto,
-  RequestStatusBody,
   RequestParamsDto,
   RequestStatus,
   GetAllRequestsQueryDto,
@@ -131,7 +123,6 @@ export const REQUEST_VALIDATORS = [
   RequestDetailsOtherDto,
   RequestDetailsQuestionDto,
   ModeratorResponseDto,
-  RequestStatusBody,
   RequestParamsDto,
   GetAllRequestsQueryDto,
 ];

--- a/backend/src/modules/request/controllers/RequestController.ts
+++ b/backend/src/modules/request/controllers/RequestController.ts
@@ -18,7 +18,7 @@ import {
   CreateRequestBodyDto,
   GetAllRequestsQueryDto,
   RequestParamsDto,
-  RequestStatusBody,
+  UpdateRequestStatusDto,
 } from '../classes/validators/RequestValidators.js';
 import { RequestService } from '../services/RequestService.js';
 import { IRequestService } from '../interfaces/IRequestService.js';
@@ -164,7 +164,7 @@ export class RequestController {
   @Authorized()
   async updateStatus(
     @Params() params: RequestParamsDto,
-    @Body() body: RequestStatusBody,
+    @Body() body: UpdateRequestStatusDto,
     @CurrentUser() user: IUser,
   ): Promise<IRequestResponse> {
     const {requestId} = params;

--- a/backend/src/modules/request/services/RequestService.ts
+++ b/backend/src/modules/request/services/RequestService.ts
@@ -67,16 +67,17 @@ export class RequestService extends BaseService implements IRequestService{
         const moderators = await this.userRepo.findModerators();
         let message = `A new Question Flag raised QuestionId ${data.entityId}`;
         let title = 'New Flag Raised';
-        for (let mod of moderators) {
-          const notification =
-            await this.notificationRepository.addNotification(
+        await Promise.all(
+          moderators.map(mod =>
+            this.notificationRepository.addNotification(
               mod._id.toString(),
               data.entityId.toString(),
               type,
               message,
               title,
-            );
-        }
+            )
+          )
+        );
         return request;
       });
     } catch (error) {
@@ -152,21 +153,24 @@ export class RequestService extends BaseService implements IRequestService{
           session,
         );
 
-        await this.notificationRepository.addNotification(
-          requestedUserId,
-          entityId,
-          type,
-          message,
-          title,
-          session,
-        );
         const subscription =
           await this.notificationRepository.getSubscriptionByUserId(
             requestedUserId,
           );
-        await notifyUser(requestedUserId, title, subscription, async (endpoint: string) => {
-          this.notificationService.deleteExpiredSubscriptionForUser(endpoint)
-        });
+
+        await Promise.all([
+          this.notificationRepository.addNotification(
+            requestedUserId,
+            entityId,
+            type,
+            message,
+            title,
+            session,
+          ),
+          notifyUser(requestedUserId, title, subscription, async (endpoint: string) => {
+            this.notificationService.deleteExpiredSubscriptionForUser(endpoint);
+          }),
+        ]);
         return result;
       });
     } catch (error) {

--- a/backend/src/shared/database/providers/mongo/repositories/RequestRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/RequestRepository.ts
@@ -18,18 +18,21 @@ import {GLOBAL_TYPES} from '#root/types.js';
 
 @injectable()
 export class RequestRepository implements IRequestRepository {
-  private RequestCollection: Collection<IRequest>;
-  private usersCollection!: Collection<IUser>;
+  private RequestCollection!: Collection<IRequest>;
+private usersCollection!: Collection<IUser>;
+private initialized = false;
 
-  constructor(
-    @inject(GLOBAL_TYPES.Database)
-    private db: MongoDatabase,
-  ) {}
+constructor(
+  @inject(GLOBAL_TYPES.Database)
+  private db: MongoDatabase,
+) {}
 
-  private async init() {
-    this.RequestCollection = await this.db.getCollection<IRequest>('requests');
-    this.usersCollection = await this.db.getCollection<IUser>('users');
-  }
+private async init() {
+  if (this.initialized) return;
+  this.RequestCollection = await this.db.getCollection<IRequest>('requests');
+  this.usersCollection = await this.db.getCollection<IUser>('users');
+  this.initialized = true;
+}
 
   async createRequest(
     data: CreateRequestBodyDto,
@@ -118,50 +121,46 @@ export class RequestRepository implements IRequestRepository {
         .toArray();
 
       const totalPages = Math.ceil(totalCount / limit);
-      const sanitizedData: IRequest[] = await Promise.all(
-        data.map(async req => {
-          const responses: IRequestResponse[] =
-            req.responses?.map(r => ({
-              ...r,
-              reviewedBy: r.reviewedBy?.toString(),
-            })) || [];
+      // Fetch all users in one query instead of N separate queries
+      const userIds = data.map(req => req.requestedBy);
+      const users = await this.usersCollection.find(
+        { _id: { $in: userIds } },
+        { projection: { firstName: 1, lastName: 1 } }
+      ).toArray();
+      const userMap = new Map(users.map(u => [u._id.toString(), u]));
 
-          const requestedUser = await this.usersCollection.findOne({
-            _id: req.requestedBy,
-          },
-          {
-        projection: {
-          firstName: 1,
-          lastName: 1,
-        },
-      },
-        );
+      const sanitizedData: IRequest[] = data.map(req => {
+        const responses: IRequestResponse[] =
+          req.responses?.map(r => ({
+            ...r,
+            reviewedBy: r.reviewedBy?.toString(),
+          })) || [];
 
-          return {
-            ...req,
-            _id: req._id?.toString(),
-            requestedBy: req.requestedBy?.toString(),
-            entityId: req.entityId?.toString(),
-            responses,
-            createdAt:
-              req.createdAt instanceof Date
-                ? req.createdAt.toISOString()
-                : req.createdAt,
-            updatedAt:
-              req.updatedAt instanceof Date
-                ? req.updatedAt.toISOString()
-                : req.updatedAt,
-            requestedUser: requestedUser
-              ? {
-                  _id: requestedUser._id.toString(),
-                  firstName: requestedUser.firstName,
-                  lastName: requestedUser.lastName,
-                }
-              : null,
-          } as IRequest;
-        }),
-      );
+        const requestedUser = userMap.get(req.requestedBy?.toString());
 
+        return {
+          ...req,
+          _id: req._id?.toString(),
+          requestedBy: req.requestedBy?.toString(),
+          entityId: req.entityId?.toString(),
+          responses,
+          createdAt:
+            req.createdAt instanceof Date
+              ? req.createdAt.toISOString()
+              : req.createdAt,
+          updatedAt:
+            req.updatedAt instanceof Date
+              ? req.updatedAt.toISOString()
+              : req.updatedAt,
+          requestedUser: requestedUser
+            ? {
+                _id: requestedUser._id.toString(),
+                firstName: requestedUser.firstName,
+                lastName: requestedUser.lastName,
+              }
+            : null,
+        } as IRequest;
+      });
       return {requests: sanitizedData, totalPages, totalCount};
     } catch (error) {
       throw new InternalServerError(`Failed to create request /More: ${error}`);
@@ -176,6 +175,7 @@ export class RequestRepository implements IRequestRepository {
     session?: ClientSession,
   ): Promise<IRequestResponse> {
     try {
+       await this.init();
       const user = await this.usersCollection.findOne({
         _id: new ObjectId(userId),
       });


### PR DESCRIPTION
Removed duplicate `RequestStatus` type — now imported from shared
- Merged `RequestStatusBody` into `UpdateRequestStatusDto`
- Added `initialized` flag to `init()` so DB collections are fetched only once
- Fixed missing `await this.init()` in `updateStatus`
- Replaced sequential notification loop with `Promise.all` in `createRequest`
- Parallelized DB notification and push notification in `updateStatus`
- Fixed N+1 query in `getAllRequests` — single bulk user fetch instead of per-request DB calls