### PR TITLE
feat: query param based thread handling and WhatsApp thread navigation

### DIFF
--- a/frontend/src/features/question_details/components/QuestionDetailsCard.tsx
+++ b/frontend/src/features/question_details/components/QuestionDetailsCard.tsx
@@ -17,10 +17,50 @@ import {
   Sprout,
 } from "lucide-react";
 import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
 
 interface QuestionDetailsCardProps {
   question: IQuestionFullData;
   currentUser: IUser;
+}
+
+function ThreadIdLink({ threadId }: { threadId: string }) {
+  const navigate = useNavigate();
+
+  const extractDate = (id: string): string => {
+    const parts = id.split("-");
+    // Handle format: 919876543210-2025-05-08 (YYYY-MM-DD)
+    if (parts.length === 4) {
+      return `${parts[1]}-${parts[2]}-${parts[3]}`;
+    }
+    // Handle format: 919876543210-20260508 (YYYYMMDD)
+    if (parts.length === 2 && parts[1].length === 8) {
+      const d = parts[1];
+      return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
+    }
+    // fallback: today
+    return new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" });
+  };
+
+  const handleClick = () => {
+    navigate({
+      to: "/whatsapp-history",
+      search: {
+        threadId,
+        date: extractDate(threadId),
+      },
+    });
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="max-w-[220px] truncate rounded-md border bg-muted px-2 py-1 text-xs font-medium text-foreground hover:bg-accent hover:text-primary transition-colors cursor-pointer"
+      title="View WhatsApp thread history"
+    >
+      {threadId}
+    </button>
+  );
 }
 
 export const QuestionDetailsCard = ({
@@ -69,7 +109,9 @@ export const QuestionDetailsCard = ({
           <Leaf className="w-4 h-4 text-primary shrink-0" />
           <div className="flex flex-col">
             <span className="text-muted-foreground">Normalized Crop</span>
-            <span className="truncate capitalize">{question.details?.normalised_crop || "-"}</span>
+            <span className="truncate capitalize">
+              {question.details?.normalised_crop || "-"}
+            </span>
           </div>
         </div>
 
@@ -104,13 +146,9 @@ export const QuestionDetailsCard = ({
 
         {question.source === "WHATSAPP" && question.threadId && (
           <div className="flex flex-col items-end min-w-0">
-            <span className="text-muted-foreground">
-              WhatsApp Thread ID
-            </span>
+            <span className="text-muted-foreground">WhatsApp Thread ID</span>
 
-            <code className="max-w-[220px] truncate rounded-md border bg-muted px-2 py-1 text-xs font-medium text-foreground">
-              {question.threadId}
-            </code>
+            <ThreadIdLink threadId={question.threadId} />
           </div>
         )}
       </div>

--- a/frontend/src/features/whatsappHistory/hooks/useWhatsAppHistory.ts
+++ b/frontend/src/features/whatsappHistory/hooks/useWhatsAppHistory.ts
@@ -18,7 +18,11 @@ export function useWhatsAppHistory() {
   const setSelectedThreadId = (threadId: string) => {
   navigate({
     to: '/whatsapp-history',
-    search: (prev: Record<string, string>) => ({ ...prev, threadId }),
+    search: (prev: Record<string, string>) => ({ 
+      ...prev, 
+      threadId,
+      date: todayIST,
+    }),
   });
 };
 
@@ -60,10 +64,12 @@ const setSelectedDate = (date: string) => {
     );
   }, [enrichedThreads, searchQuery]);
 
-  const selectedThread = useMemo(() =>
-    threads.find(t => t.id === selectedThreadId),
-    [threads, selectedThreadId]
-  );
+  const selectedThread = useMemo(() => {
+  const phoneNumber = selectedThreadId.includes('-')
+    ? selectedThreadId.split('-')[0]
+    : selectedThreadId;
+  return threads.find(t => t.id === phoneNumber || t.id === selectedThreadId);
+}, [threads, selectedThreadId]);
 
   const sendMessageMutation = useSendMessage(selectedThreadId, selectedThread?.phoneNumber);
 

--- a/frontend/src/features/whatsappHistory/hooks/useWhatsAppHistory.ts
+++ b/frontend/src/features/whatsappHistory/hooks/useWhatsAppHistory.ts
@@ -2,24 +2,40 @@ import { useState, useMemo, useEffect } from 'react';
 import { useThreads } from './useThreads';
 import { useThreadDetails } from './useThreadDetails';
 import { useSendMessage } from './useSendMessage';
+import { useSearch, useNavigate } from '@tanstack/react-router';
 
 export function useWhatsAppHistory() {
-  const [selectedThreadId, setSelectedThreadId] = useState<string | undefined>("");
-  const [selectedDate, setSelectedDate] = useState<string>(new Date().toLocaleDateString('en-CA', {
-    timeZone: 'Asia/Kolkata',
-  }));
-  const [searchQuery, setSearchQuery] = useState('');
+  const search = useSearch({ from: '/whatsapp-history' });
+  const navigate = useNavigate();
 
-  // Local cache for latest messages to override the initial 'thread_name' from API
+  const todayIST = new Date().toLocaleDateString('en-CA', {
+    timeZone: 'Asia/Kolkata',
+  });
+
+  const selectedThreadId = search.threadId ?? '';
+  const selectedDate = search.date ?? todayIST;
+
+  const setSelectedThreadId = (threadId: string) => {
+  navigate({
+    to: '/whatsapp-history',
+    search: (prev: Record<string, string>) => ({ ...prev, threadId }),
+  });
+};
+
+const setSelectedDate = (date: string) => {
+  navigate({
+    to: '/whatsapp-history',
+    search: (prev: Record<string, string>) => ({ ...prev, date }),
+  });
+};
+  const [searchQuery, setSearchQuery] = useState('');
   const [lastMessageOverrides, setLastMessageOverrides] = useState<Record<string, string>>({});
 
   const { data: threads = [], isLoading: isLoadingThreads } = useThreads();
   const { data: messages = [], isLoading: isLoadingMessages } = useThreadDetails(selectedThreadId, selectedDate);
 
-  // Sync the latest message to our local overrides whenever a thread is loaded
   useEffect(() => {
     if (messages.length > 0 && selectedThreadId) {
-      // Find the last message that isn't just a tool-only AI response if possible
       const lastMeaningfulMsg = [...messages].reverse().find(m => m.content && m.content.length > 0);
       if (lastMeaningfulMsg) {
         setLastMessageOverrides(prev => ({

--- a/frontend/src/routes/whatsapp-history.tsx
+++ b/frontend/src/routes/whatsapp-history.tsx
@@ -3,8 +3,13 @@ import { WhatsAppHistoryPage } from "@/features/whatsappHistory/WhatsAppHistoryP
 import { useAuthStore } from "@/stores/auth-store";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { z } from "zod";
 
 export const Route = createFileRoute("/whatsapp-history")({
+  validateSearch: z.object({
+    threadId: z.string().optional(),
+    date: z.string().optional(),
+  }),
   component: RouteComponent,
 });
 


### PR DESCRIPTION
- WhatsApp History page now reads the selected thread and date from the URL instead of component state
- Clicking the WhatsApp Thread ID in Question Details now navigates directly to the WhatsApp History page with the correct thread and date pre-selected
- Date is automatically picked from the thread ID itself, so no manual selection needed
- Refreshing the page now retains the selected thread and date since everything is in the URL