### PR TITLE
feat(admin):enable removing all allocated questions of an expert

### DIFF
--- a/backend/src/modules/auth/controllers/AuthController.ts
+++ b/backend/src/modules/auth/controllers/AuthController.ts
@@ -257,7 +257,7 @@ export class AuthController {
         userInfo.displayName || ''
       );
 
-      if (!user.isVerified) {
+      if (user.isVerified === false) {
         throw new HttpError(
           401,
           'Your account is pending admin verification. Please contact an administrator.'
@@ -310,7 +310,7 @@ export class AuthController {
         decodedEmail.name || ''
       );
 
-      if (!user.isVerified) {
+      if (user.isVerified === false) {
         throw new HttpError(
           401,
           'Your account is pending admin verification. Please contact an administrator.'

--- a/backend/src/modules/user/controllers/UserController.ts
+++ b/backend/src/modules/user/controllers/UserController.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import {
   JsonController,
   Get,
+  Post,
   Put,
   Body,
   HttpCode,
@@ -629,6 +630,146 @@ export class UserController {
   ): Promise<IUser | null> {
     const {email} = params;
     return await this.userService.getUserByEmail(email);
+  }
+
+  @OpenAPI({
+    summary: 'Remove all allocations for an expert (Admin)',
+    description:
+      'Clears all queued allocations for questions where the expert appears and resets the expert workload to zero.',
+  })
+  @ResponseSchema(UserSuccessMessageResponse, {
+    statusCode: 200,
+    description: 'Expert allocations removed successfully',
+  })
+  @ResponseSchema(UserErrorResponse, {
+    statusCode: 401,
+    description: 'Unauthorized - Authentication required',
+  })
+  @ResponseSchema(UserErrorResponse, {
+    statusCode: 403,
+    description: 'Forbidden - Admin access required',
+  })
+  @Authorized(['admin'])
+  @Post('/:id/remove-allocations')
+  @HttpCode(200)
+  async removeExpertAllocations(
+    @Param('id') expertId: string,
+    @CurrentUser() currentUser: IUser,
+  ): Promise<{
+    message: string;
+    questionsAffected: number;
+    removedQueues: number;
+    workloadBefore: number;
+    workloadAfter: number;
+    questionIds: string[];
+  }> {
+    let expertDetails: IUser | null = null;
+    let result:
+      | {
+          questionsAffected: number;
+          removedQueues: number;
+          workloadBefore: number;
+          workloadAfter: number;
+          questionIds: string[];
+        }
+      | null = null;
+
+    const auditPayloadBase: ModeratorAuditTrail = {
+      category: AuditCategory.EXPERTS_CATEGORY,
+      action: AuditAction.REALLOCATE_QUESTIONS,
+      actor: {
+        id: currentUser._id.toString(),
+        name: `${currentUser.firstName} ${currentUser.lastName}`,
+        email: currentUser.email,
+        role: currentUser.role,
+        avatar: currentUser?.avatar || '',
+      },
+      context: {
+        targetExpertId: expertId,
+      },
+      outcome: {
+        status: OutComeStatus.SUCCESS,
+      },
+    };
+
+    try {
+      expertDetails = await this.userService.getUserById(expertId);
+      result = await this.userService.removeExpertAllocations(
+        currentUser,
+        expertId,
+      );
+    } catch (err: any) {
+      this.auditTrailsService.createAuditTrail({
+        ...auditPayloadBase,
+        changes: {
+          before: {
+            targetExpert: expertDetails
+              ? {
+                  id: expertDetails._id?.toString(),
+                  name: `${expertDetails.firstName} ${expertDetails.lastName || ''}`.trim(),
+                  email: expertDetails.email,
+                  role: expertDetails.role,
+                  workload: expertDetails.reputation_score ?? 0,
+                }
+              : null,
+          },
+        },
+        outcome: {
+          status: OutComeStatus.FAILED,
+          errorCode: err?.errorCode || 'INTERNAL_ERROR',
+          errorMessage: err?.message || 'Failed to remove expert allocations',
+          errorName: err?.name || 'Error',
+          errorStack:
+            err?.stack?.split('\n')?.slice(0, 5)?.join('\n') ||
+            'No stack trace available',
+        },
+      });
+
+      if (err instanceof InternalServerError) {
+        throw new InternalServerError(err.message);
+      }
+      throw new BadRequestError(
+        err?.message || 'Failed to remove expert allocations',
+      );
+    }
+
+    this.auditTrailsService.createAuditTrail({
+      ...auditPayloadBase,
+      changes: {
+        before: {
+          targetExpert: expertDetails
+            ? {
+                id: expertDetails._id?.toString(),
+                name: `${expertDetails.firstName} ${expertDetails.lastName || ''}`.trim(),
+                email: expertDetails.email,
+                role: expertDetails.role,
+                workload: result?.workloadBefore ?? 0,
+              }
+            : null,
+        },
+        after: {
+          targetExpert: {
+            id: expertId,
+            workload: result?.workloadAfter ?? 0,
+          },
+          questionsAffected: result?.questionsAffected ?? 0,
+          removedQueues: result?.removedQueues ?? 0,
+        },
+      },
+      context: {
+        ...auditPayloadBase.context,
+        questionIds: result?.questionIds || [],
+      },
+    });
+
+    return {
+      message: 'Expert allocations removed successfully',
+      questionsAffected: result?.questionsAffected ?? 0,
+      removedQueues: result?.removedQueues ?? 0,
+      workloadBefore: result?.workloadBefore ?? 0,
+      workloadAfter: result?.workloadAfter ?? 0,
+      questionIds: result?.questionIds || [],
+    };
   }
 
   @OpenAPI({

--- a/backend/src/modules/user/services/UserService.ts
+++ b/backend/src/modules/user/services/UserService.ts
@@ -353,4 +353,100 @@ async getAllUsersforManualSelect(
       );
     }
   }
+
+  async removeExpertAllocations(
+    currentUser: IUser,
+    expertId: string,
+  ): Promise<{
+    questionsAffected: number;
+    removedQueues: number;
+    workloadBefore: number;
+    workloadAfter: number;
+    questionIds: string[];
+  }> {
+    if (!currentUser || currentUser.role !== 'admin') {
+      throw new ForbiddenError('Only admins can remove expert allocations');
+    }
+
+    return this._withTransaction(async (session: ClientSession) => {
+      const expert = await this.userRepo.findById(expertId, session);
+      if (!expert) {
+        throw new NotFoundError(`User with ID ${expertId} not found`);
+      }
+
+      if (expert.role !== 'expert' && expert.role !== 'pae_expert') {
+        throw new BadRequestError(
+          'Allocations can only be removed for expert users',
+        );
+      }
+
+      const workloadBefore =
+        typeof expert.reputation_score === 'number'
+          ? expert.reputation_score
+          : 0;
+
+      const submissions = await this.questionSubmissionRepo.findByQueuedExpertId(
+        expertId,
+        session,
+      );
+
+      let questionsAffected = 0;
+      const questionIds: string[] = [];
+
+      for (const submission of submissions) {
+        const queue = submission.queue || [];
+        if (queue.length === 0) continue;
+
+        const hasTargetExpert = queue.some(
+          queuedExpertId => queuedExpertId.toString() === expertId,
+        );
+        if (!hasTargetExpert) continue;
+
+        const history = submission.history || [];
+        let activeExpertId: string | null = null;
+
+        if (history.length === 0) {
+          activeExpertId = queue[0] ? queue[0].toString() : null;
+        } else {
+          const lastHistory = history[history.length - 1];
+          if (lastHistory?.status === 'in-review' && lastHistory.updatedBy) {
+            activeExpertId = lastHistory.updatedBy.toString();
+          }
+        }
+
+        if (activeExpertId) {
+          await this.userRepo.updateReputationScore(
+            activeExpertId,
+            false,
+            session,
+          );
+        }
+
+        const shouldPopHistory =
+          history.length > 0 && history[history.length - 1]?.status === 'in-review';
+
+        await this.questionSubmissionRepo.updateSubmissionState(
+          submission.questionId.toString(),
+          {
+            queue: [],
+            popHistory: shouldPopHistory,
+          },
+          session,
+        );
+
+        questionsAffected += 1;
+        questionIds.push(submission.questionId.toString());
+      }
+
+      await this.userRepo.setReputationScore(expertId, 0, session);
+
+      return {
+        questionsAffected,
+        removedQueues: questionsAffected,
+        workloadBefore,
+        workloadAfter: 0,
+        questionIds,
+      };
+    });
+  }
 }

--- a/backend/src/modules/user/services/UserService.ts
+++ b/backend/src/modules/user/services/UserService.ts
@@ -423,16 +423,38 @@ async getAllUsersforManualSelect(
         }
 
         const shouldPopHistory =
-          history.length > 0 && history[history.length - 1]?.status === 'in-review';
+        history.length > 0 &&
+        history[history.length - 1]?.status === 'in-review';
+      const hasReviewed = history.some(
+        item =>
+          item.status === 'reviewed' ||
+          item.status === 'approved' ||
+          item.status === 'rejected',
+      );
 
-        await this.questionSubmissionRepo.updateSubmissionState(
-          submission.questionId.toString(),
-          {
-            queue: [],
-            popHistory: shouldPopHistory,
-          },
-          session,
+      let updatedQueue = [];
+
+      if (!hasReviewed) {
+        updatedQueue = [];
+      } else {
+        const removeIndex = queue.findIndex(
+          queuedExpertId =>
+            queuedExpertId.toString() === expertId,
         );
+
+        if (removeIndex !== -1) {
+          updatedQueue = queue.slice(0, removeIndex);
+        }
+      }
+
+      await this.questionSubmissionRepo.updateSubmissionState(
+        submission.questionId.toString(),
+        {
+          queue: updatedQueue,
+          popHistory: shouldPopHistory,
+        },
+        session,
+      );
 
         questionsAffected += 1;
         questionIds.push(submission.questionId.toString());

--- a/backend/src/shared/database/interfaces/IQuestionSubmissionRepository.ts
+++ b/backend/src/shared/database/interfaces/IQuestionSubmissionRepository.ts
@@ -104,6 +104,16 @@ export interface IQuestionSubmissionRepository {
   ): Promise<IQuestionSubmission | null>;
 
   /**
+   * Find all submissions where the given expert appears in the queue.
+   * @param expertId - Expert user id
+   * @param session - Optional MongoDB session for transaction
+   */
+  findByQueuedExpertId(
+    expertId: string,
+    session?: ClientSession,
+  ): Promise<IQuestionSubmission[]>;
+
+  /**
    * to get count of what level review level passed
    */
   getReviewWiseCount(): Promise<IReviewWiseStats>;

--- a/backend/src/shared/database/interfaces/IUserRepository.ts
+++ b/backend/src/shared/database/interfaces/IUserRepository.ts
@@ -164,6 +164,15 @@ export interface IUserRepository {
   ): Promise<void>;
 
   /**
+   *Setting workload/reputation score for a user.
+   */
+  setReputationScore(
+    userId: string,
+    score: number,
+    session?: ClientSession,
+  ): Promise<void>;
+
+  /**
    * Finds all moderators.
    * @returns A promise that resolves to an array of moderators.
    */

--- a/backend/src/shared/database/providers/mongo/repositories/SubmissionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SubmissionRepository.ts
@@ -62,6 +62,23 @@ export class QuestionSubmissionRepository implements IQuestionSubmissionReposito
     }
   }
 
+  async findByQueuedExpertId(
+    expertId: string,
+    session?: ClientSession,
+  ): Promise<IQuestionSubmission[]> {
+    try {
+      await this.init();
+      return this.QuestionSubmissionCollection.find(
+        {queue: new ObjectId(expertId)},
+        {session},
+      ).toArray();
+    } catch (error) {
+      throw new InternalServerError(
+        `Failed to get submissions by queued expert: ${error}`,
+      );
+    }
+  }
+
   async addSubmission(
     submission: IQuestionSubmission,
     session?: ClientSession,

--- a/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
@@ -541,6 +541,24 @@ export class UserRepository implements IUserRepository {
     );
   }
 
+  async setReputationScore(
+    userId: string,
+    score: number,
+    session?: ClientSession,
+  ): Promise<void> {
+    await this.init();
+    await this.usersCollection.updateOne(
+      { _id: new ObjectId(userId) },
+      {
+        $set: {
+          reputation_score: Math.max(0, score),
+          updatedAt: new Date(),
+        },
+      },
+      { session },
+    );
+  }
+
   async findExpertsByPreference(
     details: PreferenceDto,
     session?: ClientSession,

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@firebase/util': false
+  '@tailwindcss/oxide': false
+  esbuild: false
+  msw: false
+  protobufjs: false

--- a/frontend/src/components/ExpertDashboard.tsx
+++ b/frontend/src/components/ExpertDashboard.tsx
@@ -296,8 +296,9 @@ useEffect(() => {
               trigger={
                 <Button
                   size="sm"
+                  disabled
                   variant="outline"
-                  className="border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+                  className="border-red-200 cursor-not-allowed text-red-600 hover:bg-red-50 hover:text-red-700"
                 >
                   Remove Allocations
                 </Button>

--- a/frontend/src/components/ExpertDashboard.tsx
+++ b/frontend/src/components/ExpertDashboard.tsx
@@ -29,11 +29,14 @@ import {
 import { Button } from "./atoms/button";
 import { DateRangeFilter } from "./DateRangeFilter";
 import { TopRightBadge } from "./NewBadge";
+import { ConfirmationModal } from "./confirmation-modal";
+import { useRemoveExpertAllocations } from "@/hooks/api/Admin/useRemoveExpertAllocations";
 interface ExpertDashboardProps {
   expertId?: string | null;
   goBack?: () => void;
   rankPosition?: number;
   expertDetailsList?: any;
+  currentUserRole?: string;
 }
 interface DateRange {
   startTime?: Date;
@@ -45,6 +48,7 @@ export const ExpertDashboard = ({
   goBack,
   rankPosition,
   expertDetailsList,
+  currentUserRole,
 }: ExpertDashboardProps) => {
 
 
@@ -218,6 +222,10 @@ useEffect(() => {
 
 
   const { checkIn, isPending } = useCheckIn();
+  const {
+    mutateAsync: removeExpertAllocations,
+    isPending: removingAllocations,
+  } = useRemoveExpertAllocations();
 
   const handleDateChange = (key: string, value?: Date) => {
     setExpertDate((prev) => ({
@@ -274,6 +282,28 @@ useEffect(() => {
 
           {/* <DashboardClock /> */}
           <div className="flex flex-col items-center gap-1">
+          {expertId && currentUserRole === "admin" && (
+            <ConfirmationModal
+              title="Remove all allocations for this expert?"
+              description="This will clear all question queues where this expert is allocated. All experts in those queues will be removed, and this expert's pending workload will be reset to zero."
+              confirmText="Remove Allocations"
+              cancelText="Cancel"
+              type="delete"
+              isLoading={removingAllocations}
+              onConfirm={async () => {
+                await removeExpertAllocations(expertId);
+              }}
+              trigger={
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+                >
+                  Remove Allocations
+                </Button>
+              }
+            />
+          )}
           {user?.role==='expert' && (
            <div className="flex flex-col items-center gap-1">
              

--- a/frontend/src/components/user-management.tsx
+++ b/frontend/src/components/user-management.tsx
@@ -124,6 +124,7 @@ export const UserManagement = ({ currentUser }: { currentUser?: IUser }) => {
           goBack={goBack}
           rankPosition={rankPostion}
           expertDetailsList={expertDetails}
+          currentUserRole={currentUser?.role}
         />
       ) : (
         <>

--- a/frontend/src/hooks/api/Admin/useRemoveExpertAllocations.ts
+++ b/frontend/src/hooks/api/Admin/useRemoveExpertAllocations.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { AdminUserService } from "@/hooks/services/adminService";
+
+const adminUserService = new AdminUserService();
+
+export const useRemoveExpertAllocations = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["admin", "remove-expert-allocations"],
+    mutationFn: async (expertId: string) => {
+      return adminUserService.removeExpertAllocations(expertId);
+    },
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin"],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["experts"],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["userReviewLevel"],
+        exact: false,
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["dashboard", "expert-performance"],
+      });
+
+      const affectedCount = response?.questionsAffected ?? 0;
+      toast.success(
+        `Allocations removed successfully from ${affectedCount} question(s).`,
+      );
+    },
+    onError: (error: Error) => {
+      toast.error(
+        error?.message || "Failed to remove allocations. Please try again.",
+      );
+    },
+  });
+};

--- a/frontend/src/hooks/services/adminService.ts
+++ b/frontend/src/hooks/services/adminService.ts
@@ -7,6 +7,28 @@ const API_BASE_URL = env.apiBaseUrl();
 export class AdminUserService {
   private _baseUrl = `${API_BASE_URL}/users`;
 
+  async removeExpertAllocations(
+    expertId: string,
+  ): Promise<{
+    message: string;
+    questionsAffected: number;
+    removedQueues: number;
+    workloadBefore: number;
+    workloadAfter: number;
+    questionIds: string[];
+  } | null> {
+    return apiFetch<{
+      message: string;
+      questionsAffected: number;
+      removedQueues: number;
+      workloadBefore: number;
+      workloadAfter: number;
+      questionIds: string[];
+    }>(`${this._baseUrl}/${expertId}/remove-allocations`, {
+      method: "POST",
+    });
+  }
+
   async getAllUsers(
     page: number,
     limit: number,


### PR DESCRIPTION
- Added a button for admin to remove all allocated questions of an expert from expert performance page 
- Ensured that, by removing the allocated question from experts the experts in same question queue also become empty