### PR TITLE
feat(planner): constrain domain selection and deterministic crop pipe…

### DIFF
--- a/ai/ajrasakha/agents/PLANNER_PRODUCT_DECISIONS.md
+++ b/ai/ajrasakha/agents/PLANNER_PRODUCT_DECISIONS.md
@@ -49,7 +49,7 @@ GDB no longer overrides state from thread config — it uses what the planner pa
 
 ## Feature flag
 
-- `USE_PLANNER_GRAPH=true` (default): planner → ensure_location → execute_plan → synthesize → sanitize_answer.
+- `USE_PLANNER_GRAPH=true` (default): planner → ensure_location → execute_plan → retrieval_sanitizer (when applicable) → synthesize → END. (`sanitize_answer` is commented out in the graph.)
 - `USE_PLANNER_GRAPH=false`: legacy single-LLM `ajrasakha` + `tools` loop.
 
 ## Synthesizer

--- a/ai/ajrasakha/agents/ajrasakha.py
+++ b/ai/ajrasakha/agents/ajrasakha.py
@@ -31,10 +31,12 @@ from ajrasakha.agents.plan_executor import (
     ensure_location_node,
     execute_plan_node,
     route_after_execute,
+    route_after_sanitizer,
 )
 from ajrasakha.agents.planner import clarify_node, planner_node, route_after_planner
 from ajrasakha.agents.prompts import (
     EMPTY_GDB_REPLY,
+    EXPERT_QUEUE_REPLY_MARKER,
     LLM_FALLBACK_MSG,
     WARNING_TEXT,
     WHATSAPP_SYSTEM_PROMPT,
@@ -302,6 +304,9 @@ def route_after_ajrasakha(state: AjraSakhaState) -> str:
 def sanitize_answer_node(state: AjraSakhaState) -> dict:
     """Adjust the 2-hour reviewer disclaimer on the final farmer-facing answer.
 
+    Disabled in _build_graph() (synthesize goes directly to END). Re-enable by
+    uncommenting the sanitize_answer node and edges below.
+
     - GDB returned real data (gdb_has_data=True): ALWAYS strip the 2-hour disclaimer.
     - Strong GDB-style answer (expert + sources + links): strip disclaimer if present.
     - Weak / no-database-match answer: append disclaimer if missing.
@@ -317,7 +322,7 @@ def sanitize_answer_node(state: AjraSakhaState) -> dict:
         return {}
 
     answer_text = _message_to_text(final_answer_msg)
-    if not answer_text or answer_text.startswith(EMPTY_GDB_REPLY[:80]):
+    if not answer_text or EXPERT_QUEUE_REPLY_MARKER in answer_text:
         return {}
 
     # Check if GDB returned real expert data
@@ -371,7 +376,7 @@ def sanitize_answer_node(state: AjraSakhaState) -> dict:
 def _build_graph():
     builder = StateGraph(AjraSakhaState)
     builder.add_node("empty_gdb_reply", empty_gdb_reply_node)
-    builder.add_node("sanitize_answer", sanitize_answer_node)
+    # builder.add_node("sanitize_answer", sanitize_answer_node)  # disabled: 2-hour disclaimer post-process
 
     if use_planner_graph():
         builder.add_node("planner", planner_node)
@@ -399,12 +404,19 @@ def _build_graph():
                 "empty_gdb_reply": "empty_gdb_reply",
             },
         )
-        builder.add_edge("retrieval_sanitizer", "synthesize")
-        builder.add_edge("synthesize", "sanitize_answer")
-
+        builder.add_conditional_edges(
+            "retrieval_sanitizer",
+            route_after_sanitizer,
+            {
+                "empty_gdb_reply": "empty_gdb_reply",
+                "synthesize": "synthesize",
+            },
+        )
+        builder.add_edge("synthesize", END)
+        # builder.add_edge("synthesize", "sanitize_answer")
 
     builder.add_edge("empty_gdb_reply", END)
-    builder.add_edge("sanitize_answer", END)
+    # builder.add_edge("sanitize_answer", END)
     return builder.compile()
 
 

--- a/ai/ajrasakha/agents/crop_requirement.py
+++ b/ai/ajrasakha/agents/crop_requirement.py
@@ -1,0 +1,83 @@
+"""LLM crop requirement classifier (crop_specific vs general)."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.runnables import RunnableConfig
+
+from ajrasakha.agents.config import CLAUDE_MODEL
+
+logger = logging.getLogger(__name__)
+
+_CROP_CLASSIFICATION_SYSTEM_PROMPT = (
+    "You classify agricultural farmer questions. Given a domain and question, "
+    "decide whether a human expert must know the specific crop to answer correctly, "
+    "and whether the answer would meaningfully differ across crops. "
+    "Return exactly one word: crop_specific or general. No other text."
+)
+
+
+def parse_crop_classification(raw_output: str) -> bool:
+    """
+    Parse LLM output.
+    Returns True if crop-specific (crop required), False if general.
+    Unknown values fail open to general (False).
+    """
+    cleaned = (raw_output or "").strip().lower()
+    if not cleaned:
+        return False
+
+    if re.search(r"\bcrop[_\s-]?specific\b", cleaned) or cleaned in {
+        "yes",
+        "true",
+        "1",
+        "crop_specific",
+    }:
+        return True
+
+    if re.search(r"\bgeneral\b", cleaned) or cleaned in {"no", "false", "0"}:
+        return False
+
+    return False
+
+
+async def is_crop_specific_question(
+    question: str,
+    original_question: str,
+    domain: str,
+    *,
+    config: Optional[RunnableConfig] = None,
+) -> bool:
+    """
+    Returns True if crop is required; False if general (crop=all ok).
+    On LLM failure, fails open to False (general).
+    """
+    try:
+        llm = ChatAnthropic(model=CLAUDE_MODEL, max_tokens=16, temperature=0)
+        response = await llm.ainvoke(
+            [
+                SystemMessage(content=_CROP_CLASSIFICATION_SYSTEM_PROMPT),
+                HumanMessage(
+                    content=(
+                        f"Domain: {domain}\n"
+                        f"Question: {question}\n"
+                        f"Original question: {original_question}\n\n"
+                        "Return only crop_specific or general."
+                    )
+                ),
+            ],
+            config=config,
+        )
+        raw = response.content if isinstance(response.content, str) else str(response.content)
+        return parse_crop_classification(raw)
+    except Exception as exc:
+        logger.warning(
+            "Crop requirement classifier failed (fail-open to general): %s",
+            exc,
+        )
+        return False

--- a/ai/ajrasakha/agents/domains.py
+++ b/ai/ajrasakha/agents/domains.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 # Domains that REQUIRE a specific crop (not "all").
 CROP_REQUIRED_DOMAINS: frozenset[str] = frozenset({
     "Agriculture Mechanization",
@@ -42,6 +44,47 @@ CROP_ALL_DOMAINS: frozenset[str] = frozenset({
 
 ALLOWED_DOMAINS: frozenset[str] = CROP_REQUIRED_DOMAINS | CROP_ALL_DOMAINS
 
+ALLOWED_DOMAINS_LIST: list[str] = sorted(ALLOWED_DOMAINS)
+
+# Common LLM / legacy label mistakes -> canonical ALLOWED_DOMAINS name.
+_DOMAIN_ALIASES: dict[str, str] = {
+    "crop protection": "Plant Protection",
+    "plant protection": "Plant Protection",
+    "soil health": "Soil Health Card",
+    "government scheme": "Government Schemes",
+    "government schemes": "Government Schemes",
+    "market price": "Market Prices",
+    "market prices": "Market Prices",
+    "financial and institutional services": "Financial & Institutional Services",
+    "pm-kisan": "Financial & Institutional Services",
+    "pm kisan": "Financial & Institutional Services",
+    "farm machinery and equipment": "Agriculture Mechanization",
+    "farm machinery": "Agriculture Mechanization",
+}
+
+# AI routing domains not in MCP allowed_domains -> upload-safe reviewer domain.
+_REVIEWER_UPLOAD_MAP: dict[str, str] = {
+    "Weather": "General",
+    "Market Prices": "Market Information",
+    "Government Schemes": "Financial & Institutional Services",
+    "General": "General",
+}
+
+_SCHEME_DOMAINS: frozenset[str] = frozenset({
+    "Government Schemes",
+    "Financial & Institutional Services",
+    "Crop Insurance",
+})
+
+
+class PlannerToolFlags(TypedDict, total=False):
+    weather: bool
+    mandi: bool
+    soil: bool
+    schemes: bool
+    chemical_checker: bool
+    knowledge_base: bool
+
 
 def domain_requires_crop(domain: str) -> bool:
     d = (domain or "").strip()
@@ -52,3 +95,69 @@ def domain_requires_crop(domain: str) -> bool:
     if d in CROP_REQUIRED_DOMAINS:
         return True
     return False
+
+
+def normalize_domain(raw: str) -> str:
+    """Map LLM output to exactly one ALLOWED_DOMAINS value; fallback General."""
+    d = (raw or "").strip()
+    if not d:
+        return "General"
+    if d in ALLOWED_DOMAINS:
+        return d
+    alias = _DOMAIN_ALIASES.get(d.lower())
+    if alias:
+        return alias
+    lowered = d.lower()
+    for canonical in ALLOWED_DOMAINS_LIST:
+        if canonical.lower() == lowered:
+            return canonical
+    return "General"
+
+
+def apply_tool_flags_from_domain(domain: str) -> PlannerToolFlags:
+    """Derive planner tool booleans from canonical domain (server-side only)."""
+    d = normalize_domain(domain)
+    flags: PlannerToolFlags = {
+        "weather": False,
+        "mandi": False,
+        "soil": False,
+        "schemes": False,
+        "chemical_checker": False,
+        "knowledge_base": False,
+    }
+    if d == "Weather":
+        flags["weather"] = True
+    elif d == "Market Prices":
+        flags["mandi"] = True
+    elif d in {"Soil Health Card", "Soil Testing"}:
+        flags["soil"] = True
+    elif d in _SCHEME_DOMAINS:
+        flags["schemes"] = True
+        flags["knowledge_base"] = False
+    elif d in CROP_REQUIRED_DOMAINS:
+        flags["knowledge_base"] = True
+    return flags
+
+
+def reviewer_upload_domain(domain: str) -> str:
+    """
+    Map AI planner domain to a name accepted by reviewer MCP allowed_domains.
+
+    MCP lacks Weather / Market Prices / Government Schemes / General as upload labels.
+    """
+    d = normalize_domain(domain)
+    return _REVIEWER_UPLOAD_MAP.get(d, d)
+
+
+def crop_counts_as_resolved(crop: str | None) -> bool:
+    """True when crop slot is filled (including all/general placeholders)."""
+    if not crop:
+        return False
+    return crop.strip().lower() not in {"", "not specified", "unknown", "none", "null", "n/a"}
+
+
+def is_crop_placeholder(crop: str | None) -> bool:
+    """True when crop means 'no specific crop' (all/general)."""
+    if not crop:
+        return False
+    return crop.strip().lower() in {"all", "general", "not specified", "none", "null"}

--- a/ai/ajrasakha/agents/plan_executor.py
+++ b/ai/ajrasakha/agents/plan_executor.py
@@ -19,6 +19,7 @@ from ajrasakha.agents.location_context import (
     merge_location_dict,
 )
 from ajrasakha.agents.language import text_matches_user_language
+from ajrasakha.agents.domains import reviewer_upload_domain
 from ajrasakha.agents.state import AjraSakhaState, Location, PlannerPlan
 from ajrasakha.agents.retrieval_sanitizer import should_skip_sanitizer_for_gdb
 from ajrasakha.agents.tool_registry import get_location_tool, get_main_tool_node, get_reviewer_tool
@@ -107,17 +108,7 @@ def _entity_str(
 
 
 def _reviewer_domain(plan: PlannerPlan) -> str:
-    if plan.get("weather"):
-        return "Weather"
-    if plan.get("mandi"):
-        return "Market Prices"
-    if plan.get("soil"):
-        return "Soil Health"
-    if plan.get("schemes"):
-        return "Government Schemes"
-    if plan.get("knowledge_base"):
-        return "Crop Protection"
-    return "General"
+    return reviewer_upload_domain(plan.get("domain") or "General")
 
 
 async def build_tool_calls_from_plan(

--- a/ai/ajrasakha/agents/plan_executor.py
+++ b/ai/ajrasakha/agents/plan_executor.py
@@ -26,6 +26,9 @@ from ajrasakha.agents.tool_registry import get_location_tool, get_main_tool_node
 
 logger = logging.getLogger(__name__)
 
+_SIMILAR_PAIR_KEYS = tuple(f"similar_pair{i}" for i in range(1, 6))
+_GDB_EMPTY_SENTINELS = frozenset({"NO_RELEVANT_CONTENT", "[]", "{}"})
+
 _CHEMICAL_NAME_RE = re.compile(
     r"\b(monocrotophos|chlorpyrifos|endosulfan|carbofuran|paraquat|"
     r"glyphosate|imidacloprid|thiamethoxam|mancozeb|carbendazim|"
@@ -417,6 +420,106 @@ async def execute_plan_node(
     return {"messages": [ai_msg] + new_msgs, "location": merged_loc}
 
 
+def _latest_turn_gdb_payload(messages: list[BaseMessage]) -> Optional[dict]:
+    """Parse gdb ToolMessage JSON from the current turn (after last HumanMessage)."""
+    last_human_idx = -1
+    for i in range(len(messages) - 1, -1, -1):
+        if isinstance(messages[i], HumanMessage):
+            last_human_idx = i
+            break
+    if last_human_idx < 0:
+        return None
+    for i in range(len(messages) - 1, last_human_idx, -1):
+        msg = messages[i]
+        if isinstance(msg, ToolMessage) and getattr(msg, "name", None) == "gdb":
+            text = _message_to_text(msg)
+            if not text or text.upper() in _GDB_EMPTY_SENTINELS:
+                return None
+            try:
+                data = json.loads(text)
+                if isinstance(data, dict):
+                    return data
+            except (json.JSONDecodeError, TypeError):
+                return None
+    return None
+
+
+def _gdb_has_usable_data(messages: list[BaseMessage]) -> bool:
+    """True when GDB has an exact answer or at least one similar pair with content."""
+    data = _latest_turn_gdb_payload(messages)
+    if not data:
+        return False
+    if data.get("is_exact"):
+        exact = data.get("exact_match") or {}
+        if (exact.get("answer") or "").strip():
+            return True
+    if data.get("is_similar"):
+        for key in _SIMILAR_PAIR_KEYS:
+            pair = data.get(key)
+            if isinstance(pair, dict) and (
+                (pair.get("question") or "").strip() or (pair.get("answer") or "").strip()
+            ):
+                return True
+    exact = data.get("exact_match") or {}
+    if (exact.get("answer") or "").strip():
+        return True
+    for key in _SIMILAR_PAIR_KEYS:
+        pair = data.get(key)
+        if isinstance(pair, dict) and (
+            (pair.get("question") or "").strip() or (pair.get("answer") or "").strip()
+        ):
+            return True
+    return False
+
+
+_SPECIALIST_TOOL_NAMES = frozenset({"weather", "market", "soil", "schemes", "chemical_checker"})
+
+
+def _plan_used_specialist_tools(plan: PlannerPlan) -> bool:
+    """True when weather/mandi/soil/schemes/chemical_checker were requested this turn."""
+    return bool(
+        plan.get("weather")
+        or plan.get("mandi")
+        or plan.get("soil")
+        or plan.get("schemes")
+        or plan.get("chemical_checker")
+    )
+
+
+def _turn_has_specialist_tool_message(messages: list[BaseMessage]) -> bool:
+    """True when a specialist ToolMessage exists in the current turn."""
+    last_human_idx = -1
+    for i in range(len(messages) - 1, -1, -1):
+        if isinstance(messages[i], HumanMessage):
+            last_human_idx = i
+            break
+    if last_human_idx < 0:
+        return False
+    for i in range(len(messages) - 1, last_human_idx, -1):
+        msg = messages[i]
+        if isinstance(msg, ToolMessage):
+            name = getattr(msg, "name", None) or ""
+            if name in _SPECIALIST_TOOL_NAMES and _message_to_text(msg):
+                return True
+    return False
+
+
+def should_expert_queue_reply(state: AjraSakhaState) -> bool:
+    """GDB empty after retrieval + no specialist tools → canned expert-queue message."""
+    plan = state.get("plan") or {}
+    messages = state.get("messages") or []
+    used_specialists = _plan_used_specialist_tools(plan) or _turn_has_specialist_tool_message(
+        messages
+    )
+    return not _gdb_has_usable_data(messages) and not used_specialists
+
+
+def route_after_sanitizer(state: AjraSakhaState) -> str:
+    if should_expert_queue_reply(state):
+        return "empty_gdb_reply"
+    return "synthesize"
+
+
 def route_after_execute(state: AjraSakhaState) -> str:
     plan = state.get("plan") or {}
     if plan.get("skip_synthesize"):
@@ -426,25 +529,13 @@ def route_after_execute(state: AjraSakhaState) -> str:
         if isinstance(msg, AIMessage):
             break
         if isinstance(msg, ToolMessage) and getattr(msg, "name", None) == "gdb":
-            text = _message_to_text(msg)
-            if not text or text.upper() == "NO_RELEVANT_CONTENT" or text in {"[]", "{}"}:
+            if should_expert_queue_reply(state):
                 return "empty_gdb_reply"
-            try:
-                data = json.loads(text)
-                if isinstance(data, dict):
-                    if should_skip_sanitizer_for_gdb(data):
-                        return "synthesize"
-                    is_exact = data.get("is_exact", False)
-                    is_similar = data.get("is_similar", False)
-                    # If neither exact nor similar match, it's empty
-                    if not is_exact and not is_similar:
-                        # Also check legacy format
-                        exact = data.get("exact_match") or {}
-                        similar = data.get("similar_match") or {}
-                        if not exact and not similar:
-                            return "empty_gdb_reply"
-            except Exception:
-                pass
+            data = _latest_turn_gdb_payload(messages)
+            if data and should_skip_sanitizer_for_gdb(data):
+                return "synthesize"
             return "retrieval_sanitizer"
+    if should_expert_queue_reply(state):
+        return "empty_gdb_reply"
     return "retrieval_sanitizer"
 

--- a/ai/ajrasakha/agents/planner.py
+++ b/ai/ajrasakha/agents/planner.py
@@ -2,22 +2,10 @@
 
 Flow:
   1. Take input query
-  2. Check domain (via LLM classification)
-  3. Check state (from query text first, then from lat/long)
-  4. Check crop (from query text)
-  5. Lookup table: is crop required for this domain?
-     - crop_required=True  AND crop available   → pass
-     - crop_required=True  AND crop unavailable  → ask user for crop
-     - crop_required=False                       → crop = "All"
-  6. State resolution:
-     - state in query   → state = query_state
-     - state not in query → state = from lat/long
-  7. Completeness check:
-     - state=True AND crop_required=True  AND crop=True  → is_question_complete=True
-     - state=True AND crop_required=True  AND crop=False → is_question_complete=False
-  8. If is_question_complete=True → determine tools to call
-  9. Final output to main agent:
-     {original_query, rephrased_query, state, crop, tools: [list]}
+  2. LLM picks domain from domains.py ALLOWED_DOMAINS (latest message)
+  3. Derive tool flags from domain; resolve state (latest + GPS)
+  4. CROP_ALL_DOMAINS -> crop=all; CROP_REQUIRED -> extract + LLM classifier
+  5. Completeness check -> clarify or execute
 """
 
 from __future__ import annotations
@@ -34,20 +22,25 @@ from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
 from ajrasakha.agents.config import CLAUDE_MODEL
-from ajrasakha.agents.domains import domain_requires_crop, ALLOWED_DOMAINS
+from ajrasakha.agents.crop_requirement import is_crop_specific_question
+from ajrasakha.agents.domains import (
+    CROP_ALL_DOMAINS,
+    CROP_REQUIRED_DOMAINS,
+    apply_tool_flags_from_domain,
+    crop_counts_as_resolved,
+    normalize_domain,
+)
 from ajrasakha.agents.language import detect_farmer_language
 from ajrasakha.agents.location_context import (
     gps_state_from_location,
     latest_human_text,
     main_agent_location_context_message,
-    recent_human_text,
     resolve_state_for_turn,
 )
 from ajrasakha.agents.planner_rules import (
     apply_planner_completeness_rules,
-    extract_crop_from_text,
     format_conversation_for_planner,
-    infer_domain_for_plan,
+    resolve_crop_for_turn,
 )
 from ajrasakha.agents.prompts import PLANNER_SYSTEM_PROMPT
 from ajrasakha.agents.state import AjraSakhaState, PlannerEntities, PlannerPlan
@@ -69,6 +62,10 @@ class PlannerEntitiesOutput(BaseModel):
 
 
 class PlannerOutput(BaseModel):
+    domain: str = Field(
+        default="General",
+        description="Exactly one value from ALLOWED_DOMAINS in ajrasakha.agents.domains",
+    )
     weather: bool = False
     mandi: bool = False
     soil: bool = False
@@ -138,6 +135,7 @@ def planner_output_to_plan(output: PlannerOutput) -> PlannerPlan:
         entities["chemicals"] = list(output.entities.chemicals)
 
     return {
+        "domain": normalize_domain(output.domain),
         "weather": output.weather,
         "mandi": output.mandi,
         "soil": output.soil,
@@ -157,6 +155,7 @@ def planner_output_to_plan(output: PlannerOutput) -> PlannerPlan:
 
 def _default_plan_for_agriculture(user_query: Optional[str] = None) -> PlannerPlan:
     return {
+        "domain": "General",
         "weather": False,
         "mandi": False,
         "soil": False,
@@ -182,14 +181,53 @@ def _resolve_state_deterministic(
     return resolve_state_for_turn(latest_human_text(messages), location)
 
 
-def _resolve_crop_deterministic(
+async def _apply_domain_and_crop_async(
+    plan: PlannerPlan,
     messages: list[BaseMessage],
-) -> Optional[str]:
-    """Crop from recent clarify turns only (not full thread history)."""
-    crop = extract_crop_from_text(recent_human_text(messages, max_turns=5))
-    if crop:
-        return crop[0].upper() + crop[1:].lower()
-    return None
+    *,
+    crop_prefilled: Optional[str],
+    config: RunnableConfig,
+) -> tuple[PlannerPlan, str, bool]:
+    """Normalize domain, derive flags, apply CROP_ALL / CROP_REQUIRED crop rules."""
+    domain = normalize_domain(plan.get("domain") or "General")
+    plan["domain"] = domain
+
+    tool_flags = apply_tool_flags_from_domain(domain)
+    chemical_checker = plan.get("chemical_checker", False)
+    plan.update(tool_flags)
+    if chemical_checker:
+        plan["chemical_checker"] = True
+
+    entities: PlannerEntities = dict(plan.get("entities") or {})
+    user_text = latest_human_text(messages)
+    question = plan.get("rephrased_query") or user_text
+    original = plan.get("original_query_en") or user_text
+
+    crop_required = False
+
+    if domain in CROP_ALL_DOMAINS:
+        entities["crop"] = "all"
+        crop_required = False
+    elif domain in CROP_REQUIRED_DOMAINS:
+        crop = crop_prefilled or resolve_crop_for_turn(messages) or entities.get("crop")
+        if crop and crop_counts_as_resolved(crop):
+            entities["crop"] = (
+                "all" if crop.lower() == "all"
+                else crop[0].upper() + crop[1:].lower()
+            )
+            crop_required = False
+        else:
+            crop_required = await is_crop_specific_question(
+                question, original, domain, config=config
+            )
+            if not crop_required:
+                entities["crop"] = "all"
+    else:
+        entities["crop"] = "all"
+        crop_required = False
+
+    plan["entities"] = entities
+    return plan, domain, crop_required
 
 
 def _check_question_completeness(
@@ -199,19 +237,10 @@ def _check_question_completeness(
     has_gps: bool,
     farmer_language: str = "English",
 ) -> tuple[bool, list[str], Optional[str]]:
-    """Deterministic completeness check following the specified flow.
-
-    Returns (is_complete, missing_info, follow_up_question).
-
-    Logic:
-      - State must be known (from text or GPS)
-      - If crop_required and crop not available → incomplete, ask for crop
-      - If crop_required=False → crop = "All" (handled by caller)
-    """
+    """Deterministic completeness check following the specified flow."""
     missing: list[str] = []
     follow_up: Optional[str] = None
 
-    # State check: either from text or GPS must be available
     has_state = bool(state_resolved) or has_gps
     if not has_state:
         missing.append("location")
@@ -222,8 +251,7 @@ def _check_question_completeness(
         )
         return False, missing, follow_up
 
-    # Crop check: only when domain requires it
-    if crop_required and not crop_resolved:
+    if crop_required and not crop_counts_as_resolved(crop_resolved):
         missing.append("crop")
         follow_up = (
             "Which crop are you growing?"
@@ -247,6 +275,7 @@ async def planner_node(
     user_text = _message_to_text(human)
     if is_greeting_message(user_text):
         plan: PlannerPlan = {
+            "domain": "General",
             "weather": False,
             "mandi": False,
             "soil": False,
@@ -257,39 +286,31 @@ async def planner_node(
             "missing_info": [],
             "follow_up_question": None,
             "reasoning": "greeting",
-            "entities": {},
+            "entities": {"crop": "all"},
             "skip_synthesize": False,
             "rephrased_query": user_text,
             "original_query_en": user_text,
         }
         return {"plan": plan}
 
-    # ── Step 1: Deterministic entity extraction (NO LLM for state/crop) ────
     location = state.get("location")
     farmer_lang = detect_farmer_language(user_text)
 
-    # Resolve state: text first, then GPS location
     state_resolved = _resolve_state_deterministic(messages, location)
+    crop_resolved = resolve_crop_for_turn(messages)
 
-    # Resolve crop: from conversation text
-    crop_resolved = _resolve_crop_deterministic(messages)
-
-    # Check if GPS exists on thread
     has_gps = bool(
         location
         and location.get("latitude") is not None
         and location.get("longitude") is not None
     )
 
-    # ── Step 2: Use LLM ONLY for domain/tool classification + translation ──
     llm_messages: list[BaseMessage] = [SystemMessage(content=PLANNER_SYSTEM_PROMPT)]
     loc_ctx = main_agent_location_context_message(location)
     if loc_ctx:
         llm_messages.append(loc_ctx)
     conv_block = format_conversation_for_planner(messages) or user_text
 
-    # Inject deterministically extracted entities so the LLM doesn't
-    # re-derive them (and potentially get them wrong)
     deterministic_context = (
         f"PRE-EXTRACTED ENTITIES (use these, do not override):\n"
         f"- state: {state_resolved or 'NOT RESOLVED'}\n"
@@ -300,7 +321,8 @@ async def planner_node(
         HumanMessage(
             content=(
                 f"{deterministic_context}\n"
-                f"Farmer conversation (language: {farmer_lang}):\n{conv_block}\n\n"
+                f"Latest farmer message (language: {farmer_lang}):\n{conv_block}\n\n"
+                f"Pick `domain` from the allowed list using this latest message only.\n"
                 f"Write follow_up_question in {farmer_lang} only when rules require it.\n"
                 "Return the routing plan only."
             )
@@ -312,10 +334,8 @@ async def planner_node(
         output = await llm.ainvoke(llm_messages, config=config)
         plan = planner_output_to_plan(output)
 
-        # ── Step 3: Override LLM entities with deterministic values ─────
         entities = plan.get("entities") or {}
 
-        # State: deterministic resolution takes priority
         if state_resolved:
             entities["state"] = state_resolved
         elif not entities.get("state"):
@@ -323,24 +343,20 @@ async def planner_node(
             if gps_state:
                 entities["state"] = gps_state
 
-        # Crop: deterministic extraction takes priority
         if crop_resolved:
             entities["crop"] = crop_resolved
 
         plan["entities"] = entities
 
-        # ── Step 4: Determine domain and crop requirement ──────────────
-        domain = infer_domain_for_plan(plan, user_text)
-        crop_required = domain_requires_crop(domain)
+        plan, domain, crop_required = await _apply_domain_and_crop_async(
+            plan,
+            messages,
+            crop_prefilled=crop_resolved,
+            config=config,
+        )
 
-        # If crop is NOT required for this domain, set crop = "All"
+        entities = plan.get("entities") or {}
         effective_crop = entities.get("crop")
-        if not crop_required:
-            effective_crop = "All"
-            entities["crop"] = "All"
-            plan["entities"] = entities
-
-        # ── Step 5: Deterministic completeness check ───────────────────
         final_state = entities.get("state") or state_resolved
         is_complete, missing, follow_up = _check_question_completeness(
             state_resolved=final_state,
@@ -354,7 +370,6 @@ async def planner_node(
         plan["missing_info"] = missing
         plan["follow_up_question"] = follow_up
 
-        # Apply remaining post-processing rules (schemes override, etc.)
         plan = apply_planner_completeness_rules(
             plan,
             messages,
@@ -366,6 +381,7 @@ async def planner_node(
             plan["rephrased_query"] = user_text
         if not plan.get("original_query_en"):
             plan["original_query_en"] = user_text
+        plan["knowledge_base"] = True
 
         logger.info(
             "Planner: complete=%s domain=%s crop_required=%s "
@@ -373,7 +389,7 @@ async def planner_node(
             "flags=(w=%s m=%s s=%s sch=%s chem=%s kb=%s) "
             "rephrased=%s missing=%s",
             plan.get("is_complete"),
-            domain,
+            plan.get("domain"),
             crop_required,
             entities.get("state"),
             entities.get("crop"),

--- a/ai/ajrasakha/agents/planner_rules.py
+++ b/ai/ajrasakha/agents/planner_rules.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import re
 from typing import Optional
 
-from langchain_core.messages import BaseMessage, HumanMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
-from ajrasakha.agents.domains import domain_requires_crop
+from ajrasakha.agents.domains import (
+    crop_counts_as_resolved,
+    domain_requires_crop,
+    is_crop_placeholder,
+    normalize_domain,
+)
 from ajrasakha.agents.location_context import (
     extract_state_from_text,
     gps_state_from_location,
@@ -31,6 +36,10 @@ _PM_KISAN_RE = re.compile(r"\b(pm[\s-]?kisan|pmkisan)\b", re.I)
 _META_CLARIFY_RE = re.compile(
     r"what would you like to know|something else|are you asking about|"
     r"which type of|cultivation practices, pest|checking eligibility for\?",
+    re.I,
+)
+_CROP_CLARIFY_RE = re.compile(
+    r"which crop|what crop|कौन सी फसल|कौनसी फसल",
     re.I,
 )
 
@@ -86,20 +95,35 @@ def conversation_text_from_messages(messages: list[BaseMessage], *, max_turns: i
 
 
 def format_conversation_for_planner(messages: list[BaseMessage]) -> str:
-    human_lines: list[str] = []
-    for msg in messages:
-        if isinstance(msg, HumanMessage):
-            text = _message_to_text(msg)
-            if text:
-                human_lines.append(text)
-    if len(human_lines) > 8:
-        human_lines = human_lines[-8:]
-    if not human_lines:
-        return ""
-    if len(human_lines) == 1:
-        return human_lines[0]
-    numbered = "\n".join(f"{i}. {t}" for i, t in enumerate(human_lines, 1))
-    return f"Conversation so far:\n{numbered}\n\nLatest message: {human_lines[-1]}"
+    """Latest farmer message only — domain must not bleed from older thread topics."""
+    return latest_human_text(messages)
+
+
+def is_crop_clarify_turn(messages: list[BaseMessage]) -> bool:
+    """True when the farmer's latest reply follows an AI crop clarify question."""
+    last_human_idx: int | None = None
+    for i in range(len(messages) - 1, -1, -1):
+        if isinstance(messages[i], HumanMessage):
+            last_human_idx = i
+            break
+    if last_human_idx is None or last_human_idx == 0:
+        return False
+    prev = messages[last_human_idx - 1]
+    if isinstance(prev, AIMessage):
+        return bool(_CROP_CLARIFY_RE.search(_message_to_text(prev)))
+    return False
+
+
+def resolve_crop_for_turn(messages: list[BaseMessage]) -> Optional[str]:
+    """Crop from latest message, or last few human lines only during crop clarify."""
+    if is_crop_clarify_turn(messages):
+        text = recent_human_text(messages, max_turns=3)
+    else:
+        text = latest_human_text(messages)
+    crop = extract_crop_from_text(text)
+    if crop:
+        return crop[0].upper() + crop[1:].lower()
+    return None
 
 
 def extract_crop_from_text(text: str) -> Optional[str]:
@@ -141,12 +165,16 @@ def _merge_entities(
 ) -> PlannerEntities:
     merged: PlannerEntities = dict(plan_entities or {})
     latest = latest_human_text(messages)
-    recent = recent_human_text(messages, max_turns=5)
     has_gps = has_gps_coordinates(location)
 
-    crop = merged.get("crop") or extract_crop_from_text(recent)
-    if crop:
-        merged["crop"] = crop[0].upper() + crop[1:].lower()
+    if not merged.get("crop") or is_crop_placeholder(merged.get("crop")):
+        turn_crop = resolve_crop_for_turn(messages)
+        if turn_crop:
+            merged["crop"] = turn_crop
+    else:
+        c = merged["crop"]
+        if c:
+            merged["crop"] = c[0].upper() + c[1:].lower()
 
     state = merged.get("state") or extract_state_from_text(latest)
     if not state:
@@ -199,7 +227,8 @@ def _finalize_location_and_crop_completeness(
 ) -> PlannerPlan:
     """Single completeness pass: state (or GPS) required; district defaults to all."""
     crop = entities.get("crop")
-    needs_crop = domain_requires_crop(domain) and not crop
+    domain = normalize_domain(domain)
+    needs_crop = domain_requires_crop(domain) and not crop_counts_as_resolved(crop)
 
     if not has_state and not has_gps:
         out["is_complete"] = False
@@ -244,19 +273,18 @@ def apply_planner_completeness_rules(
     """
     out: PlannerPlan = dict(plan)
     latest = latest_human_text(messages)
-    recent = recent_human_text(messages, max_turns=5)
     entities = _merge_entities(out.get("entities") or {}, messages, location)
     out["entities"] = entities
 
     has_state, _, has_gps = _location_status(entities, location)
-    domain = infer_domain_for_plan(out, recent)
-    schemes = (
-        bool(out.get("schemes"))
-        or is_schemes_intent(latest)
-        or is_schemes_intent(recent)
-    )
+    domain = normalize_domain(out.get("domain") or "General")
 
-    if schemes:
+    if is_schemes_intent(latest) and domain in {
+        "Government Schemes",
+        "Financial & Institutional Services",
+        "Crop Insurance",
+        "General",
+    }:
         out["schemes"] = True
         out["knowledge_base"] = False
 

--- a/ai/ajrasakha/agents/prompts.py
+++ b/ai/ajrasakha/agents/prompts.py
@@ -497,13 +497,15 @@ Other agricultural information and advisories are expert-verified by Annam.ai.
 
 Users should independently validate recommendations before acting."""
 
-# Canned reply when the `gdb` sub-agent finds nothing relevant. We short-circuit
-# so the farmer gets a clean acknowledgement instead of an empty or hallucinated answer.
+# Marker for sanitize_answer to skip re-processing deterministic canned replies.
+EXPERT_QUEUE_REPLY_MARKER = "Your question has been shared with our agri expert at annam.ai"
+
+# Canned reply when GDB has no usable data and no specialist tools ran this turn.
 EMPTY_GDB_REPLY = (
-    "Your question has been sent to Agri Experts at annam.ai, and they will "
-    "review it within 2 hours. Please ask the same question after 2 hours for "
-    "a detailed answer from our experts."
-    f"\n\n{WARNING_TEXT}"
+    "Your question has been shared with our agri expert at annam.ai. "
+    "You will get the answer within 2 hours.\n"
+    "Thank You.\n\n"
+    f"{WARNING_TEXT}"
 )
 
 WHATSAPP_SYSTEM_PROMPT = """You are AjraSakha, an AI assistant for Indian farmers. You help with crops, soil, pests, fertilizers, irrigation, weather, market prices, farm equipment, and government schemes.

--- a/ai/ajrasakha/agents/prompts.py
+++ b/ai/ajrasakha/agents/prompts.py
@@ -610,19 +610,21 @@ Other agricultural information and advisories are expert-verified by Annam.ai.
 Users should independently validate recommendations before acting.
 """
 
+from ajrasakha.agents.domains import ALLOWED_DOMAINS_LIST
 
+_PLANNER_DOMAINS_DOC = "\n".join(f"- {d}" for d in ALLOWED_DOMAINS_LIST)
 
-PLANNER_SYSTEM_PROMPT = """
+PLANNER_SYSTEM_PROMPT = f"""
 You are the planner agent responsible for analyzing incoming farmer queries, determining the question completness, and routing to the correct specialist agents and tools based on the content of the query.
 Your job is to analyze the user's message and determine the correct execution path and validate information completeness.
 
-**Flow Decision Logic (Set each boolean flag independently based on reasoning):**
-1. **weather**: Set to True if real-time weather information is required to answer the query (e.g., "Should I irrigate my wheat crop in Ludhiana this week?" requires weather data to determine irrigation needs).
-2. **mandi**: Set to True if live mandi price information is needed to answer the query (e.g., "What is the current market price of tomatoes in Nashik?" or "Should I sell my wheat now based on current mandi rates?").
-3. **soil**: Set to True if the user provides soil test values or explicitly asks for N-P-K fertilizer ratios/soil-based recommendations.
-4. **schemes**: Set to True if the user asks for government agricultural benefits, subsidies, or farming schemes.
-5. **chemical_checker**: Set to True ONLY if the user mentions a specific pesticide, herbicide, fertilizer, or agrochemical by name (e.g., "Monocrotophos", "Chlorpyrifos", "Urea").
-6. **knowledge_base**: Set to True if the user asks for general farming advice, crop disease identification/pest control methods, sowing guides, or cultural practices, etc. This typically requires querying the GDB or similar knowledge bases.
+**Domain (REQUIRED — pick exactly one string from this list):**
+{_PLANNER_DOMAINS_DOC}
+
+- Set `domain` from the **latest farmer message only** (and its English `rephrased_query`). Do **not** let older conversation topics change `domain`.
+- Tool flags (`weather`, `mandi`, `soil`, `schemes`, `knowledge_base`) are derived server-side from `domain`; leave them false unless you must set **chemical_checker** (see below).
+
+**chemical_checker**: Set to True ONLY if the latest message mentions a specific pesticide, herbicide, fertilizer, or agrochemical by name (e.g., "Monocrotophos", "Chlorpyrifos", "Urea").
 
 **Translation & Rephrasing Rules (CRITICAL for non-English queries):**
 1. Determine the language of the farmer's latest query.
@@ -635,9 +637,9 @@ Your job is to analyze the user's message and determine the correct execution pa
 
 **Completeness Check Rules (STRICT — avoid interview-style clarifications):**
 
-Read the conversation for routing context, but **location entities follow strict turn scope**:
+**Location entities follow strict turn scope**:
 - **State and district**: from the farmer's **latest message only**, or from **GPS lat/long on the thread** (metadata). Never reuse state/district from unrelated older questions.
-- **Crop**: may carry from the **last few clarify replies** (recent turns) when the farmer is answering a follow-up (e.g. "Cotton" after "which crop?").
+- **Crop**: only when answering a direct crop clarify (e.g. "Cotton" after "which crop?"); otherwise use latest message only for crop mentions.
 
 1. **Location** (only these cases block execution):
    - **State in the farmer's text** but district missing and no GPS on thread → `is_complete=false`, ask **one** question: which district (do not re-ask state).
@@ -649,11 +651,11 @@ Read the conversation for routing context, but **location entities follow strict
    - **NOT required** for: PM-KISAN, general government schemes, soil health card, livestock, weather, mandi (use crop="all" downstream).
    - Never ask "what would you like to know about X" or list multiple topics — that is forbidden.
 
-3. **Government schemes / insurance / PM-KISAN**:
-   - Set `schemes=true`.
-   - Examples: "crop insurance", "PM-KISAN", "subsidy", "eligibility", "government scheme" → proceed to schemes tool when location rules pass; do not ask what type of insurance unless the message is totally empty of intent.
+3. **Government schemes / insurance / PM-KISAN** (latest message only):
+   - Use domain `Government Schemes`, `Financial & Institutional Services`, or `Crop Insurance` as appropriate.
+   - Do not ask what type of insurance unless the message is totally empty of intent.
 
-4. **Default**: If location rules pass and crop is not required (or crop is known), set `is_complete=true`. Prefer executing tools over asking questions.
+4. **Default**: If location rules pass, set `is_complete=true`. Prefer executing tools over asking questions. Crop gating is handled server-side from `domain`.
 
 5. **Follow-up format**: At most **one** short question. Never combine crop + location + symptom in one follow-up. Never ask meta questions like "are you asking about enrollment, claim, or eligibility?"
 

--- a/ai/ajrasakha/agents/state.py
+++ b/ai/ajrasakha/agents/state.py
@@ -49,6 +49,7 @@ class RetrievalSanitizerAudit(TypedDict, total=False):
 
 
 class PlannerPlan(TypedDict, total=False):
+    domain: Optional[str]
     weather: bool
     mandi: bool
     soil: bool

--- a/ai/ajrasakha/agents/synthesizer.py
+++ b/ai/ajrasakha/agents/synthesizer.py
@@ -23,7 +23,8 @@ from ajrasakha.agents.config import CLAUDE_MODEL
 from ajrasakha.agents.language import detect_farmer_language, language_directive_for_synthesis
 from ajrasakha.agents.memory import load_long_term_summary
 from ajrasakha.agents.location_context import main_agent_location_context_message
-from ajrasakha.agents.prompts import LLM_FALLBACK_MSG, SYNTHESIZER_SYSTEM_PROMPT, WARNING_TEXT
+from ajrasakha.agents.plan_executor import should_expert_queue_reply
+from ajrasakha.agents.prompts import EMPTY_GDB_REPLY, LLM_FALLBACK_MSG, SYNTHESIZER_SYSTEM_PROMPT, WARNING_TEXT
 from ajrasakha.agents.state import AjraSakhaState
 
 logger = logging.getLogger(__name__)
@@ -138,6 +139,11 @@ def _collect_all_sources(gdb_data: dict) -> str:
 
 # ── Synthesizer prompts for exact vs similar ──────────────────────────────
 
+_SYNTHESIS_BODY_ONLY_REMINDER = (
+    "Rephrase/synthesize the answer body only. "
+    "Do not add sources, disclaimers, or footers — the system appends those."
+)
+
 EXACT_MATCH_REPHRASE_PROMPT = """You are AjraSakha, rephrasing an expert-verified answer for an Indian farmer.
 
 You receive an EXACT MATCH answer from the Golden Database. Your job is minimal:
@@ -148,6 +154,16 @@ You receive an EXACT MATCH answer from the Golden Database. Your job is minimal:
 5. Write in WhatsApp-friendly plain text (no markdown: no **, ##, or - bullets)
 6. Use professional emojis for section headers
 7. Keep it concise and practical
+
+OUTPUT CONTRACT (NON-NEGOTIABLE):
+- Return ONLY the answer body. End on the last farming fact. Zero lines after that.
+- No footer, disclaimer, source list, or "where this answer came from" paragraph.
+
+FORBIDDEN — never output any of the following:
+- "The answer I provided is sourced only from the following approved materials"
+- "This is AjraSakha's testing version" or any "testing version" closing line
+- "Answers synthesized from" or closers naming SKUAST, universities, or "expert agricultural database"
+- SOURCE: / Sources: / plain-text source lists (system uses 📚 and 👨‍🌾 lines)
 
 LANGUAGE (NON-NEGOTIABLE):
 Reply in the EXACT same language as the farmer's query. Translate the expert answer if needed.
@@ -167,6 +183,17 @@ You receive SIMILAR MATCH pairs from the Golden Database. Your job:
 6. Write in WhatsApp-friendly plain text (no markdown: no **, ##, or - bullets)
 7. Use professional emojis for section headers
 8. Keep it concise, practical, and farmer-friendly
+
+OUTPUT CONTRACT (NON-NEGOTIABLE):
+- Return ONLY the answer body. End on the last farming fact. Zero lines after that.
+- No footer, disclaimer, source list, or "where this answer came from" paragraph.
+
+
+FORBIDDEN — never output any of the following:
+- "The answer I provided is sourced only from the following approved materials"
+- "This is AjraSakha's testing version" or any "testing version" closing line
+- "Answers synthesized from" or closers naming SKUAST, universities, or "expert agricultural database"
+- SOURCE: / Sources: / plain-text source lists (system uses 📚 and 👨‍🌾 lines)
 
 LANGUAGE (NON-NEGOTIABLE):
 Reply in the EXACT same language as the farmer's query. Translate the expert data if needed.
@@ -298,6 +325,13 @@ async def synthesize_node(
     if human is None:
         return {}
 
+    if should_expert_queue_reply(state):
+        logger.info("GDB empty with no specialist tools — returning expert-queue canned reply")
+        return {
+            "messages": [AIMessage(content=EMPTY_GDB_REPLY)],
+            "location": state.get("location"),
+        }
+
     user_text = _message_to_text(human)
     output_lang = detect_farmer_language(user_text)
     long_term_summary = await load_long_term_summary(store, config)
@@ -337,6 +371,7 @@ async def synthesize_node(
         llm_messages.append(
             HumanMessage(
                 content=(
+                    f"{_SYNTHESIS_BODY_ONLY_REMINDER}\n\n"
                     f"Farmer's question (language: {output_lang}):\n{user_text}\n\n"
                     f"EXACT MATCH from Golden Database:\n"
                     f"Matched Question: {exact_question}\n"
@@ -421,6 +456,7 @@ async def synthesize_node(
         llm_messages.append(
             HumanMessage(
                 content=(
+                    f"{_SYNTHESIS_BODY_ONLY_REMINDER}\n\n"
                     f"Farmer's question (language: {output_lang}):\n{user_text}\n\n"
                     f"SIMILAR MATCHES from Golden Database:\n{pairs_text}"
                     f"{other_tools_section}\n\n"

--- a/ai/ajrasakha/agents/tests/test_crop_requirement.py
+++ b/ai/ajrasakha/agents/tests/test_crop_requirement.py
@@ -1,0 +1,18 @@
+"""Tests for crop requirement LLM output parsing."""
+
+from ajrasakha.agents.crop_requirement import parse_crop_classification
+
+
+def test_parse_crop_specific():
+    assert parse_crop_classification("crop_specific") is True
+    assert parse_crop_classification("CROP_SPECIFIC") is True
+
+
+def test_parse_general():
+    assert parse_crop_classification("general") is False
+    assert parse_crop_classification("general.") is False
+
+
+def test_parse_unknown_fail_open():
+    assert parse_crop_classification("") is False
+    assert parse_crop_classification("maybe") is False

--- a/ai/ajrasakha/agents/tests/test_crop_turn_scope.py
+++ b/ai/ajrasakha/agents/tests/test_crop_turn_scope.py
@@ -1,0 +1,36 @@
+"""Tests for turn-scoped crop resolution."""
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from ajrasakha.agents.planner_rules import (
+    is_crop_clarify_turn,
+    resolve_crop_for_turn,
+)
+
+
+def test_crop_clarify_turn_extracts_cotton():
+    messages = [
+        HumanMessage(content="My leaves are turning yellow"),
+        AIMessage(content="Which crop are you growing?"),
+        HumanMessage(content="Cotton"),
+    ]
+    assert is_crop_clarify_turn(messages) is True
+    assert resolve_crop_for_turn(messages) == "Cotton"
+
+
+def test_new_query_does_not_bleed_crop_from_old_turn():
+    messages = [
+        HumanMessage(content="Yellow rust on my wheat crop"),
+        AIMessage(content="Here is advice for wheat."),
+        HumanMessage(content="What is PM-KISAN eligibility?"),
+    ]
+    assert is_crop_clarify_turn(messages) is False
+    assert resolve_crop_for_turn(messages) is None
+
+
+def test_latest_message_crop_on_new_query():
+    messages = [
+        HumanMessage(content="Wheat disease in Karnataka"),
+        HumanMessage(content="Onion mandi price in Punjab"),
+    ]
+    assert resolve_crop_for_turn(messages) == "Onion"

--- a/ai/ajrasakha/agents/tests/test_domains.py
+++ b/ai/ajrasakha/agents/tests/test_domains.py
@@ -1,0 +1,63 @@
+"""Tests for domain normalization and tool-flag derivation."""
+
+from ajrasakha.agents.domains import (
+    ALLOWED_DOMAINS,
+    apply_tool_flags_from_domain,
+    crop_counts_as_resolved,
+    domain_requires_crop,
+    normalize_domain,
+    reviewer_upload_domain,
+)
+
+
+def test_normalize_domain_exact():
+    assert normalize_domain("Plant Protection") == "Plant Protection"
+    assert normalize_domain("  Weather  ") == "Weather"
+
+
+def test_normalize_domain_alias():
+    assert normalize_domain("Crop Protection") == "Plant Protection"
+    assert normalize_domain("soil health") == "Soil Health Card"
+
+
+def test_normalize_domain_invalid_fallback():
+    assert normalize_domain("Not A Real Domain") == "General"
+    assert normalize_domain("") == "General"
+
+
+def test_apply_tool_flags_weather():
+    flags = apply_tool_flags_from_domain("Weather")
+    assert flags["weather"] is True
+    assert flags["knowledge_base"] is False
+
+
+def test_apply_tool_flags_plant_protection():
+    flags = apply_tool_flags_from_domain("Plant Protection")
+    assert flags["knowledge_base"] is True
+    assert flags["weather"] is False
+
+
+def test_apply_tool_flags_schemes():
+    flags = apply_tool_flags_from_domain("Financial & Institutional Services")
+    assert flags["schemes"] is True
+    assert flags["knowledge_base"] is False
+
+
+def test_domain_requires_crop_buckets():
+    assert domain_requires_crop("Plant Protection") is True
+    assert domain_requires_crop("Government Schemes") is False
+    assert domain_requires_crop("General") is False
+
+
+def test_crop_counts_as_resolved():
+    assert crop_counts_as_resolved("all") is True
+    assert crop_counts_as_resolved("Wheat") is True
+    assert crop_counts_as_resolved(None) is False
+
+
+def test_reviewer_upload_domain_maps_routing_only():
+    assert reviewer_upload_domain("Weather") == "General"
+    assert reviewer_upload_domain("Market Prices") == "Market Information"
+    assert reviewer_upload_domain("Plant Protection") == "Plant Protection"
+    assert reviewer_upload_domain("bogus") == "General"
+    assert reviewer_upload_domain("Plant Protection") in ALLOWED_DOMAINS

--- a/ai/ajrasakha/agents/tests/test_expert_queue_reply.py
+++ b/ai/ajrasakha/agents/tests/test_expert_queue_reply.py
@@ -1,0 +1,90 @@
+"""Tests for empty GDB + no specialist tools → expert-queue canned reply."""
+
+from __future__ import annotations
+
+import json
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from ajrasakha.agents.ajrasakha import empty_gdb_reply_node
+from ajrasakha.agents.plan_executor import (
+    route_after_sanitizer,
+    should_expert_queue_reply,
+)
+from ajrasakha.agents.prompts import EMPTY_GDB_REPLY, EXPERT_QUEUE_REPLY_MARKER, WARNING_TEXT
+from ajrasakha.agents.state import AjraSakhaState
+
+
+def _gdb_json(**overrides) -> str:
+    base = {
+        "is_exact": False,
+        "is_similar": False,
+        "similar_pair1": {"question": "Q1", "answer": "A1"},
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+def _state_after_sanitizer_filter() -> AjraSakhaState:
+    """GDB with all similar pairs removed by sanitizer."""
+    return {
+        "messages": [
+            HumanMessage(content="How to grow barley in Punjab?"),
+            AIMessage(content="", tool_calls=[{"id": "c1", "name": "gdb", "args": {}}]),
+            ToolMessage(
+                content=json.dumps({"is_exact": False, "is_similar": False}),
+                tool_call_id="c1",
+                name="gdb",
+            ),
+        ],
+        "plan": {
+            "knowledge_base": True,
+            "weather": False,
+            "mandi": False,
+            "soil": False,
+            "schemes": False,
+            "chemical_checker": False,
+        },
+    }
+
+
+def test_should_expert_queue_when_gdb_empty_no_specialists():
+    assert should_expert_queue_reply(_state_after_sanitizer_filter()) is True
+
+
+def test_should_not_expert_queue_when_weather_in_plan():
+    state = _state_after_sanitizer_filter()
+    state["plan"] = {**state["plan"], "weather": True}
+    assert should_expert_queue_reply(state) is False
+
+
+def test_should_not_expert_queue_when_gdb_has_similar_pair():
+    state = _state_after_sanitizer_filter()
+    state["messages"] = [
+        HumanMessage(content="Barley?"),
+        ToolMessage(content=_gdb_json(is_similar=True), tool_call_id="c1", name="gdb"),
+    ]
+    assert should_expert_queue_reply(state) is False
+
+
+def test_route_after_sanitizer_to_empty_gdb_reply():
+    assert route_after_sanitizer(_state_after_sanitizer_filter()) == "empty_gdb_reply"
+
+
+def test_route_after_sanitizer_to_synthesize_with_weather():
+    state = _state_after_sanitizer_filter()
+    state["plan"] = {**state["plan"], "weather": True}
+    state["messages"].append(
+        ToolMessage(content="Rain expected tomorrow", tool_call_id="w1", name="weather")
+    )
+    assert route_after_sanitizer(state) == "synthesize"
+
+
+def test_empty_gdb_reply_content():
+    result = empty_gdb_reply_node(_state_after_sanitizer_filter())
+    text = result["messages"][0].content
+    assert EXPERT_QUEUE_REPLY_MARKER in text
+    assert "Thank You." in text
+    assert "Important Notice (Testing)" in text
+    assert WARNING_TEXT.strip() in text
+    assert text == EMPTY_GDB_REPLY

--- a/ai/ajrasakha/agents/tests/test_planner_domain_crop.py
+++ b/ai/ajrasakha/agents/tests/test_planner_domain_crop.py
@@ -1,0 +1,79 @@
+"""Integration tests for planner domain + crop pipeline (no live LLM)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from ajrasakha.agents.domains import apply_tool_flags_from_domain
+from ajrasakha.agents.planner import (
+    _apply_domain_and_crop_async,
+    planner_output_to_plan,
+    PlannerOutput,
+)
+
+
+@pytest.mark.asyncio
+async def test_crop_all_domain_forces_all():
+    plan = {"domain": "Government Schemes", "entities": {}}
+    with patch(
+        "ajrasakha.agents.planner.is_crop_specific_question",
+        new_callable=AsyncMock,
+    ) as mock_cls:
+        out, domain, crop_required = await _apply_domain_and_crop_async(
+            plan,
+            [HumanMessage(content="PM-KISAN eligibility")],
+            crop_prefilled=None,
+            config={},
+        )
+    mock_cls.assert_not_called()
+    assert domain == "Government Schemes"
+    assert out["entities"]["crop"] == "all"
+    assert crop_required is False
+
+
+@pytest.mark.asyncio
+async def test_crop_required_general_classifier_sets_all():
+    plan = planner_output_to_plan(
+        PlannerOutput(domain="Plant Protection", rephrased_query="Leaves turning yellow")
+    )
+    with patch(
+        "ajrasakha.agents.planner.is_crop_specific_question",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        out, domain, crop_required = await _apply_domain_and_crop_async(
+            plan,
+            [HumanMessage(content="Leaves turning yellow")],
+            crop_prefilled=None,
+            config={},
+        )
+    assert domain == "Plant Protection"
+    assert out["entities"]["crop"] == "all"
+    assert crop_required is False
+    assert out["knowledge_base"] is True
+
+
+@pytest.mark.asyncio
+async def test_crop_required_specific_classifier_requires_crop():
+    plan = planner_output_to_plan(
+        PlannerOutput(domain="Plant Protection", rephrased_query="Leaves turning yellow")
+    )
+    with patch(
+        "ajrasakha.agents.planner.is_crop_specific_question",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        out, domain, crop_required = await _apply_domain_and_crop_async(
+            plan,
+            [HumanMessage(content="Leaves turning yellow")],
+            crop_prefilled=None,
+            config={},
+        )
+    assert crop_required is True
+    assert out["entities"].get("crop") is None
+
+
+def test_tool_flags_derived_from_domain():
+    flags = apply_tool_flags_from_domain("Weather")
+    assert flags == {"weather": True, "mandi": False, "soil": False, "schemes": False, "chemical_checker": False, "knowledge_base": False}

--- a/ai/ajrasakha/agents/tests/test_planner_rules.py
+++ b/ai/ajrasakha/agents/tests/test_planner_rules.py
@@ -48,55 +48,55 @@ def test_conversation_carries_crop():
 def test_cotton_turn_complete_with_gps():
     messages = [
         HumanMessage(content="Can i get insurance for my crop?"),
-        AIMessage(content="Which crop?"),
+        AIMessage(content="Which crop are you growing?"),
         HumanMessage(content="Cotton"),
     ]
     plan = apply_planner_completeness_rules(
         {
-            "schemes": False,
-            "knowledge_base": True,
-            "is_complete": False,
-            "follow_up_question": "What would you like to know about your cotton crop?",
-            "entities": {},
+            "domain": "Crop Insurance",
+            "schemes": True,
+            "knowledge_base": False,
+            "is_complete": True,
+            "entities": {"crop": "Cotton"},
         },
         messages,
         {"latitude": 30.9, "longitude": 76.5, "state": "Punjab", "city": "Ludhiana"},
     )
     assert plan["is_complete"] is True
-    assert plan["schemes"] is True
-    assert plan["knowledge_base"] is False
     assert plan["entities"]["crop"] == "Cotton"
     assert plan.get("follow_up_question") is None
 
 
-def test_pm_kisan_complete_with_gps_no_crop_needed():
+def test_pm_kisan_complete_with_gps_no_crop_bleed():
     messages = [
         HumanMessage(content="Can i get insurance for my crop?"),
         HumanMessage(content="Cotton"),
-        HumanMessage(content="Insurance"),
-        HumanMessage(content="Eligibility"),
-        HumanMessage(content="Government scheme"),
         HumanMessage(content="Pm kisan"),
     ]
     plan = apply_planner_completeness_rules(
         {
+            "domain": "Financial & Institutional Services",
             "schemes": True,
-            "is_complete": False,
-            "follow_up_question": "Which type of government scheme are you looking for?",
-            "entities": {},
+            "is_complete": True,
+            "entities": {"crop": "all"},
         },
         messages,
         {"latitude": 30.9, "longitude": 76.5, "state": "Punjab", "city": "Ludhiana"},
     )
     assert plan["is_complete"] is True
-    assert plan["entities"]["crop"] == "Cotton"
+    assert plan["entities"]["crop"] == "all"
     assert plan.get("follow_up_question") is None
 
 
 def test_state_only_sets_district_all_without_follow_up():
     messages = [HumanMessage(content="PM-KISAN in Kerala")]
     plan = apply_planner_completeness_rules(
-        {"schemes": True, "is_complete": True, "entities": {}},
+        {
+            "domain": "Financial & Institutional Services",
+            "schemes": True,
+            "is_complete": True,
+            "entities": {"crop": "all"},
+        },
         messages,
         None,
     )

--- a/ai/ajrasakha/agents/tests/test_synthesizer_prompts.py
+++ b/ai/ajrasakha/agents/tests/test_synthesizer_prompts.py
@@ -1,0 +1,51 @@
+"""Contract tests: GDB synthesizer prompts forbid LLM footers (code appends them)."""
+
+from __future__ import annotations
+
+from ajrasakha.agents.synthesizer import (
+    EXACT_MATCH_REPHRASE_PROMPT,
+    SIMILAR_MATCH_SYNTHESIS_PROMPT,
+    _SYNTHESIS_BODY_ONLY_REMINDER,
+)
+
+_FORBIDDEN_MARKERS = [
+    "OUTPUT CONTRACT",
+    "FORBIDDEN",
+    "The answer I provided is sourced only from the following approved materials",
+    "testing version",
+    "Answers synthesized from",
+    "SKUAST",
+    "📚 Source",
+    "👨‍🌾 Agri Expert",
+    "DO NOT include source attribution",
+    "appended automatically",
+]
+
+_BODY_ONLY_MARKERS = [
+    "ONLY the answer body",
+    "Zero lines after",
+    "system appends AFTER",
+]
+
+
+def _assert_prompt_contract(prompt: str, *, label: str) -> None:
+    for marker in _FORBIDDEN_MARKERS + _BODY_ONLY_MARKERS:
+        assert marker in prompt, f"{label} missing: {marker!r}"
+
+
+def test_exact_match_prompt_forbids_llm_footers() -> None:
+    _assert_prompt_contract(EXACT_MATCH_REPHRASE_PROMPT, label="EXACT_MATCH_REPHRASE_PROMPT")
+
+
+def test_similar_match_prompt_forbids_llm_footers() -> None:
+    _assert_prompt_contract(
+        SIMILAR_MATCH_SYNTHESIS_PROMPT, label="SIMILAR_MATCH_SYNTHESIS_PROMPT"
+    )
+
+
+def test_body_only_reminder_for_human_message() -> None:
+    assert "body only" in _SYNTHESIS_BODY_ONLY_REMINDER.lower()
+    assert "system appends" in _SYNTHESIS_BODY_ONLY_REMINDER.lower()
+    assert "sources" in _SYNTHESIS_BODY_ONLY_REMINDER.lower()
+    assert "disclaimers" in _SYNTHESIS_BODY_ONLY_REMINDER.lower()
+    assert "footers" in _SYNTHESIS_BODY_ONLY_REMINDER.lower()


### PR DESCRIPTION
…line

Route planner turns through domains.py: LLM picks one allowed domain from the latest message, tool flags are derived server-side, CROP_ALL domains force crop=all, and CROP_REQUIRED domains use turn-scoped extraction plus the crop_specific/general classifier before asking the farmer.