### PR TITLE
fix: add await to buildUserDocFilter call in ChatbotRepository 

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -146,7 +146,7 @@ export class ChatbotRepository implements IChatbotRepository {
       threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
       threeDaysAgo.setHours(0, 0, 0, 0);
 
-      const userDocFilter = this.buildUserDocFilter(userType);
+      const userDocFilter = await this.buildUserDocFilter(userType);
       const userMsgFilter = await this.buildUserMessageFilter(userType);
 
       const [totalUsers, monthlyActivity, sessionStats, todayQueryCount, totalAppInstalls, activeUsersLast3Days] =


### PR DESCRIPTION
Added await to buildUserDocFilter() on line 149 of ChatbotRepository.ts for consistency with the adjacent buildUserMessageFilter() call. The function is synchronous so behavior is unchanged — await on a non-Promise resolves immediately.