### PR TITLE
Feat/add status duplicate

### DIFF
--- a/backend/src/modules/question/helpers/duplicateQuestionHelper.ts
+++ b/backend/src/modules/question/helpers/duplicateQuestionHelper.ts
@@ -1,5 +1,5 @@
 import { ObjectId, ClientSession } from 'mongodb';
-import { IQuestion } from '#root/shared/interfaces/models.js';
+import { IQuestion,QuestionStatus } from '#root/shared/interfaces/models.js';
 import { AiService } from '#root/modules/ai/services/AiService.js';
 import { IDuplicateQuestionRepository } from '#root/shared/database/interfaces/IDuplicateQuestionRepository.js';
 import { chatbotSimilarityLogger } from '../logger/chatbot-similarity.logger.js';
@@ -121,7 +121,8 @@ export async function checkDuplicateQuestionHelper(
         similarityScore: Number(matchedScore.toFixed(2)),
         referenceQuestionId: matchedQuestionId,
         referenceQuestion: matchedQuestion,
-        referenceSource: referenceSourcefrom
+        referenceSource: referenceSourcefrom,
+        status: 'duplicate' as QuestionStatus,
       }
 
       if(fromOutReach){
@@ -147,6 +148,7 @@ export async function checkDuplicateQuestionHelper(
       referenceQuestionId: matchedQuestionId,
       referenceQuestion: matchedQuestion,
       referenceSource: referenceSourcefrom,
+      status: 'duplicate' as QuestionStatus,
     };
 
    if(fromOutReach){

--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -334,7 +334,7 @@ export class QuestionRepository implements IQuestionRepository {
     };
 
     // --- Hidden question filter ---
-    if(hiddenQuestions === 'true'){
+    if(hiddenQuestions === 'true' || status === 'pass'){
         filter.isHidden = { $eq: true }; // filter by hidden questions
     }
 

--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -1799,7 +1799,7 @@ export class QuestionRepository implements IQuestionRepository {
 
       const result = await this.QuestionCollection.updateMany(
         {
-          status: { $nin: ['hold', 'delayed', 'in-review', 'closed', 're-routed'] },
+          status: { $nin: ['hold', 'delayed', 'in-review', 'closed', 're-routed', 'pass', 'duplicate'] },
           isOnHold: { $ne: true },
           $expr: {
             $lte: [

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -1,6 +1,6 @@
 import {ObjectId} from 'mongodb';
 
-export type UserRole = 'admin' | 'moderator' | 'expert';
+export type UserRole = 'admin' | 'moderator' | 'expert' | 'pae_expert';
 export type QuestionStatus = 'open' | 'in-review' | 'closed' | 'delayed' | 're-routed' | 'hold' | 'pae_submitted'|'draft'| 'pass' | 'duplicate';
 export interface IPreference {
   state: string;

--- a/backend/src/shared/interfaces/models.ts
+++ b/backend/src/shared/interfaces/models.ts
@@ -1,7 +1,7 @@
 import {ObjectId} from 'mongodb';
 
 export type UserRole = 'admin' | 'moderator' | 'expert';
-export type QuestionStatus = 'open' | 'in-review' | 'closed' | 'delayed' | 're-routed' | 'hold';
+export type QuestionStatus = 'open' | 'in-review' | 'closed' | 'delayed' | 're-routed' | 'hold' | 'pass' | 'duplicate';
 export interface IPreference {
   state: string;
   crop: string;

--- a/frontend/src/components/MessageDetail.tsx
+++ b/frontend/src/components/MessageDetail.tsx
@@ -505,7 +505,7 @@ const ContentAnswer = ({ text, question, isQuestionAllocatedToExpert, navigateTo
     const handleSkip = () => { setPassRemarkError(""); setConfirmDialog({ open: true, type: "pass", remark: "" }); };
 
     const doSkip = async (remark?: string) => {
-        await updateQuestion({ isHidden: true, _id: question._id!, ...(remark ? { passingRemark: remark } : {}) } as any);
+        await updateQuestion({ isHidden: true,status:'pass', _id: question._id!, ...(remark ? { passingRemark: remark } : {}) } as any);
         toast.success("Question has been hidden");
         navigateToQuestionPage();
     };

--- a/frontend/src/components/advanced-question-filter.tsx
+++ b/frontend/src/components/advanced-question-filter.tsx
@@ -54,6 +54,8 @@ import {
   Users,
   Settings,
   Radio,
+  CircleSlash,
+  Copy,
 } from "lucide-react";
 import { useGetAllUsers } from "@/hooks/api/user/useGetAllUsers";
 import {
@@ -272,6 +274,18 @@ export const AdvanceFilterDialog: React.FC<AdvanceFilterDialogProps> = ({
                         <div className="flex items-center gap-2">
                           <CheckCircle2 className="w-4 h-4 text-red-500" />
                           <span>Closed</span>
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="pass">
+                        <div className="flex items-center gap-2">
+                          <CircleSlash className="w-4 h-4 text-gray-500" />
+                          <span>Passed</span>
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="duplicate">
+                        <div className="flex items-center gap-2">
+                          <Copy className="w-4 h-4 text-orange-500" />
+                          <span>Duplicate</span>
                         </div>
                       </SelectItem>
                     </SelectContent>


### PR DESCRIPTION
**Description**

This PR adds Duplicate and Pass statuses to the question status workflow and includes both options in the advanced filters for easier question management. It also ensures that questions marked as either Duplicate or Pass will not be automatically updated to the Delayed state, preserving their intended status and preventing incorrect state transitions.