### PR TITLE
feat: add low feedback users alert with click-through to filtered user table    

### DIFF
--- a/backend/src/modules/chatbot/classes/validators/ChatbotQueryValidators.ts
+++ b/backend/src/modules/chatbot/classes/validators/ChatbotQueryValidators.ts
@@ -88,6 +88,11 @@ export class UserDetailsQueryDto {
   @IsString()
   inactiveOnly?: string;
 
+  @JSONSchema({ example: 'false', description: 'If true, return only users who have never given any feedback' })
+  @IsOptional()
+  @IsString()
+  lowFeedbackOnly?: string;
+
   @JSONSchema({ example: 'all', description: 'Filter by user type: all, external (username starts with rup), or internal' })
   @IsOptional()
   @IsIn(['all', 'external', 'internal'])

--- a/backend/src/modules/chatbot/classes/validators/ChatbotResponseValidators.ts
+++ b/backend/src/modules/chatbot/classes/validators/ChatbotResponseValidators.ts
@@ -90,6 +90,15 @@ export class KpiSummaryResponse {
   })
   @IsNumber()
   inactiveUsersLast3Days: number;
+
+  @JSONSchema({
+    description: 'Number of users who have never given any feedback',
+    example: 1200,
+    type: 'number',
+    readOnly: true,
+  })
+  @IsNumber()
+  lowFeedbackUsersCount: number;
 }
 
 // ─── Daily Active Users Entry ─────────────────────────────────────────────────

--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -278,6 +278,7 @@ export class ChatbotController {
   @Authorized()
   async getUserDetails(@QueryParams() query: UserDetailsQueryDto) {
     const inactiveOnly = query.inactiveOnly === 'true';
+    const lowFeedbackOnly = query.lowFeedbackOnly === 'true';
     return this.chatbotService.getUserDetails(
       query.startDate,
       query.endDate,
@@ -289,6 +290,7 @@ export class ChatbotController {
       query.village,
       query.profileCompleted,
       inactiveOnly,
+      lowFeedbackOnly,
       query.userType,
       query.sortBy,
       query.sortOrder,

--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -50,7 +50,7 @@ export interface IChatbotService {
   getTodayQueryCount(source?: string, userType?: string): Promise<number>;
   getWeeklyQueryCounts(source?: string, userType?: string): Promise<WeeklyQueryCountEntry[]>;
   getDailyUserTrend(days?: number, source?: string, userType?: string): Promise<DailyActiveUsersEntry[]>;
-  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string, source?: string, crop?: string, village?: string, profileCompleted?: string, inactiveOnly?: boolean, userType?: string,sortBy?:string, sortOrder?:string): Promise<PaginatedUserDetails>;
+  getUserDetails(startDate?: string, endDate?: string, page?: number, limit?: number, search?: string, source?: string, crop?: string, village?: string, profileCompleted?: string, inactiveOnly?: boolean, lowFeedbackOnly?: boolean, userType?: string,sortBy?:string, sortOrder?:string): Promise<PaginatedUserDetails>;
   getAvgSessionDurationV2(source?: string, userType?: string): Promise<number>;
   getWeeklyAvgSessionDurationV2(weeks?: number, source?: string, userType?: string): Promise<WeeklySessionDurationEntry[]>;
   generateChatbotExcelReport(startDate: Date, endDate: Date, source?: string): Promise<ArrayBuffer | null>;

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -161,11 +161,11 @@ export class ChatbotService extends BaseService implements IChatbotService {
     }
   }
 
-  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '', source = 'vicharanashala', crop = '', village = '', profileCompleted = 'all', inactiveOnly = false, userType = 'all', sortBy = 'totalQuestions', sortOrder = 'desc') {
+  async getUserDetails(startDate?: string, endDate?: string, page = 1, limit = 10, search = '', source = 'vicharanashala', crop = '', village = '', profileCompleted = 'all', inactiveOnly = false, lowFeedbackOnly = false, userType = 'all', sortBy = 'totalQuestions', sortOrder = 'desc') {
     try {
       const start = startDate ? new Date(startDate) : undefined;
       const end = endDate ? new Date(endDate) : undefined;
-      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search, source, crop, village, profileCompleted, inactiveOnly, undefined, userType, sortBy, sortOrder);
+      return await this.chatbotRepository.getUserDetails(start, end, page, limit, search, source, crop, village, profileCompleted, inactiveOnly, undefined, userType, sortBy, sortOrder, lowFeedbackOnly);
     } catch (error) {
       throw new InternalServerError(`Failed to fetch user details: ${error}`);
     }

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -13,6 +13,7 @@ export interface KpiSummary {
   totalAppInstalls: number; // It will the count the user whose profile is completed or not.
   inactiveUsersLast3Days: number; // users with zero messages in the last 3 days
   duplicateQuestionsCount: number; // questions with a similarityScore field
+  lowFeedbackUsersCount: number; // users who have never given any feedback (no feedback object in messages)
 }
 
 export interface DuplicateQuestionEntry {
@@ -236,6 +237,7 @@ export interface IChatbotRepository {
     userType?: string,
     sortBy?: string,
     sortOrder?: string,
+    lowFeedbackOnly?: boolean,
   ): Promise<PaginatedUserDetails>;
 
   /** Aggregate conversations from the messages collection for Excel export. */

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -186,7 +186,7 @@ export class ChatbotRepository implements IChatbotRepository {
       const userDocFilter = this.buildUserDocFilter(userType);
       const userTypeLookupStages = this.buildUserTypeLookupStages(userType);
 
-      const [totalUsers, monthlyActivity, sessionStats, todayQueryCount, totalAppInstalls, activeUsersLast3Days] =
+      const [totalUsers, monthlyActivity, sessionStats, todayQueryCount, totalAppInstalls, activeUsersLast3Days, usersWithFeedback] =
         await Promise.all([
           this.users.countDocuments(userDocFilter, { session }),
 
@@ -250,6 +250,18 @@ export class ChatbotRepository implements IChatbotRepository {
               { session },
             )
             .toArray(),
+
+          // Count distinct users who have given at least one feedback (feedback object exists in any message)
+          this.messagesCollection
+            .aggregate(
+              [
+                { $match: { feedback: { $exists: true }, isCreatedByUser: false } },
+                { $group: { _id: '$user' } },
+                { $count: 'total' },
+              ],
+              { session },
+            )
+            .toArray(),
         ]);
 
       const monthMap = Object.fromEntries(
@@ -269,6 +281,7 @@ export class ChatbotRepository implements IChatbotRepository {
 
       const avgMs = sessionStats[0]?.avg ?? 0;
       const activeCount = (activeUsersLast3Days as any[])[0]?.total ?? 0;
+      const feedbackCount = (usersWithFeedback as any[])[0]?.total ?? 0;
 
       await this.initReviewSystem();
       // Count only duplicates that have a matching message in the selected source DB —
@@ -300,6 +313,7 @@ export class ChatbotRepository implements IChatbotRepository {
         totalAppInstalls,
         inactiveUsersLast3Days: Math.max(0, totalUsers - activeCount),
         duplicateQuestionsCount,
+        lowFeedbackUsersCount: Math.max(0, totalUsers - feedbackCount),
       };
     } catch (error) {
       throw new InternalServerError(`Failed to get KPI summary: ${error}`);
@@ -956,6 +970,7 @@ export class ChatbotRepository implements IChatbotRepository {
     userType = 'all',
     sortBy = 'totalQuestions',
     sortOrder = 'desc',
+    lowFeedbackOnly = false,
   ): Promise<PaginatedUserDetails> {
     try {
       await this.init(source);
@@ -1066,7 +1081,20 @@ export class ChatbotRepository implements IChatbotRepository {
       }));
 
       // Filter to inactive users only if requested
-      const finalList = inactiveOnly ? merged.filter((u) => u.totalQuestions === 0) : merged;
+      const afterInactive = inactiveOnly ? merged.filter((u) => u.totalQuestions === 0) : merged;
+
+      // Filter to low-feedback users only if requested (all-time, no date range on feedback)
+      let finalList = afterInactive;
+      if (lowFeedbackOnly) {
+        const feedbackDocs = await this.messagesCollection
+          .aggregate([
+            { $match: { feedback: { $exists: true }, isCreatedByUser: false } },
+            { $group: { _id: '$user' } },
+          ])
+          .toArray();
+        const usersWithFeedback = new Set(feedbackDocs.map((d: any) => String(d._id)));
+        finalList = afterInactive.filter((u) => !usersWithFeedback.has(u.userId));
+      }
 
       // Sort based on sortBy and sortOrder parameters
       if (sortBy === 'name') {

--- a/frontend/src/features/chatbotDashboard/AlertCard.tsx
+++ b/frontend/src/features/chatbotDashboard/AlertCard.tsx
@@ -17,6 +17,8 @@ interface AlertCardProps {
   onInactiveClick?: () => void;
   duplicateQuestionsCount?: number | null;
   onDuplicateClick?: () => void;
+  lowFeedbackUsersCount?: number | null;
+  onLowFeedbackClick?: () => void;
 }
 
 export function AlertCard({
@@ -25,6 +27,8 @@ export function AlertCard({
   onInactiveClick,
   duplicateQuestionsCount,
   onDuplicateClick,
+  lowFeedbackUsersCount,
+  onLowFeedbackClick,
 }: AlertCardProps) {
   const [isSpikesModalOpen, setIsSpikesModalOpen] = useState(false);
 
@@ -121,6 +125,43 @@ export function AlertCard({
           </div>
         </div>
         <Badge label={duplicateQuestionsCount != null ? duplicateQuestionsCount.toLocaleString() : '—'} variant="amber" />
+      </div>
+
+      {/* Low Feedback Users Row */}
+      <div
+        className="flex items-center justify-between rounded-lg p-3 mb-2.5 border border-orange-200 dark:border-orange-800/40 bg-orange-50 dark:bg-orange-950/30 cursor-pointer hover:bg-orange-100 dark:hover:bg-orange-950/50 transition-colors"
+        onClick={() => onLowFeedbackClick?.()}
+      >
+        <div className="flex items-center gap-2.5">
+          <div className="flex items-center justify-center w-7 h-7 rounded-full bg-orange-100 dark:bg-orange-900/40">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-orange-600 dark:text-orange-400"
+            >
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+            </svg>
+          </div>
+          <div>
+            <div className="text-xs font-medium text-gray-900 dark:text-gray-50">
+              Low Feedback Users
+            </div>
+            <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
+              Users who have never given feedback
+            </div>
+          </div>
+        </div>
+        <Badge label={lowFeedbackUsersCount != null ? lowFeedbackUsersCount.toLocaleString() : '—'} variant="amber" />
       </div>
 
       {/* Domain Spikes Row — always rendered, shows top spike or a placeholder */}

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -69,6 +69,19 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
   const clearSegment = () => setActiveSegment(null);
   const [isDuplicateModalOpen, setIsDuplicateModalOpen] = useState(false);
 
+  // Navigate to User Details with low-feedback-only filter pre-applied
+  const handleLowFeedbackUsersClick = useCallback(() => {
+    setUserDetailsInitialFilters({
+      lowFeedbackOnly: true,
+      inactiveOnly: false,
+      search: "",
+      crop: "",
+      village: "",
+      profileCompleted: "all",
+    });
+    setActiveView("user-details");
+  }, []);
+
   // Navigate to User Details with inactive-only filter pre-applied
   const handleInactiveUsersClick = useCallback(() => {
     // Align to midnight to match the backend KPI calculation in getKpiSummary
@@ -210,6 +223,8 @@ export function AnnamDashboard_dev({ className, source = 'vicharanashala' }: { c
                       onInactiveClick={handleInactiveUsersClick}
                       duplicateQuestionsCount={(data as any).duplicateQuestionsCount ?? 0}
                       onDuplicateClick={() => setIsDuplicateModalOpen(true)}
+                      lowFeedbackUsersCount={(data as any).lowFeedbackUsersCount ?? null}
+                      onLowFeedbackClick={handleLowFeedbackUsersClick}
                     />
                     {isDuplicateModalOpen && (
                       <DuplicateQuestionsModal onClose={() => setIsDuplicateModalOpen(false)} source={source} />

--- a/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
+++ b/frontend/src/features/chatbotDashboard/UserDetailsView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { X, MapPin, Maximize2 } from "lucide-react";
 import { Button } from "@/components/atoms/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/atoms/card";
@@ -96,6 +96,7 @@ const DEFAULT_FILTERS: UserDetailsFilters = {
   endTime: undefined,
   profileCompleted: "all",
   inactiveOnly: false,
+  lowFeedbackOnly: false,
 };
 
 interface UserDetailsViewProps {
@@ -116,12 +117,20 @@ export function UserDetailsView({ source = 'vicharanashala', initialFilters, use
   const [isBarGraphMaximized, setIsBarGraphMaximized] = useState(false);
   const [isKnowledgeMaximized, setIsKnowledgeMaximized] = useState(false);
   const [isDuplicateModalOpen, setIsDuplicateModalOpen] = useState(false);
+  const tableRef = useRef<HTMLDivElement>(null);
 
-  // Apply initialFilters when they change (e.g. clicking from AlertCard)
+  const scrollToTable = () => {
+    setTimeout(() => tableRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 100);
+  };
+
+  // Apply initialFilters when they change (e.g. clicking from AlertCard in overview)
   useEffect(() => {
     if (initialFilters) {
       setFilters(prev => ({ ...prev, ...initialFilters }));
       setCurrentPage(1);
+      if (initialFilters.inactiveOnly || initialFilters.lowFeedbackOnly) {
+        scrollToTable();
+      }
     }
   }, [initialFilters]);
 
@@ -136,6 +145,7 @@ export function UserDetailsView({ source = 'vicharanashala', initialFilters, use
     filters.village,
     filters.profileCompleted,
     filters.inactiveOnly,
+    filters.lowFeedbackOnly,
     userType,
     sortBy,
     sortOrder,
@@ -214,7 +224,8 @@ export function UserDetailsView({ source = 'vicharanashala', initialFilters, use
     filters.state ||
     filters.startTime ||
     filters.profileCompleted !== "all" ||
-    filters.inactiveOnly;
+    filters.inactiveOnly ||
+    filters.lowFeedbackOnly;
 
   const dateLabel = filters.startTime && filters.endTime
     ? `${filters.startTime.toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })} – ${filters.endTime.toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })}`
@@ -267,11 +278,23 @@ export function UserDetailsView({ source = 'vicharanashala', initialFilters, use
                     startTime: threeDaysAgo,
                     endTime: today,
                     inactiveOnly: true,
+                    lowFeedbackOnly: false,
                   }));
                   setCurrentPage(1);
+                  scrollToTable();
                 }}
                 duplicateQuestionsCount={isDashboardLoading ? undefined : (dashboardData as any).duplicateQuestionsCount ?? 0}
                 onDuplicateClick={() => setIsDuplicateModalOpen(true)}
+                lowFeedbackUsersCount={isDashboardLoading ? null : (dashboardData as any).lowFeedbackUsersCount ?? null}
+                onLowFeedbackClick={() => {
+                  setFilters(prev => ({
+                    ...prev,
+                    lowFeedbackOnly: true,
+                    inactiveOnly: false,
+                  }));
+                  setCurrentPage(1);
+                  scrollToTable();
+                }}
               />
               {isDuplicateModalOpen && (
                 <DuplicateQuestionsModal onClose={() => setIsDuplicateModalOpen(false)} source={source} />
@@ -570,6 +593,7 @@ export function UserDetailsView({ source = 'vicharanashala', initialFilters, use
       </div>
 
       {/* Users table */}
+      <div ref={tableRef}>
       <Card className="dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between gap-3 min-w-0 w-full">
@@ -840,6 +864,7 @@ export function UserDetailsView({ source = 'vicharanashala', initialFilters, use
           )}
         </CardContent>
       </Card>
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
+++ b/frontend/src/features/chatbotDashboard/components/UserDetailsPreferenceFilter.tsx
@@ -32,6 +32,7 @@ import {
   UserCheck,
   RefreshCcw,
   UserX,
+  MessageSquareOff,
   Info,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -47,13 +48,14 @@ export interface UserDetailsFilters {
   endTime: Date | undefined;
   profileCompleted: "all" | "yes" | "no";
   inactiveOnly: boolean;
+  lowFeedbackOnly: boolean;
 }
 
 interface UserDetailsPreferenceFilterProps {
   filters: UserDetailsFilters;
   onApply: (filters: UserDetailsFilters) => void;
   /** Fields to hide from the filter dialog */
-  hideFields?: Array<'crop' | 'inactive' | 'profile'>;
+  hideFields?: Array<'crop' | 'inactive' | 'profile' | 'lowFeedback'>;
 }
 
 function toDateInputValue(d: Date | undefined): string {
@@ -155,6 +157,7 @@ export function UserDetailsPreferenceFilter({
       endTime: undefined,
       profileCompleted: "all",
       inactiveOnly: false,
+      lowFeedbackOnly: false,
     });
   };
 
@@ -167,7 +170,8 @@ export function UserDetailsPreferenceFilter({
     (filters.state ? 1 : 0) +
     (filters.startTime ? 1 : 0) +
     (filters.profileCompleted !== "all" ? 1 : 0) +
-    (filters.inactiveOnly ? 1 : 0);
+    (filters.inactiveOnly ? 1 : 0) +
+    (filters.lowFeedbackOnly ? 1 : 0);
 
   return (
     <Dialog open={open} onOpenChange={handleOpen}>
@@ -347,6 +351,53 @@ export function UserDetailsPreferenceFilter({
                     className={cn(
                       "pointer-events-none inline-block h-[18px] w-[18px] rounded-full bg-white shadow transition-transform duration-200",
                       draft.inactiveOnly ? "translate-x-[20px]" : "translate-x-[2px]"
+                    )}
+                  />
+                </label>
+              </div>
+            </div>
+          )}
+
+          {/* Low Feedback Users */}
+          {!hideFields.includes('lowFeedback') && (
+            <div className="rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-[#161616] p-4">
+              <div className="flex items-center justify-between">
+                <Label className="flex items-center gap-2 text-sm font-semibold text-(--foreground)">
+                  <span className="flex items-center justify-center w-6 h-6 rounded-md bg-orange-500/10 text-orange-500">
+                    <MessageSquareOff className="h-3.5 w-3.5" />
+                  </span>
+                  Low Feedback Users
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info className="h-3.5 w-3.5 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 cursor-help" />
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="max-w-[200px] text-xs">
+                      Shows users who have never given any feedback (no thumbs up/down on any response)
+                    </TooltipContent>
+                  </Tooltip>
+                </Label>
+                <label
+                  htmlFor="low-feedback-only"
+                  className={cn(
+                    "relative inline-flex h-[22px] w-[40px] shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200",
+                    draft.lowFeedbackOnly
+                      ? "bg-orange-500"
+                      : "bg-gray-300 dark:bg-gray-600"
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    id="low-feedback-only"
+                    className="sr-only"
+                    checked={draft.lowFeedbackOnly}
+                    onChange={(e) =>
+                      setDraft((d) => ({ ...d, lowFeedbackOnly: e.target.checked }))
+                    }
+                  />
+                  <span
+                    className={cn(
+                      "pointer-events-none inline-block h-[18px] w-[18px] rounded-full bg-white shadow transition-transform duration-200",
+                      draft.lowFeedbackOnly ? "translate-x-[20px]" : "translate-x-[2px]"
                     )}
                   />
                 </label>

--- a/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useDashboardData.ts
@@ -22,6 +22,8 @@ interface DashboardApiResponse {
     voiceUsageSharePct: number;
     totalAppInstalls: number;
     inactiveUsersLast3Days: number;
+    duplicateQuestionsCount: number;
+    lowFeedbackUsersCount: number;
   };
   dau: DailyEntry[];
   weeklySessionDuration: Array<{ week: string; avgSessionDurationMin: number }>;
@@ -115,8 +117,8 @@ function weeklyRange(entries: Array<{ week: string }>): string {
 
 // ── Transform raw API response into dashboard shape ─────────────────────────
 
-function transformApiResponse(result: DashboardApiResponse): DashboardDataType & { inactiveUsersLast3Days: number; duplicateQuestionsCount: number } {
-  const updatedData = { ...DASHBOARD_DATA } as DashboardDataType & { inactiveUsersLast3Days: number; duplicateQuestionsCount: number };
+function transformApiResponse(result: DashboardApiResponse): DashboardDataType & { inactiveUsersLast3Days: number; duplicateQuestionsCount: number; lowFeedbackUsersCount: number } {
+  const updatedData = { ...DASHBOARD_DATA } as DashboardDataType & { inactiveUsersLast3Days: number; duplicateQuestionsCount: number; lowFeedbackUsersCount: number };
   // Use the real month-over-month % from the backend
   const pct = result.kpi.dauLastMonthPct;
   const delta = pct > 0
@@ -187,6 +189,7 @@ function transformApiResponse(result: DashboardApiResponse): DashboardDataType &
 
   updatedData.inactiveUsersLast3Days = result.kpi.inactiveUsersLast3Days ?? 0;
   updatedData.duplicateQuestionsCount = result.kpi.duplicateQuestionsCount ?? 0;
+  updatedData.lowFeedbackUsersCount = result.kpi.lowFeedbackUsersCount ?? 0;
 
   updatedData.kpiRow1 = DASHBOARD_DATA.kpiRow1.map(card => {
     if (card.id === 'dau') {

--- a/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useUserDetails.ts
@@ -56,6 +56,7 @@ export function useUserDetails(
   village = '',
   profileCompleted: 'all' | 'yes' | 'no' = 'all',
   inactiveOnly = false,
+  lowFeedbackOnly = false,
   userType: 'all' | 'external' | 'internal' = 'all',
   sortBy: 'totalQuestions' | 'name' = 'totalQuestions',
   sortOrder: 'asc' | 'desc' = 'desc',
@@ -68,7 +69,7 @@ export function useUserDetails(
     : undefined;
 
   const { data, isLoading, error } = useQuery<PaginatedUserDetailsResponse, Error>({
-    queryKey: ['user-details', startISO, endISO, page, limit, search, source, crop, village, profileCompleted, inactiveOnly, userType, sortBy, sortOrder],
+    queryKey: ['user-details', startISO, endISO, page, limit, search, source, crop, village, profileCompleted, inactiveOnly, lowFeedbackOnly, userType, sortBy, sortOrder],
     staleTime: 30 * 1000,
     queryFn: async () => {
       const API_BASE_URL = env.apiBaseUrl();
@@ -83,6 +84,7 @@ export function useUserDetails(
       if (village.trim()) params.set('village', village.trim());
       if (profileCompleted !== 'all') params.set('profileCompleted', profileCompleted);
       if (inactiveOnly) params.set('inactiveOnly', 'true');
+      if (lowFeedbackOnly) params.set('lowFeedbackOnly', 'true');
       if (userType !== 'all') params.set('userType', userType);
       params.set('sortBy', sortBy);
       params.set('sortOrder', sortOrder);


### PR DESCRIPTION
Adds a "Low Feedback Users" row to the Alerts & Notifications card showing the count of users who have never given any feedback (thumbs up/down). Clicking it navigates to the User Details page with the filter pre-applied and auto-scrolls to the users table. The same click-through works from within the User Details page's own alert card. A Low Feedback Users toggle is also added to the Preferences filter dialog.  