### PR TITLE
faq+pop+outreach processing dashboard

### DIFF
--- a/frontend/src/components/mobile-sidebar.tsx
+++ b/frontend/src/components/mobile-sidebar.tsx
@@ -4,6 +4,7 @@ import {
   BarChart3,
   Bot,
   Clock,
+  Database,
   History,
   List,
   Menu,
@@ -122,6 +123,10 @@ export const MobileSidebar = ({
             icon: Bot,
           },
         ]
+      : []),
+
+    ...(user && (user.role === "moderator" || user.role === "admin")
+      ? [{ id: "data_processing", label: "Data Processing", icon: Database }]
       : []),
 
     ...(user ? [{ id: "history", label: "History", icon: History }] : []),

--- a/frontend/src/components/play-ground.tsx
+++ b/frontend/src/components/play-ground.tsx
@@ -32,6 +32,7 @@ import { AnnamDashboard_dev as AnnamDashboard } from "../features/chatbotDashboa
 import { cn } from "@/lib/utils";
 import AuditPage from "./AuditPage";
 import { WhatsAppHistoryPage } from "../features/whatsappHistory/WhatsAppHistoryPage";
+import { DataProcessingDashboard } from "../features/faq-pop/DataProcessingDashboard";
 
 export const PlaygroundPage = () => {
   const { data: user } = useGetCurrentUser({});
@@ -244,7 +245,15 @@ export const PlaygroundPage = () => {
                     <span>ChatBot Analytics</span>
                   </TabsTrigger>
                 )}
-                {/* 
+                {user && (user.role === "moderator" || user.role === "admin") && (
+                  <TabsTrigger
+                    value="data_processing"
+                    className="px-2 md:px-3 py-1.5 rounded-lg font-medium text-sm md:text-base transition-all duration-150 flex-shrink-0"
+                  >
+                    <span>Data Processing</span>
+                  </TabsTrigger>
+                )}
+                {/*
                 {user && (
                   <TabsTrigger
                     value="history"
@@ -420,6 +429,21 @@ export const PlaygroundPage = () => {
                   </div>
                 </div>
               </TabsContent>
+              {user && (user.role === "moderator" || user.role === "admin") && (
+                <TabsContent
+                  value="data_processing"
+                  className={cn(
+                    "mt-0 border-0 outline-none",
+                    "data-[state=active]:animate-in",
+                    "data-[state=active]:fade-in-0",
+                    "data-[state=active]:zoom-in-[0.98]",
+                    "data-[state=active]:slide-in-from-bottom-3",
+                    "duration-500 ease-out",
+                  )}
+                >
+                  <DataProcessingDashboard />
+                </TabsContent>
+              )}
               {/* {user && (
                 <TabsContent
                   value="history"

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -17,7 +17,11 @@ type EnvKey =
   | "VITE_SARVAM_API_KEY"
 
   // Notification
-  | "VITE_VAPID_PUBLIC_KEY";
+  | "VITE_VAPID_PUBLIC_KEY"
+
+  // FAQ / POP processing servers
+  | "VITE_FAQ_API_URL"
+  | "VITE_POP_API_URL";
 
 /**
  * Internal getter (single source of truth)
@@ -52,4 +56,7 @@ export const env = {
   sarvamApiKey: () => getEnv("VITE_SARVAM_API_KEY"),
 
   vapidPublicKey: () => getEnv("VITE_VAPID_PUBLIC_KEY"),
+
+  faqApiUrl: () => getEnv("VITE_FAQ_API_URL", false),
+  popApiUrl: () => getEnv("VITE_POP_API_URL", false),
 };

--- a/frontend/src/features/faq-pop/DataProcessingDashboard.tsx
+++ b/frontend/src/features/faq-pop/DataProcessingDashboard.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import FunctionsPanel from "./components/FunctionsPanel/FunctionsPanel";
+import PopTranslationPanel from "./components/FunctionsPanel/PopTranslationPanel";
+
+const TABS = [
+  { id: "faq-cluster", label: "FAQ-Cluster" },
+  { id: "pop-translation", label: "POP-Translation" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
+
+export function DataProcessingDashboard() {
+  const [activeTab, setActiveTab] = useState<TabId>("faq-cluster");
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex gap-1 border-b border-border px-4 py-2.5 flex-shrink-0">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors
+              ${
+                activeTab === tab.id
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground hover:bg-accent"
+              }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex-1 overflow-y-auto p-4">
+        {activeTab === "faq-cluster" && <FunctionsPanel />}
+        {activeTab === "pop-translation" && (
+          <PopTranslationPanel onJobCreated={() => {}} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/faq-pop/api.ts
+++ b/frontend/src/features/faq-pop/api.ts
@@ -1,0 +1,404 @@
+import { env } from "@/config/env";
+
+const FAQ_API = (env.faqApiUrl() || "").replace(/\/$/, "");
+const POP_API = (env.popApiUrl() || "").replace(/\/$/, "");
+
+async function _handleResponse(res: Response) {
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body.detail) detail = body.detail;
+    } catch {
+      // ignore parse error
+    }
+    throw new Error(detail);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// FAQ Cluster — file management
+// ---------------------------------------------------------------------------
+
+export async function getTree() {
+  const res = await fetch(`${FAQ_API}/files/tree`);
+  return _handleResponse(res);
+}
+
+export function downloadUrl(path: string) {
+  return `${FAQ_API}/files/download/${path}`;
+}
+
+export function outputDownloadUrl(state: string, crop: string) {
+  return `${FAQ_API}/app/output/${encodeURIComponent(state)}/${encodeURIComponent(crop)}`;
+}
+
+export async function deleteFile(path: string) {
+  const res = await fetch(`${FAQ_API}/files/${path}`, { method: "DELETE" });
+  return _handleResponse(res);
+}
+
+export async function renameFile(fromPath: string, toPath: string) {
+  const res = await fetch(`${FAQ_API}/files/rename/${fromPath}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ to: toPath }),
+  });
+  return _handleResponse(res);
+}
+
+export async function deleteFolder(path: string) {
+  const res = await fetch(`${FAQ_API}/folders/${path}`, { method: "DELETE" });
+  return _handleResponse(res);
+}
+
+export async function createFolder(path: string) {
+  const res = await fetch(`${FAQ_API}/files/folders`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ path }),
+  });
+  return _handleResponse(res);
+}
+
+const _CHUNK_SIZE = 800 * 1024;
+
+async function _uploadChunked(
+  file: File,
+  dest: string,
+  chunkEndpoint: string,
+  onProgress?: (pct: number) => void,
+) {
+  const totalChunks = Math.ceil(file.size / _CHUNK_SIZE);
+  const uploadId = crypto.randomUUID();
+  let result;
+  for (let i = 0; i < totalChunks; i++) {
+    const chunk = file.slice(
+      i * _CHUNK_SIZE,
+      Math.min((i + 1) * _CHUNK_SIZE, file.size),
+    );
+    const params = new URLSearchParams({
+      upload_id: uploadId,
+      chunk_index: String(i),
+      total_chunks: String(totalChunks),
+      filename: file.name,
+      dest: dest || "",
+    });
+    const res = await fetch(`${chunkEndpoint}?${params}`, {
+      method: "POST",
+      body: chunk,
+      headers: { "Content-Type": "application/octet-stream" },
+    });
+    result = await _handleResponse(res);
+    onProgress?.(Math.round(((i + 1) / totalChunks) * 100));
+  }
+  return result;
+}
+
+export async function uploadFile(
+  file: File,
+  dest = "",
+  onProgress?: (pct: number) => void,
+) {
+  if (file.size > _CHUNK_SIZE)
+    return _uploadChunked(
+      file,
+      dest,
+      `${FAQ_API}/files/upload-chunk`,
+      onProgress,
+    );
+  const fd = new FormData();
+  fd.append("file", file);
+  const url = dest
+    ? `${FAQ_API}/files/upload?dest=${encodeURIComponent(dest)}`
+    : `${FAQ_API}/files/upload`;
+  const res = await fetch(url, { method: "POST", body: fd });
+  const result = await _handleResponse(res);
+  onProgress?.(100);
+  return result;
+}
+
+export async function uploadAuditedFile(
+  file: File,
+  state: string,
+  crop: string,
+) {
+  const fd = new FormData();
+  fd.append("file", file);
+  fd.append("state", state);
+  fd.append("crop", crop);
+  const res = await fetch(`${FAQ_API}/files/upload-audited`, {
+    method: "POST",
+    body: fd,
+  });
+  return _handleResponse(res);
+}
+
+// ---------------------------------------------------------------------------
+// FAQ Cluster — pipeline runs
+// ---------------------------------------------------------------------------
+
+export async function runPre(body: object) {
+  const res = await fetch(`${FAQ_API}/run/pre`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return _handleResponse(res);
+}
+
+export async function runPipeline(body: object) {
+  const res = await fetch(`${FAQ_API}/run/pipeline`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return _handleResponse(res);
+}
+
+export async function runPost(body: object) {
+  const res = await fetch(`${FAQ_API}/run/post`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return _handleResponse(res);
+}
+
+export async function runFull(body: object) {
+  const res = await fetch(`${FAQ_API}/run/full`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return _handleResponse(res);
+}
+
+// ---------------------------------------------------------------------------
+// FAQ Cluster — app utility
+// ---------------------------------------------------------------------------
+
+export async function getNextState(state = "", domains: string[] = []) {
+  const params = new URLSearchParams({ state });
+  for (const d of domains) params.append("domains", d);
+  const res = await fetch(`${FAQ_API}/app/next-state?${params}`);
+  return _handleResponse(res);
+}
+
+export async function getStateTable() {
+  const res = await fetch(`${FAQ_API}/app/state-table`);
+  return _handleResponse(res);
+}
+
+// ---------------------------------------------------------------------------
+// FAQ Cluster — job management
+// ---------------------------------------------------------------------------
+
+export async function getJobs() {
+  const res = await fetch(`${FAQ_API}/jobs`);
+  return _handleResponse(res);
+}
+
+export async function getJob(jobId: string) {
+  const res = await fetch(`${FAQ_API}/jobs/${jobId}`);
+  return _handleResponse(res);
+}
+
+export async function deleteJob(jobId: string) {
+  const res = await fetch(`${FAQ_API}/jobs/${jobId}`, { method: "DELETE" });
+  return _handleResponse(res);
+}
+
+export async function stopJob(jobId: string) {
+  const res = await fetch(`${FAQ_API}/jobs/${jobId}/stop`, { method: "POST" });
+  return _handleResponse(res);
+}
+
+// ---------------------------------------------------------------------------
+// POP Translation — calls the separate POP server
+// ---------------------------------------------------------------------------
+
+export async function getPopStates() {
+  const res = await fetch(`${POP_API}/pop/states`);
+  const data = await _handleResponse(res);
+  return Array.isArray(data) ? { states: data } : data;
+}
+
+export async function getPopCrops(state: string) {
+  const res = await fetch(
+    `${POP_API}/pop/crops?state=${encodeURIComponent(state)}`,
+  );
+  const data = await _handleResponse(res);
+  return Array.isArray(data) ? { crops: data } : data;
+}
+
+export async function getPopDocs(state: string, crop: string) {
+  const res = await fetch(
+    `${POP_API}/pop/docs?state=${encodeURIComponent(state)}&crop=${encodeURIComponent(crop)}`,
+  );
+  const data = await _handleResponse(res);
+  return Array.isArray(data) ? { docs: data } : data;
+}
+
+export async function getPopJob(jobId: string) {
+  const res = await fetch(`${POP_API}/pop/jobs/${jobId}`);
+  return _handleResponse(res);
+}
+
+export async function stopPopJob(jobId: string) {
+  const res = await fetch(`${POP_API}/pop/jobs/${jobId}/stop`, {
+    method: "POST",
+  });
+  return _handleResponse(res);
+}
+
+export async function getPopDataTree() {
+  const res = await fetch(`${POP_API}/pop/data/tree`);
+  return _handleResponse(res);
+}
+
+export async function getPopOutputTree() {
+  const res = await fetch(`${POP_API}/pop/output/tree`);
+  return _handleResponse(res);
+}
+
+export async function getPopStateTable() {
+  const res = await fetch(`${POP_API}/pop/state-table`);
+  return _handleResponse(res);
+}
+
+export async function runPop(body: object) {
+  const res = await fetch(`${POP_API}/run/pop`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return _handleResponse(res);
+}
+
+export async function createPopState(state: string) {
+  const res = await fetch(`${POP_API}/pop/state`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ state }),
+  });
+  return _handleResponse(res);
+}
+
+export async function createPopCrop(state: string, crop: string) {
+  const res = await fetch(`${POP_API}/pop/crop`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ state, crop }),
+  });
+  return _handleResponse(res);
+}
+
+export async function uploadPopDoc(file: File, state: string, crop: string) {
+  const fd = new FormData();
+  fd.append("file", file);
+  fd.append("state", state);
+  fd.append("crop", crop);
+  const res = await fetch(`${POP_API}/pop/upload-doc`, {
+    method: "POST",
+    body: fd,
+  });
+  return _handleResponse(res);
+}
+
+export async function deletePopDoc(
+  state: string,
+  crop: string,
+  docName: string,
+) {
+  const params = new URLSearchParams({ state, crop, doc_name: docName });
+  const res = await fetch(`${POP_API}/pop/doc?${params}`, {
+    method: "DELETE",
+  });
+  return _handleResponse(res);
+}
+
+export async function deleteEmptyPopCrop(state: string, crop: string) {
+  const params = new URLSearchParams({ state, crop });
+  const res = await fetch(`${POP_API}/pop/crop?${params}`, {
+    method: "DELETE",
+  });
+  return _handleResponse(res);
+}
+
+export async function deleteEmptyPopState(state: string) {
+  const params = new URLSearchParams({ state });
+  const res = await fetch(`${POP_API}/pop/state?${params}`, {
+    method: "DELETE",
+  });
+  return _handleResponse(res);
+}
+
+export function popDownloadUrl(path: string) {
+  return `${POP_API}/pop/download/${path}`;
+}
+
+export function popOutputDownloadUrl(
+  state: string,
+  crop: string,
+  docName: string,
+) {
+  const params = new URLSearchParams({ state, crop, doc_name: docName });
+  return `${POP_API}/pop/output?${params}`;
+}
+
+export async function uploadPopFile(
+  file: File,
+  dest = "",
+  onProgress?: (pct: number) => void,
+) {
+  if (file.size > _CHUNK_SIZE)
+    return _uploadChunked(
+      file,
+      dest,
+      `${POP_API}/pop/upload-chunk`,
+      onProgress,
+    );
+  const fd = new FormData();
+  fd.append("file", file);
+  const url = dest
+    ? `${POP_API}/pop/upload?dest=${encodeURIComponent(dest)}`
+    : `${POP_API}/pop/upload`;
+  const res = await fetch(url, { method: "POST", body: fd });
+  const result = await _handleResponse(res);
+  onProgress?.(100);
+  return result;
+}
+
+export async function deletePopFile(path: string) {
+  const res = await fetch(`${POP_API}/pop/files/${path}`, {
+    method: "DELETE",
+  });
+  return _handleResponse(res);
+}
+
+export async function deletePopFolder(path: string) {
+  const res = await fetch(`${POP_API}/pop/folders/${path}`, {
+    method: "DELETE",
+  });
+  return _handleResponse(res);
+}
+
+export async function uploadPopAuditedFile(
+  file: File,
+  state: string,
+  crop: string,
+  docName: string,
+) {
+  const fd = new FormData();
+  fd.append("file", file);
+  fd.append("state", state);
+  fd.append("crop", crop);
+  fd.append("doc_name", docName);
+  const res = await fetch(`${POP_API}/pop/upload-audited`, {
+    method: "POST",
+    body: fd,
+  });
+  return _handleResponse(res);
+}

--- a/frontend/src/features/faq-pop/components/FunctionsPanel/ColumnFilter.tsx
+++ b/frontend/src/features/faq-pop/components/FunctionsPanel/ColumnFilter.tsx
@@ -1,0 +1,115 @@
+// @ts-nocheck
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronDown, X } from 'lucide-react';
+
+export default function ColumnFilter({ label, options, selected, onChange }) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+  const btnRef = useRef(null);
+  const panelRef = useRef(null);
+
+  useEffect(() => {
+    function onClickOutside(e) {
+      if (
+        btnRef.current && !btnRef.current.contains(e.target) &&
+        panelRef.current && !panelRef.current.contains(e.target)
+      ) {
+        setOpen(false);
+        setSearch('');
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, []);
+
+  function handleToggle() {
+    if (!open && btnRef.current) {
+      const rect = btnRef.current.getBoundingClientRect();
+      setPos({ top: rect.bottom + 4, left: rect.left });
+    }
+    setOpen(o => !o);
+    setSearch('');
+  }
+
+  const filtered = options.filter(o => o.toLowerCase().includes(search.toLowerCase()));
+  const hasSelection = selected.length > 0;
+
+  function toggle(opt) {
+    if (selected.includes(opt)) onChange(selected.filter(s => s !== opt));
+    else onChange([...selected, opt]);
+  }
+
+  return (
+    <div className="relative inline-block">
+      <button
+        ref={btnRef}
+        onClick={handleToggle}
+        className={`flex items-center gap-1 font-semibold text-[11px] uppercase tracking-wide transition-colors cursor-pointer
+          ${hasSelection ? 'text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+      >
+        {label}
+        {hasSelection && (
+          <span className="inline-flex items-center justify-center bg-primary text-primary-foreground rounded-full text-[9px] font-bold w-4 h-4 leading-none">
+            {selected.length}
+          </span>
+        )}
+        <ChevronDown size={11} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && createPortal(
+        <div
+          ref={panelRef}
+          style={{ position: 'fixed', top: pos.top, left: pos.left, zIndex: 9999, width: '13rem' }}
+          className="rounded-lg border border-border bg-card shadow-xl"
+        >
+          <div className="p-2 border-b border-border/50">
+            <input
+              autoFocus
+              type="text"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search…"
+              className="w-full bg-input border border-border rounded px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+
+          {hasSelection && (
+            <div className="px-2 py-1 border-b border-border/50 flex items-center justify-between">
+              <span className="text-[10px] text-muted-foreground">{selected.length} selected</span>
+              <button
+                onClick={() => onChange([])}
+                className="flex items-center gap-0.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              >
+                <X size={10} /> Clear
+              </button>
+            </div>
+          )}
+
+          <div className="max-h-48 overflow-y-auto overscroll-contain py-1">
+            {filtered.length === 0 ? (
+              <div className="px-3 py-2 text-[10px] text-muted-foreground/50 italic">No matches</div>
+            ) : (
+              filtered.map(opt => (
+                <label
+                  key={opt}
+                  className="flex items-center gap-2 px-3 py-1.5 hover:bg-muted/30 cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(opt)}
+                    onChange={() => toggle(opt)}
+                    className="accent-primary"
+                  />
+                  <span className="text-[11px] text-foreground truncate" title={opt}>{opt}</span>
+                </label>
+              ))
+            )}
+          </div>
+        </div>,
+        document.body
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/faq-pop/components/FunctionsPanel/FunctionsPanel.tsx
+++ b/frontend/src/features/faq-pop/components/FunctionsPanel/FunctionsPanel.tsx
@@ -1,0 +1,171 @@
+// @ts-nocheck
+import { useState, useRef, useEffect } from 'react';
+import RunTile from './RunTile';
+import StateTable from './StateTable';
+import { runFull } from '../../api';
+
+export const STATE_NAMES = [
+  'A And N Islands', 'Andhra Pradesh', 'Arunachal Pradesh', 'Assam',
+  'Bihar', 'Chhattisgarh', 'Dadra And Nagar Haveli', 'Daman And Diu',
+  'Delhi', 'Goa', 'Gujarat', 'Haryana', 'Himachal Pradesh',
+  'Jammu And Kashmir', 'Jharkand', 'Karnataka', 'Kerala', 'Madhya Pradesh',
+  'Maharashtra', 'Manipur', 'Meghalaya', 'Mizoram', 'Nagaland', 'Odisha',
+  'Puducherry', 'Punjab', 'Rajasthan', 'Sikkim', 'Tamilnadu', 'Telangana',
+  'Tripura', 'Uttar Pradesh', 'Uttarakhand', 'West Bengal',
+].sort();
+
+export const DOMAIN_NAMES = [
+  'Abiotic Stress Management',
+  'Agriculture Mechanization',
+  'Bio-Pesticides and Bio-Fertilizers',
+  'Breeding -Inbreeding',
+  'Cold Storage',
+  'Credit',
+  'Crop Insurance',
+  'Cultural Practices',
+  'Disease',
+  'Disease (Bacterial)',
+  'Disease (Viral)',
+  'Disease - External Parasitic',
+  'Disease Management',
+  'Disease Reporting',
+  'Dosage',
+  'Feed',
+  'Fertilizer Use and Availability',
+  'Field Preparation',
+  'Floriculture',
+  'Harvesting Management',
+  'Horticulture',
+  'Hormone Imbalance Management',
+  'Hormonic Imbalance',
+  'Insect Management',
+  'Integrated Farming',
+  'Irrigation Management',
+  'Landscaping',
+  'Loans',
+  'Management',
+  'Medicinal and Aromatic Plants',
+  'Mushroom Production',
+  'Nursery Management',
+  'Nutrient Deficiency/Excessiveness Management',
+  'Nutrient Management',
+  'Old/Senile Orchard Rejuvenation',
+  'OldSenile Orchard Rejuvenation',
+  'Organic Farming',
+  'Pathogenic Disease Management',
+  'Plant Protection',
+  'Plasticulture',
+  'Post Harvest Management - Abiotic',
+  'Post Harvest Management - Biotic',
+  'Post Harvest Management Cleaning Grading Packaging Food Processing Cool Chain etc',
+  'Post Harvest Management (Cleaning, Grading, Packaging, Food Processing, Cool Chain etc.)',
+  'Post Harvest Preservation',
+  'Power Roads etc',
+  'Power, Roads etc.',
+  'Problem Of Soil',
+  'Seed Sowing And Treatment',
+  'Soil Health Card',
+  'Soil Testing',
+  'Sowing Time and Weather',
+  'Spices and Condiment Crops',
+  'Storage',
+  'Tank Pond and Reservoir Management',
+  'Tank, Pond and Reservoir Management',
+  'Training',
+  'Training and Exposure Visits',
+  'Varietal Selection',
+  'Varieties',
+  'Varities',
+  'Vegetative Propagation and Tissue Culture',
+  'Water Management',
+  'Water Management Micro Irrigation',
+  'Water Management, Micro Irrigation',
+  'Weed Management',
+].sort();
+
+export const CROP_NAMES = [
+  'Acid Lime', 'Almond', 'Aloe Vera', 'Amaranthus', 'Anthurium', 'Aonla', 'Apple', 'Apricot',
+  'Arecanut', 'Arum', 'Ash Gourd', 'Avocado', 'Babul', 'Bael', 'Banana',
+  'Barnyard Millet', 'Barley', 'Bay Leaf', 'Beekeeping', 'Beetroot', 'Bengal Gram',
+  'Ber', 'Berseem', 'Betel Vine', 'Birdwood Grass', "Bishop's Weed", 'Bitter Gourd',
+  'Black Gram', 'Bottle Gourd', 'Broad Bean', 'Brinjal', 'Broccoli',
+  'Brussels Sprouts', 'Buckwheat', 'Buffel Grass', 'Bush Squash', 'Butter Pea',
+  'Cabbage', 'Cardamom', 'Carnation', 'Carrot', 'Castor', 'Cashew', 'Cauliflower',
+  'Celery', 'Chapan Kaddu', 'Chestnut', 'Capsicum', 'Chillies', 'China Aster', 'Chinese Cabbage',
+  'Chinar Tree', 'Chrysanthemum', 'Cinnamon', 'Citrus', 'Clove', 'Cluster Bean',
+  'Cocoa', 'Coconut', 'Coffee', 'Coleus', 'Colocasia', 'Coriander', 'Cotton',
+  'Cowpea', 'Crossandra', 'Cucumber', 'Cumin', 'Curry Leaf', 'Custard Apple',
+  'Cymbidium', 'Dhaincha', 'Dharaf Grass', 'Dinanath Grass', 'Dill Seed',
+  'Dolichos Bean', 'Drumstick', 'Elephant Foot Yam', 'Eucalyptus', 'Faba Bean',
+  'Fennel', 'Fenugreek', 'Fig', 'Finger Millet', 'Fodder Sorghum', 'Foxtail Millet',
+  'French Bean', 'Garden Pea', 'Garlic', 'Gerbera', 'Ginger', 'Gladiolus',
+  'Golden Timothy', 'Grape', 'Greater Yam', 'Green Gram', 'Groundnut', 'Guar',
+  'Guava', 'Guinea Grass', 'Gunda', 'Hemp', 'Hibiscus', 'Honey Plant', 'Horse Gram',
+  'Indian Bean', 'Indian Clover', 'Ivy Gourd', 'Jackfruit', 'Jamun', 'Jasmine',
+  'Jatropha', 'Jojoba', 'Jute', 'Karan Rai', 'Karonda', 'Kidney Bean', 'Kiwi Fruit',
+  'Knol-Khol', 'Kodo Millet', 'Kokum', 'Kolanchi', 'Lablab Bean', 'Large Cardamom',
+  'Lathyrus', 'Leafy Vegetable', 'Lehberry', 'Lemon', 'Lentil', 'Lesser Yam',
+  'Lettuce', 'Lilies', 'Linseed', 'Litchi', 'Little Millet', 'Long Melon', 'Loquat',
+  'Lucerne', 'Maize', 'Mango', 'Marigold', 'Marvel Grass', 'Melon', 'Mesta', 'Mint',
+  'Mosambi', 'Moth Bean', 'Mulberry', 'Mushroom', 'Muskmelon', 'Mustard',
+  'Napier Grass', 'Neem', 'Niger', 'Nutmeg', 'Oats', 'Oil Palm', 'Okra', 'Oleander',
+  'Olive', 'Onion', 'Opium Poppy', 'Orange', 'Paddy', 'Palmyra', 'Papaya',
+  'Passion Fruit', 'Pea', 'Peach', 'Pecan Nut', 'Pearl Millet', 'Pear', 'Periwinkle',
+  'Persian Clover', 'Persimmon', 'Pigeon Pea', 'Pillipesara', 'Pineapple', 'Plum',
+  'Pointed Gourd', 'Pomegranate', 'Poplar', 'Potato', 'Proso Millet', 'Pumpkin',
+  'Radish', 'Red Clover', 'Ribbed Gourd', 'Ricebean', 'Ridge Gourd', 'Rocket Salad',
+  'Rose', 'Roselle', 'Round Melon', 'Rubber', 'Runner Bean', 'Ryegrass', 'Safed Musli',
+  'Safflower', 'Saffron', 'Sal Wood', 'Sandalwood', 'Sapota', 'Sen Grass', 'Sesame',
+  'Setaria Grass', 'Shatavari', 'Snap Melon', 'Snake Gourd', 'Sorghum', 'Soybean',
+  'Spinach', 'Spine Gourd', 'Sponge Gourd', 'Stevia', 'Strawberry', 'Stylosanthes',
+  'Sudan Grass', 'Sugar Beet', 'Sugarcane', 'Summer Squash', 'Sunflower', 'Sunnhemp',
+  'Sweet Cherry', 'Sweet Potato', 'Tall Fescue Grass', 'Tapioca', 'Tea', 'Teak',
+  'Teosinte', 'Tobacco', 'Tomato', 'Triticale', 'Tuberose', 'Tulsi', 'Tumba',
+  'Turmeric', 'Turnip', 'Vanilla', 'Velimasal', 'Walnut', 'Watermelon', 'Wheat',
+  'White Clover', 'White Yam', 'Winged Bean', 'Yard Long Bean', 'Zantedeschia',
+].filter((v, i, a) => a.indexOf(v) === i).sort();
+
+const FULL_FIELDS = [
+  { key: 'state',       label: 'State',   type: 'states-selector' },
+  { key: 'crops',       label: 'Crops',   type: 'crops-selector' },
+  { key: 'domains',     label: 'Domains', type: 'domains-selector' },
+  { key: 'skip_qa_gen', label: 'Skip QA gen', type: 'checkbox' },
+];
+
+export default function FunctionsPanel() {
+  const [tableRefreshKey, setTableRefreshKey] = useState(0);
+  const formRef = useRef(null);
+  const [stacked, setStacked] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => setStacked(!entry.isIntersecting),
+      { threshold: 0 }
+    );
+    if (formRef.current) observer.observe(formRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="flex flex-col">
+      <div ref={formRef} className="max-w-3xl mx-auto w-full">
+        <RunTile
+          title="Full Pipeline"
+          description="Pre-pipeline → clustering → post-pipeline in one shot"
+          fields={FULL_FIELDS}
+          onRun={runFull}
+          cropNames={CROP_NAMES}
+          domainNames={DOMAIN_NAMES}
+          stateNames={STATE_NAMES}
+          onJobDone={() => setTableRefreshKey((k) => k + 1)}
+          tileKey="full-pipeline"
+        />
+      </div>
+      <div className={`sticky top-0 z-10 bg-background pt-6 h-screen ${stacked ? 'overflow-y-auto' : 'overflow-hidden'}`}>
+        <div className="max-w-[96rem] mx-auto w-full">
+          <StateTable refreshKey={tableRefreshKey} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/faq-pop/components/FunctionsPanel/PopStateTable.tsx
+++ b/frontend/src/features/faq-pop/components/FunctionsPanel/PopStateTable.tsx
@@ -1,0 +1,645 @@
+// @ts-nocheck
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { RefreshCw, Download, Upload, FolderPlus, Trash2 } from 'lucide-react';
+import { uploadPopDoc, createPopState, createPopCrop, popDownloadUrl, popOutputDownloadUrl, deletePopDoc, deleteEmptyPopCrop, deleteEmptyPopState, deletePopFile, uploadPopAuditedFile } from '../../api';
+import ColumnFilter from './ColumnFilter';
+
+const inputClass =
+  'bg-input border border-border rounded-md px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-ring transition-shadow';
+
+function AutocompleteInput({ value, onChange, suggestions, placeholder, className }) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 });
+  const inputRef = useRef(null);
+  const panelRef = useRef(null);
+
+  const filtered = suggestions.filter(
+    s => s.toLowerCase().includes(value.toLowerCase()) && s.toLowerCase() !== value.toLowerCase()
+  );
+
+  function updatePos() {
+    if (inputRef.current) {
+      const r = inputRef.current.getBoundingClientRect();
+      setPos({ top: r.bottom + 2, left: r.left, width: r.width });
+    }
+  }
+
+  useEffect(() => {
+    function onClickOutside(e) {
+      if (
+        inputRef.current && !inputRef.current.contains(e.target) &&
+        panelRef.current && !panelRef.current.contains(e.target)
+      ) setOpen(false);
+    }
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, []);
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        className={className}
+        onChange={e => { onChange(e.target.value); updatePos(); setOpen(true); }}
+        onFocus={() => { updatePos(); setOpen(true); }}
+      />
+      {open && filtered.length > 0 && createPortal(
+        <div
+          ref={panelRef}
+          style={{ position: 'fixed', top: pos.top, left: pos.left, width: Math.max(pos.width, 112), zIndex: 9999 }}
+          className="max-h-40 overflow-y-auto overscroll-contain rounded-md border border-border bg-card shadow-lg"
+        >
+          {filtered.map(opt => (
+            <button
+              key={opt}
+              onMouseDown={e => { e.preventDefault(); onChange(opt); setOpen(false); }}
+              className="w-full text-left px-2 py-1.5 text-xs hover:bg-muted/30 text-foreground cursor-pointer"
+            >
+              {opt}
+            </button>
+          ))}
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}
+
+function PopAuditCell({ row, onUploaded }) {
+  const inputRef = useRef(null);
+  const [uploading, setUploading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleFile(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      await uploadPopAuditedFile(file, row.state, row.crop, row.doc_name);
+      onUploaded?.();
+    } catch (err) {
+      alert(`Upload failed: ${err.message}`);
+    } finally {
+      setUploading(false);
+      e.target.value = '';
+    }
+  }
+
+  async function handleDelete() {
+    if (!row.audit_file) return;
+    if (!window.confirm('Delete audited file?')) return;
+    setDeleting(true);
+    try {
+      await deletePopFile(row.audit_file);
+      onUploaded?.();
+    } catch (err) {
+      alert(`Delete failed: ${err.message}`);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {row.audit_file && (
+        <a
+          href={popDownloadUrl(row.audit_file)}
+          className="flex items-center gap-1 text-[10px] text-green-400 hover:text-green-300 transition-colors"
+          download
+        >
+          <Download size={11} /> {row.audit_file.split('/').pop()}
+        </a>
+      )}
+      <input ref={inputRef} type="file" className="hidden" onChange={handleFile} disabled={uploading} />
+      <button
+        className={`flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border transition-colors cursor-pointer
+          ${uploading
+            ? 'border-border/40 text-muted-foreground/30 cursor-not-allowed'
+            : 'border-border text-muted-foreground hover:border-primary hover:text-primary'
+          }`}
+        onClick={() => inputRef.current?.click()}
+        disabled={uploading}
+      >
+        <Upload size={11} />
+        {uploading ? 'uploading…' : row.audit_file ? 'replace' : 'upload'}
+      </button>
+      {row.audit_file && (
+        <button
+          className={`flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border transition-colors cursor-pointer
+            ${deleting
+              ? 'border-border/40 text-muted-foreground/30 cursor-not-allowed'
+              : 'border-destructive/40 text-destructive/70 hover:border-destructive hover:text-destructive hover:bg-destructive/5'
+            }`}
+          onClick={handleDelete}
+          disabled={deleting}
+        >
+          <Trash2 size={11} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function UploadControls({ onDone, stateOptions, stateCropMap }) {
+  const fileRef = useRef(null);
+  const [uploadState, setUploadState] = useState('');
+  const [uploadCrop, setUploadCrop] = useState('');
+  const [uploading, setUploading] = useState(false);
+
+  const [addStateInput, setAddStateInput] = useState('');
+  const [creatingState, setCreatingState] = useState(false);
+
+  const [folderState, setFolderState] = useState('');
+  const [folderCrop, setFolderCrop] = useState('');
+  const [creatingCrop, setCreatingCrop] = useState(false);
+
+  const cropSuggestionsFor = (s) => {
+    const key = stateOptions.find(o => o.toLowerCase() === s.toLowerCase());
+    return key && stateCropMap[key] ? [...stateCropMap[key]].sort() : [];
+  };
+
+  async function handleUpload(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!uploadState.trim() || !uploadCrop.trim()) {
+      alert('Please enter both state and crop before uploading.');
+      e.target.value = '';
+      return;
+    }
+    setUploading(true);
+    try {
+      await uploadPopDoc(file, uploadState.trim(), uploadCrop.trim());
+      onDone?.();
+    } catch (err) {
+      alert(`Upload failed: ${err.message}`);
+    } finally {
+      setUploading(false);
+      e.target.value = '';
+    }
+  }
+
+  async function handleAddState() {
+    if (!addStateInput.trim()) { alert('Please enter a state name.'); return; }
+    setCreatingState(true);
+    try {
+      await createPopState(addStateInput.trim());
+      onDone?.();
+      setAddStateInput('');
+    } catch (err) {
+      alert(`Create state failed: ${err.message}`);
+    } finally {
+      setCreatingState(false);
+    }
+  }
+
+  async function handleAddCrop() {
+    if (!folderState.trim() || !folderCrop.trim()) {
+      alert('Please enter both state and crop.');
+      return;
+    }
+    setCreatingCrop(true);
+    try {
+      await createPopCrop(folderState.trim(), folderCrop.trim());
+      onDone?.();
+      setFolderState('');
+      setFolderCrop('');
+    } catch (err) {
+      alert(`Create crop failed: ${err.message}`);
+    } finally {
+      setCreatingCrop(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3">
+      <div className="flex items-end gap-2 flex-wrap">
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Upload PDF to</label>
+          <div className="flex items-center gap-1">
+            <AutocompleteInput
+              value={uploadState}
+              onChange={v => { setUploadState(v); setUploadCrop(''); }}
+              suggestions={stateOptions}
+              placeholder="state"
+              className={`${inputClass} w-28`}
+            />
+            <span className="text-muted-foreground text-sm">/</span>
+            <AutocompleteInput
+              value={uploadCrop}
+              onChange={setUploadCrop}
+              suggestions={cropSuggestionsFor(uploadState)}
+              placeholder="crop"
+              className={`${inputClass} w-28`}
+            />
+          </div>
+        </div>
+        <input ref={fileRef} type="file" accept=".pdf" className="hidden" onChange={handleUpload} disabled={uploading} />
+        <button
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md border text-xs font-medium transition-colors cursor-pointer
+            ${uploading ? 'border-border/40 text-muted-foreground/40 cursor-not-allowed' : 'border-border text-foreground hover:bg-accent'}`}
+          onClick={() => fileRef.current?.click()}
+          disabled={uploading}
+        >
+          <Upload size={12} />
+          {uploading ? 'Uploading…' : 'Upload PDF'}
+        </button>
+      </div>
+
+      <div className="flex items-end gap-2 flex-wrap border-t border-border/50 pt-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Add State</label>
+          <AutocompleteInput
+            value={addStateInput}
+            onChange={setAddStateInput}
+            suggestions={stateOptions}
+            placeholder="state"
+            className={`${inputClass} w-28`}
+          />
+        </div>
+        <button
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md border text-xs font-medium transition-colors cursor-pointer
+            ${creatingState ? 'border-border/40 text-muted-foreground/40 cursor-not-allowed' : 'border-border text-foreground hover:bg-accent'}`}
+          onClick={handleAddState}
+          disabled={creatingState}
+        >
+          <FolderPlus size={12} />
+          {creatingState ? 'Creating…' : 'Create'}
+        </button>
+      </div>
+
+      <div className="flex items-end gap-2 flex-wrap border-t border-border/50 pt-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Add Crop</label>
+          <div className="flex items-center gap-1">
+            <AutocompleteInput
+              value={folderState}
+              onChange={v => { setFolderState(v); setFolderCrop(''); }}
+              suggestions={stateOptions}
+              placeholder="state"
+              className={`${inputClass} w-28`}
+            />
+            <span className="text-muted-foreground text-sm">/</span>
+            <AutocompleteInput
+              value={folderCrop}
+              onChange={setFolderCrop}
+              suggestions={cropSuggestionsFor(folderState)}
+              placeholder="crop"
+              className={`${inputClass} w-28`}
+            />
+          </div>
+        </div>
+        <button
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md border text-xs font-medium transition-colors cursor-pointer
+            ${creatingCrop ? 'border-border/40 text-muted-foreground/40 cursor-not-allowed' : 'border-border text-foreground hover:bg-accent'}`}
+          onClick={handleAddCrop}
+          disabled={creatingCrop}
+        >
+          <FolderPlus size={12} />
+          {creatingCrop ? 'Creating…' : 'Create'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function PopStateTable({ rows: rowsProp, loading, error, onRefresh }) {
+  const rows = rowsProp ?? null;
+  const [selectedRows, setSelectedRows] = useState(new Set());
+  const [deleting, setDeleting] = useState(false);
+  const selectAllRef = useRef(null);
+
+  const [stateFilter, setStateFilter] = useState([]);
+  const [cropFilter, setCropFilter] = useState([]);
+  const [pdfFilter, setPdfFilter] = useState([]);
+  const [outputFilter, setOutputFilter] = useState([]);
+  const [auditFilter, setAuditFilter] = useState([]);
+
+  function load() { onRefresh?.(); }
+
+  const allRows = rows || [];
+
+  const stateOptions = [...new Set(allRows.map(r => r.state).filter(Boolean))].sort();
+  const stateCropMap = {};
+  allRows.forEach(r => {
+    if (r.state && r.crop) {
+      if (!stateCropMap[r.state]) stateCropMap[r.state] = new Set();
+      stateCropMap[r.state].add(r.crop);
+    }
+  });
+
+  const filterStateOptions = stateOptions;
+  const filterCropOptions = [...new Set(allRows.map(r => r.crop).filter(Boolean))].sort();
+
+  const anyStatusFilter = pdfFilter.length > 0 || outputFilter.length > 0 || auditFilter.length > 0;
+
+  const filtered = allRows.filter(r =>
+    (stateFilter.length === 0 || stateFilter.includes(r.state)) &&
+    (cropFilter.length === 0 || (r.crop ? cropFilter.includes(r.crop) : false)) &&
+    (!r.is_empty || !anyStatusFilter) &&
+    (r.is_empty || pdfFilter.length === 0 || pdfFilter.includes(r.processed ? 'processed' : 'not processed')) &&
+    (r.is_empty || outputFilter.length === 0 || outputFilter.includes(r.downloaded ? 'downloaded' : 'not downloaded')) &&
+    (r.is_empty || auditFilter.length === 0 || auditFilter.includes(r.audited ? 'audited' : 'not audited'))
+  );
+
+  const anyFilter = stateFilter.length > 0 || cropFilter.length > 0
+    || pdfFilter.length > 0 || outputFilter.length > 0 || auditFilter.length > 0;
+
+  const selectableFiltered = filtered.filter(r => !r.is_empty && r.doc_path);
+
+  function rowKey(row) { return row.doc_path || `${row.state}__${row.crop}__empty`; }
+
+  const allSelected = selectableFiltered.length > 0 && selectableFiltered.every(r => selectedRows.has(rowKey(r)));
+  const someSelected = selectableFiltered.some(r => selectedRows.has(rowKey(r)));
+  const selectedCount = selectableFiltered.filter(r => selectedRows.has(rowKey(r))).length;
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someSelected && !allSelected;
+    }
+  }, [someSelected, allSelected]);
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      setSelectedRows(new Set());
+    } else {
+      setSelectedRows(new Set(selectableFiltered.map(rowKey)));
+    }
+  }
+
+  function toggleRow(row) {
+    const key = rowKey(row);
+    setSelectedRows(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  async function deletePopRow(row) {
+    if (!window.confirm(`Delete "${row.doc_name}" (${row.state}/${row.crop})?\n\nThis will permanently remove the PDF${row.output_path ? ' and its processed output folder' : ''}.`)) return;
+    setDeleting(true);
+    try {
+      await deletePopDoc(row.state, row.crop, row.doc_name);
+      setSelectedRows(prev => { const n = new Set(prev); n.delete(rowKey(row)); return n; });
+      await load();
+    } catch (err) {
+      alert(`Delete failed: ${err.message}`);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function deleteEmptyCrop(row) {
+    if (!window.confirm(`Delete empty crop folder "${row.crop}" in ${row.state}?`)) return;
+    setDeleting(true);
+    try {
+      await deleteEmptyPopCrop(row.state, row.crop);
+      await load();
+    } catch (err) {
+      alert(`Delete failed: ${err.message}`);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function deleteEmptyState(row) {
+    if (!window.confirm(`Delete empty state folder "${row.state}"?`)) return;
+    setDeleting(true);
+    try {
+      await deleteEmptyPopState(row.state);
+      await load();
+    } catch (err) {
+      alert(`Delete failed: ${err.message}`);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function deleteSelected() {
+    const toDelete = selectableFiltered.filter(r => selectedRows.has(rowKey(r)));
+    if (!toDelete.length) return;
+    if (!window.confirm(`Delete ${toDelete.length} document(s)?\n\nThis will permanently remove the PDFs and any associated processed output folders.`)) return;
+    setDeleting(true);
+    try {
+      for (const row of toDelete) {
+        await deletePopDoc(row.state, row.crop, row.doc_name);
+      }
+      setSelectedRows(new Set());
+      await load();
+    } catch (err) {
+      alert(`Delete failed: ${err.message}`);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-foreground">POP Documents</h2>
+        <div className="flex items-center gap-3">
+          {someSelected && (
+            <button
+              className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded border transition-colors cursor-pointer
+                ${deleting
+                  ? 'border-border/40 text-muted-foreground/40 cursor-not-allowed'
+                  : 'border-destructive/50 text-destructive hover:bg-destructive/10'
+                }`}
+              onClick={deleteSelected}
+              disabled={deleting}
+            >
+              <Trash2 size={11} />
+              {deleting ? 'Deleting…' : `Delete ${selectedCount} selected`}
+            </button>
+          )}
+          {anyFilter && rows && (
+            <span className="text-[10px] text-muted-foreground">
+              Showing {filtered.length} of {rows.length}
+            </span>
+          )}
+          <button
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            onClick={load}
+          >
+            <RefreshCw size={12} className={loading ? 'animate-spin' : ''} /> Refresh
+          </button>
+        </div>
+      </div>
+
+      <UploadControls onDone={load} stateOptions={stateOptions} stateCropMap={stateCropMap} />
+
+      {error && (
+        <div className="flex items-center justify-between rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3">
+          <span className="text-sm text-destructive">{error}</span>
+          <button className="text-xs text-muted-foreground hover:text-foreground cursor-pointer" onClick={load}>retry</button>
+        </div>
+      )}
+
+      {!error && (
+        rows === null || loading ? (
+          <div className="flex items-center justify-center py-6 text-muted-foreground text-sm">
+            <RefreshCw size={14} className="animate-spin mr-2" /> Loading…
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="rounded-lg border border-border bg-card px-4 py-8 text-center text-sm text-muted-foreground italic">
+            No POP documents yet. Upload PDFs using the controls above.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full text-xs border-collapse">
+              <thead>
+                <tr className="border-b border-border bg-muted/30">
+                  <th className="px-3 py-2 w-8">
+                    <input
+                      ref={selectAllRef}
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={toggleSelectAll}
+                      disabled={selectableFiltered.length === 0}
+                      className="cursor-pointer accent-primary disabled:cursor-default disabled:opacity-30"
+                    />
+                  </th>
+                  <th className="text-left px-3 py-2 whitespace-nowrap">
+                    <ColumnFilter label="State" options={filterStateOptions} selected={stateFilter} onChange={setStateFilter} />
+                  </th>
+                  <th className="text-left px-3 py-2 whitespace-nowrap">
+                    <ColumnFilter label="Crop" options={filterCropOptions} selected={cropFilter} onChange={setCropFilter} />
+                  </th>
+                  <th className="text-left px-3 py-2 font-semibold text-muted-foreground text-[11px] uppercase tracking-wide">Doc</th>
+                  <th className="text-left px-3 py-2 whitespace-nowrap">
+                    <ColumnFilter label="PDF" options={['processed', 'not processed']} selected={pdfFilter} onChange={setPdfFilter} />
+                  </th>
+                  <th className="text-left px-3 py-2 whitespace-nowrap">
+                    <ColumnFilter label="Output" options={['downloaded', 'not downloaded']} selected={outputFilter} onChange={setOutputFilter} />
+                  </th>
+                  <th className="text-left px-3 py-2 whitespace-nowrap">
+                    <ColumnFilter label="Audit" options={['audited', 'not audited']} selected={auditFilter} onChange={setAuditFilter} />
+                  </th>
+                  <th className="px-3 py-2 w-12"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.length === 0 ? (
+                  <tr>
+                    <td colSpan={8} className="px-4 py-8 text-center text-sm text-muted-foreground italic">
+                      No rows match the current filters.
+                    </td>
+                  </tr>
+                ) : (
+                  filtered.map((row, idx) => {
+                    if (row.is_empty) {
+                      const isEmptyState = row.crop === null || row.crop === undefined;
+                      return (
+                        <tr
+                          key={isEmptyState ? `${row.state}-empty-state` : `${row.state}-${row.crop}-empty`}
+                          className="border-b border-border/30 bg-amber-500/5"
+                        >
+                          <td className="px-3 py-2" />
+                          <td className="px-3 py-2 font-medium text-foreground whitespace-nowrap align-middle">
+                            {row.state}
+                          </td>
+                          <td className="px-3 py-2 align-middle">
+                            {isEmptyState
+                              ? <span className="text-[10px] text-amber-500/50 italic">no crops yet</span>
+                              : <span className="text-foreground">{row.crop}</span>
+                            }
+                          </td>
+                          <td colSpan={3} className="px-3 py-2 text-[10px] text-amber-500/70 italic align-middle">
+                            {isEmptyState
+                              ? 'Empty state folder — create a crop folder to get started'
+                              : 'Empty folder — upload a PDF to get started'
+                            }
+                          </td>
+                          <td className="px-3 py-2" />
+                          <td className="px-3 py-2 align-middle">
+                            <button
+                              className={`flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border transition-colors cursor-pointer
+                                ${deleting
+                                  ? 'border-border/40 text-muted-foreground/30 cursor-not-allowed'
+                                  : 'border-destructive/40 text-destructive/70 hover:border-destructive hover:text-destructive hover:bg-destructive/5'
+                                }`}
+                              onClick={() => isEmptyState ? deleteEmptyState(row) : deleteEmptyCrop(row)}
+                              disabled={deleting}
+                              title={isEmptyState ? 'Delete empty state folder' : 'Delete empty crop folder'}
+                            >
+                              <Trash2 size={11} />
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    }
+                    const isSelected = selectedRows.has(rowKey(row));
+                    return (
+                      <tr
+                        key={`${row.state}-${row.crop}-${row.doc_name}`}
+                        className={`border-b border-border/50 hover:bg-muted/20 transition-colors ${isSelected ? 'bg-primary/5' : idx % 2 === 0 ? '' : 'bg-muted/10'}`}
+                      >
+                        <td className="px-3 py-2 align-middle">
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => toggleRow(row)}
+                            className="cursor-pointer accent-primary"
+                          />
+                        </td>
+                        <td className="px-3 py-2 font-medium text-foreground whitespace-nowrap align-top">{row.state}</td>
+                        <td className="px-3 py-2 text-foreground whitespace-nowrap align-top">{row.crop}</td>
+                        <td className="px-3 py-2 text-muted-foreground align-top max-w-[240px]">
+                          <span className="block truncate" title={row.doc_name}>{row.doc_name}</span>
+                        </td>
+                        <td className="px-3 py-2 align-top whitespace-nowrap">
+                          <a
+                            href={popDownloadUrl(row.doc_path)}
+                            className="flex items-center gap-1 text-[10px] text-primary hover:text-primary/80 transition-colors"
+                            download
+                          >
+                            <Download size={11} /> PDF
+                          </a>
+                        </td>
+                        <td className="px-3 py-2 align-top whitespace-nowrap">
+                          {row.output_path ? (
+                            <a
+                              href={popOutputDownloadUrl(row.state, row.crop, row.doc_name)}
+                              className={`flex items-center gap-1 text-[10px] transition-colors ${row.downloaded ? 'text-green-400 hover:text-green-300' : 'text-primary hover:text-primary/80'}`}
+                              download
+                            >
+                              <Download size={11} /> docx
+                            </a>
+                          ) : (
+                            <span className="text-muted-foreground/30">—</span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2 align-top">
+                          <PopAuditCell row={row} onUploaded={load} />
+                        </td>
+                        <td className="px-3 py-2 align-middle">
+                          <button
+                            className={`flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border transition-colors cursor-pointer
+                              ${deleting
+                                ? 'border-border/40 text-muted-foreground/30 cursor-not-allowed'
+                                : 'border-destructive/40 text-destructive/70 hover:border-destructive hover:text-destructive hover:bg-destructive/5'
+                              }`}
+                            onClick={() => deletePopRow(row)}
+                            disabled={deleting}
+                            title="Delete document"
+                          >
+                            <Trash2 size={11} />
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/faq-pop/components/FunctionsPanel/PopTranslationPanel.tsx
+++ b/frontend/src/features/faq-pop/components/FunctionsPanel/PopTranslationPanel.tsx
@@ -1,0 +1,389 @@
+// @ts-nocheck
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Square, FileText, Check, ChevronRight } from 'lucide-react';
+import { MultiSelector, StateSelector } from './RunTile';
+import { getPopStateTable, runPop, getPopJob, stopPopJob } from '../../api';
+import PopStateTable from './PopStateTable';
+
+const inputClass =
+  'w-full bg-input border border-border rounded-md px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-ring transition-shadow';
+
+const labelClass = 'text-xs font-medium text-foreground/70';
+
+function parseStdoutProgress(stdout) {
+  if (!stdout) return null;
+  const lines = stdout.split('\n');
+  let totalDocs = null;
+  const docs = [];
+  let currentIdx = -1;
+
+  for (const line of lines) {
+    const totalMatch = line.match(/\[POP\] Total docs: (\d+)/);
+    if (totalMatch) { totalDocs = parseInt(totalMatch[1]); continue; }
+
+    const processingMatch = line.match(/\[POP\] Processing: (.+)/);
+    if (processingMatch) {
+      if (currentIdx >= 0 && docs[currentIdx].status === 'running') docs[currentIdx].status = 'done';
+      docs.push({ name: processingMatch[1].trim(), pagesTotal: null, pagesDone: 0, status: 'running' });
+      currentIdx = docs.length - 1;
+      continue;
+    }
+
+    const startedMatch = line.match(/Translation stage started \| pages=(\d+)/);
+    if (startedMatch && currentIdx >= 0) {
+      docs[currentIdx].pagesTotal = parseInt(startedMatch[1]);
+      continue;
+    }
+
+    const progressMatch = line.match(/Translation progress \| completed (\d+)\/(\d+)/);
+    if (progressMatch && currentIdx >= 0) {
+      docs[currentIdx].pagesDone = parseInt(progressMatch[1]);
+      docs[currentIdx].pagesTotal = parseInt(progressMatch[2]);
+      continue;
+    }
+
+    if (line.trim() === 'DONE' && currentIdx >= 0) {
+      docs[currentIdx].status = 'done';
+      continue;
+    }
+  }
+
+  const runningDoc = docs.find((d) => d.status === 'running');
+  return {
+    totalDocs,
+    docsDone: docs.filter((d) => d.status === 'done').length,
+    currentDoc: runningDoc?.name ?? null,
+    currentPage: runningDoc?.pagesDone ?? null,
+    currentTotalPages: runningDoc?.pagesTotal ?? null,
+    docs,
+  };
+}
+
+function getProgressData(jobData) {
+  if (jobData?.progress) {
+    const p = jobData.progress;
+    return {
+      totalDocs: p.total_docs ?? null,
+      docsDone: p.docs_done ?? 0,
+      currentDoc: p.current_doc ?? null,
+      currentPage: p.current_page ?? null,
+      currentTotalPages: p.current_total_pages ?? null,
+      docs: (p.docs || []).map((d) => ({
+        name: d.name,
+        status: d.status,
+        pagesTotal: d.pages_total ?? null,
+        pagesDone: d.pages_done ?? 0,
+      })),
+    };
+  }
+  return parseStdoutProgress(jobData?.stdout);
+}
+
+function PopProgress({ jobData }) {
+  const data = getProgressData(jobData);
+  if (!data || (data.totalDocs === null && data.docs.length === 0)) return null;
+
+  const pct = (done, total) => (total > 0 ? Math.round((done / total) * 100) : 0);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {data.currentDoc && (
+        <div className="rounded-md border border-blue-500/20 bg-blue-500/5 px-3 py-2 flex flex-col gap-1.5">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="w-1.5 h-1.5 rounded-full bg-blue-400 animate-pulse flex-shrink-0" />
+            <span className="text-xs font-medium text-foreground flex-shrink-0">Processing</span>
+            <span className="text-xs text-foreground/80 truncate min-w-0" title={data.currentDoc}>{data.currentDoc}</span>
+          </div>
+          {data.currentTotalPages !== null && (
+            <>
+              <div className="flex items-center justify-between text-[10px] text-muted-foreground">
+                <span>Page {data.currentPage ?? 0} / {data.currentTotalPages}</span>
+                <span>{pct(data.currentPage ?? 0, data.currentTotalPages)}%</span>
+              </div>
+              <div className="h-1.5 w-full bg-muted/50 rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-blue-400 animate-pulse transition-all duration-300"
+                  style={{ width: `${pct(data.currentPage ?? 0, data.currentTotalPages)}%` }}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {data.docs.length > 0 && (
+        <div className="flex flex-col gap-1 rounded-md border border-border/50 bg-muted/10 px-3 py-2">
+          {data.totalDocs !== null && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-0.5">
+              <FileText size={11} />
+              <span>Docs: {data.docsDone} / {data.totalDocs}</span>
+            </div>
+          )}
+          {data.docs.map((doc, i) => (
+            <div key={i} className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-1.5">
+                {doc.status === 'done'    && <Check size={11} className="text-green-500 flex-shrink-0" />}
+                {doc.status === 'running' && <ChevronRight size={11} className="text-blue-400 flex-shrink-0" />}
+                {doc.status === 'pending' && <span className="w-[11px] text-center text-[10px] text-muted-foreground/40 flex-shrink-0">—</span>}
+                <span
+                  className={`text-xs truncate flex-1 min-w-0 ${doc.status === 'done' ? 'text-muted-foreground' : doc.status === 'running' ? 'text-foreground' : 'text-muted-foreground/40'}`}
+                  title={doc.name}
+                >
+                  {doc.name}
+                </span>
+                <span className="text-[10px] shrink-0 text-muted-foreground">
+                  {doc.status === 'done'    && doc.pagesTotal !== null ? `${doc.pagesTotal}p` : ''}
+                  {doc.status === 'running' && doc.pagesTotal !== null ? `${doc.pagesDone}/${doc.pagesTotal}p` : ''}
+                  {doc.status === 'done'    && doc.pagesTotal === null ? 'Done' : ''}
+                  {doc.status === 'pending' ? 'Pending' : ''}
+                </span>
+              </div>
+              {doc.pagesTotal !== null && (
+                <div className="h-0.5 w-full bg-muted/30 rounded-full overflow-hidden pl-[15px]">
+                  <div
+                    className={`h-full rounded-full transition-all duration-300 ${doc.status === 'done' ? 'bg-green-500' : 'bg-blue-400 animate-pulse'}`}
+                    style={{ width: `${pct(doc.pagesDone ?? 0, doc.pagesTotal)}%` }}
+                  />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const POP_TILE_KEY = 'tile:pop-translation';
+
+export default function PopTranslationPanel({ onJobCreated }) {
+  const [state, setState] = useState('');
+  const [crop, setCrop] = useState('');
+  const [docs, setDocs] = useState([]);
+  const [concurrency, setConcurrency] = useState(1);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [jobId, setJobId] = useState(null);
+  const [jobData, setJobData] = useState(null);
+  const [jobLabel, setJobLabel] = useState('');
+  const pollRef = useRef(null);
+
+  const [tableRows, setTableRows] = useState([]);
+  const [tableLoading, setTableLoading] = useState(true);
+  const [tableError, setTableError] = useState(null);
+
+  const formRef = useRef(null);
+  const [stacked, setStacked] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => setStacked(!entry.isIntersecting),
+      { threshold: 0 }
+    );
+    if (formRef.current) observer.observe(formRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  function stopPolling() {
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+  }
+  useEffect(() => () => stopPolling(), []);
+
+  function startPolling(jid) {
+    stopPolling();
+    pollRef.current = setInterval(async () => {
+      try {
+        const data = await getPopJob(jid);
+        setJobData(data);
+        if (data.status === 'done' || data.status === 'failed' || data.status === 'stopped') {
+          stopPolling();
+          loadTable();
+        }
+      } catch { /* ignore */ }
+    }, 3000);
+  }
+
+  useEffect(() => {
+    const saved = localStorage.getItem(POP_TILE_KEY);
+    if (!saved) return;
+    try {
+      const { jobId: savedJid, label: savedLabel } = JSON.parse(saved);
+      if (!savedJid) return;
+      setJobLabel(savedLabel || '');
+      getPopJob(savedJid).then((data) => {
+        setJobId(savedJid);
+        setJobData(data);
+        if (data.status === 'running') startPolling(savedJid);
+        else { loadTable(); }
+      }).catch(() => localStorage.removeItem(POP_TILE_KEY));
+    } catch { localStorage.removeItem(POP_TILE_KEY); }
+  }, []);
+
+  async function loadTable() {
+    setTableLoading(true);
+    setTableError(null);
+    try {
+      const data = await getPopStateTable();
+      setTableRows(data.rows || []);
+    } catch (err) {
+      setTableError(err.message || 'Failed to load');
+    } finally {
+      setTableLoading(false);
+    }
+  }
+
+  useEffect(() => { loadTable(); }, []);
+
+  useEffect(() => { setCrop(''); setDocs([]); }, [state]);
+  useEffect(() => { setDocs([]); }, [crop]);
+
+  const stateOptions = [...new Set(tableRows.map((r) => r.state).filter(Boolean))].sort();
+  const cropOptions = [...new Set(
+    tableRows.filter((r) => r.state === state).map((r) => r.crop).filter(Boolean)
+  )].sort();
+  const docOptions = tableRows
+    .filter((r) => r.state === state && r.crop === crop && r.doc_name)
+    .map((r) => r.doc_name);
+
+  async function handleRun() {
+    if (!state || !crop) return;
+    const body = { state, crop, concurrency };
+    if (docs.length > 0) body.docs = docs;
+    const label = `${state} / ${crop}`;
+    setSubmitting(true);
+    try {
+      const result = await runPop(body);
+      const jid = result.job_id;
+      setJobId(jid);
+      setJobData({ job_id: jid, status: 'running', stdout: '', stderr: '' });
+      setJobLabel(label);
+      localStorage.setItem(POP_TILE_KEY, JSON.stringify({ jobId: jid, label }));
+      toast.success(`POP job queued — ${jid.slice(0, 8)}`);
+      if (onJobCreated) onJobCreated();
+      startPolling(jid);
+    } catch (err) {
+      toast.error(err.message || 'Failed to start POP translation');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleStop() {
+    if (!jobId) return;
+    try { await stopPopJob(jobId); } catch { /* ignore */ }
+  }
+
+  const isRunning = jobData?.status === 'running';
+  const isSettled = jobData && !isRunning;
+  const STATUS_COLORS = { done: 'text-green-400', failed: 'text-destructive', stopped: 'text-amber-400' };
+
+  return (
+    <div className="flex flex-col">
+      <div ref={formRef} className="max-w-3xl mx-auto w-full">
+      <div className="flex justify-center">
+      <div className="w-full max-w-md bg-card rounded-lg border border-border shadow-sm p-5 flex flex-col gap-4">
+
+      {isRunning && (
+        <>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-blue-500 animate-pulse flex-shrink-0" />
+              <span className="text-sm font-bold text-foreground">Running</span>
+              {jobLabel && <span className="text-xs bg-accent/50 border border-border rounded px-1.5 py-0.5 text-foreground">{jobLabel}</span>}
+            </div>
+            <button
+              className="flex items-center gap-1 px-2.5 py-1 rounded border border-destructive/40 text-destructive hover:bg-destructive/10 text-xs transition-colors cursor-pointer"
+              onClick={handleStop}
+            >
+              <Square size={11} /> Stop
+            </button>
+          </div>
+          {jobData && <PopProgress jobData={jobData} />}
+        </>
+      )}
+
+      {isSettled && (
+        <div className="flex items-center gap-2">
+          <span className={`text-xs font-semibold capitalize ${STATUS_COLORS[jobData.status] || 'text-muted-foreground'}`}>
+            Last run: {jobData.status}
+          </span>
+          {jobLabel && <span className="text-xs bg-accent/50 border border-border rounded px-1.5 py-0.5 text-muted-foreground">{jobLabel}</span>}
+        </div>
+      )}
+        <div>
+          <h2 className="text-base font-semibold text-foreground">POP Translation</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Translate agricultural POP PDFs to English using Gemini
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>State</label>
+            <StateSelector
+              value={state}
+              onChange={setState}
+              stateNames={stateOptions}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Crop</label>
+            <select
+              className={inputClass}
+              value={crop}
+              onChange={(e) => setCrop(e.target.value)}
+              disabled={!state || cropOptions.length === 0}
+            >
+              <option value="">
+                {!state ? 'Select a state first' : cropOptions.length === 0 ? 'No crops found' : '— select crop —'}
+              </option>
+              {cropOptions.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Documents <span className="font-normal text-muted-foreground">(leave empty to translate all)</span></label>
+            <MultiSelector
+              value={docs}
+              onChange={setDocs}
+              names={docOptions}
+              placeholder={!crop ? 'Select a crop first' : docOptions.length === 0 ? 'No PDFs found' : 'Select documents…'}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className={labelClass}>Parallel pages (concurrency)</label>
+            <input
+              type="number"
+              className={inputClass}
+              min={1}
+              max={10}
+              value={concurrency}
+              onChange={(e) => setConcurrency(Math.max(1, Math.min(10, parseInt(e.target.value) || 1)))}
+            />
+          </div>
+        </div>
+
+        <button
+          className="mt-1 w-full py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium
+            hover:bg-primary/90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={handleRun}
+          disabled={!state || !crop || submitting || isRunning}
+        >
+          {submitting ? 'Submitting…' : isRunning ? 'Running…' : 'Run Translation'}
+        </button>
+      </div>
+      </div>
+      </div>
+      <div className={`sticky top-0 z-10 bg-background pt-6 h-screen ${stacked ? 'overflow-y-auto' : 'overflow-hidden'}`}>
+        <div className="max-w-4xl mx-auto w-full">
+          <PopStateTable rows={tableRows} loading={tableLoading} error={tableError} onRefresh={loadTable} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/faq-pop/components/FunctionsPanel/RunTile.tsx
+++ b/frontend/src/features/faq-pop/components/FunctionsPanel/RunTile.tsx
@@ -1,0 +1,570 @@
+// @ts-nocheck
+import { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from 'sonner';
+import { Square } from 'lucide-react';
+import { getNextState, getJob, stopJob } from '../../api';
+import PipelineOutput, {
+  parsePipelineOutput,
+  parsePrePipelineOutput,
+  parsePostPipelineOutput,
+  PrePipelineOutput,
+  PostPipelineOutput,
+} from '../JobsPanel/PipelineOutput';
+
+const inputClass =
+  'w-full bg-input border border-border rounded-md px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-ring transition-shadow';
+
+// ── MultiSelector ──────────────────────────────────────────────────────────────
+
+export function MultiSelector({ value, onChange, names, placeholder }) {
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [expanded, setExpanded] = useState(false);
+  const [expandedRect, setExpandedRect] = useState(null);
+  const [dropdownPos, setDropdownPos] = useState(null);
+  const listRef = useRef(null);
+  const containerRef = useRef(null);
+  const dropdownRef = useRef(null);
+
+  const filtered = (names || []).filter(
+    (c) => !value.includes(c) && c.toLowerCase().includes(search.trim().toLowerCase()),
+  );
+
+  useEffect(() => {
+    if (listRef.current && highlightedIndex >= 0) {
+      const item = listRef.current.children[highlightedIndex];
+      if (item) item.scrollIntoView({ block: 'nearest' });
+    }
+  }, [highlightedIndex]);
+
+  // click-outside closes the inline dropdown
+  useEffect(() => {
+    if (!open || expanded) return;
+    function handler(e) {
+      if (containerRef.current?.contains(e.target) || dropdownRef.current?.contains(e.target)) return;
+      setOpen(false);
+      setHighlightedIndex(-1);
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open, expanded]);
+
+  function computePos() {
+    if (containerRef.current) {
+      const r = containerRef.current.getBoundingClientRect();
+      setDropdownPos({ top: r.bottom + 2, left: r.left, width: r.width });
+    }
+  }
+
+  function closeAll() { setExpanded(false); setOpen(false); setHighlightedIndex(-1); }
+
+  function addItem(item) { onChange([...value, item]); setSearch(''); setHighlightedIndex(-1); }
+  function removeItem(item) { onChange(value.filter((c) => c !== item)); }
+
+  function handleKeyDown(e) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setOpen(true); setHighlightedIndex((i) => Math.min(i + 1, filtered.length - 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setHighlightedIndex((i) => Math.max(i - 1, 0)); }
+    else if (e.key === 'Enter') { e.preventDefault(); if (highlightedIndex >= 0 && highlightedIndex < filtered.length) addItem(filtered[highlightedIndex]); }
+    else if (e.key === 'Escape') { closeAll(); }
+  }
+
+  function handleExpand(e) {
+    e.preventDefault();
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      setExpandedRect({ left: rect.left, width: rect.width });
+    }
+    setExpanded(true);
+  }
+
+  const listItems = filtered.map((c, i) => (
+    <button key={c} type="button"
+      className={`w-full text-left px-3 py-1.5 text-sm cursor-pointer ${i === highlightedIndex ? 'bg-accent text-accent-foreground' : 'text-foreground hover:bg-accent hover:text-accent-foreground'}`}
+      onMouseDown={() => addItem(c)} onMouseEnter={() => setHighlightedIndex(i)}>
+      {c}
+    </button>
+  ));
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="relative" ref={containerRef}>
+        <input type="text" className={inputClass} placeholder={placeholder} value={search}
+          onChange={(e) => { computePos(); setSearch(e.target.value); setOpen(true); setHighlightedIndex(-1); }}
+          onFocus={() => { computePos(); setOpen(true); }}
+          onBlur={() => { if (!expanded) setTimeout(() => { setOpen(false); setHighlightedIndex(-1); }, 150); }}
+          onKeyDown={handleKeyDown} />
+        {open && filtered.length > 0 && !expanded && dropdownPos && createPortal(
+          <div ref={dropdownRef}
+            style={{ position: 'fixed', top: dropdownPos.top, left: dropdownPos.left, width: dropdownPos.width, zIndex: 9999 }}
+            className="bg-popover border border-border rounded-md shadow-lg"
+            onWheel={(e) => e.stopPropagation()}>
+            <div className="flex justify-end px-1 py-0.5 border-b border-border/40">
+              <button type="button" title="Expand"
+                className="text-muted-foreground hover:text-foreground px-2.5 py-1 rounded hover:bg-accent cursor-pointer text-sm leading-none"
+                onMouseDown={handleExpand}>↕</button>
+            </div>
+            <div ref={listRef} className="max-h-44 overflow-y-auto overscroll-contain">{listItems}</div>
+          </div>,
+          document.body,
+        )}
+      </div>
+      {expanded && open && filtered.length > 0 && createPortal(
+        <>
+          <div style={{ position: 'fixed', inset: 0, zIndex: 9998 }} onMouseDown={closeAll} />
+          <div style={{ position: 'fixed', top: 0, bottom: 0, left: expandedRect?.left ?? 0, width: expandedRect?.width ?? 300, zIndex: 9999 }}
+            className="bg-popover border border-border rounded-md shadow-xl flex flex-col"
+            onWheel={(e) => e.stopPropagation()}>
+            <div className="flex justify-end px-1 py-0.5 border-b border-border/40 shrink-0">
+              <button type="button" title="Collapse"
+                className="text-muted-foreground hover:text-foreground px-2.5 py-1 rounded hover:bg-accent cursor-pointer text-xl font-bold leading-none"
+                onClick={closeAll}>×</button>
+            </div>
+            <div ref={listRef} className="flex-1 overflow-y-auto overscroll-contain">{listItems}</div>
+          </div>
+        </>,
+        document.body,
+      )}
+      {value.length > 0 && (
+        <div className="flex flex-col gap-1 mt-1">
+          {value.map((c) => (
+            <div key={c} className="flex items-center justify-between bg-accent/40 border border-border rounded px-2 py-0.5 text-xs text-foreground">
+              <span>{c}</span>
+              <button type="button" className="ml-2 text-muted-foreground hover:text-destructive leading-none cursor-pointer" onClick={() => removeItem(c)}>×</button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── StateSelector ─────────────────────────────────────────────────────────────
+
+export function StateSelector({ value, onChange, stateNames }) {
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [expanded, setExpanded] = useState(false);
+  const [expandedRect, setExpandedRect] = useState(null);
+  const [dropdownPos, setDropdownPos] = useState(null);
+  const listRef = useRef(null);
+  const containerRef = useRef(null);
+  const dropdownRef = useRef(null);
+
+  const displayText = value || search;
+  const filtered = (stateNames || []).filter(
+    (s) => s.toLowerCase().includes((value ? '' : search).toLowerCase()),
+  );
+
+  useEffect(() => {
+    if (listRef.current && highlightedIndex >= 0) {
+      const item = listRef.current.children[highlightedIndex];
+      if (item) item.scrollIntoView({ block: 'nearest' });
+    }
+  }, [highlightedIndex]);
+
+  // click-outside closes the inline dropdown
+  useEffect(() => {
+    if (!open || expanded) return;
+    function handler(e) {
+      if (containerRef.current?.contains(e.target) || dropdownRef.current?.contains(e.target)) return;
+      setOpen(false);
+      setHighlightedIndex(-1);
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open, expanded]);
+
+  function computePos() {
+    if (containerRef.current) {
+      const r = containerRef.current.getBoundingClientRect();
+      setDropdownPos({ top: r.bottom + 2, left: r.left, width: r.width });
+    }
+  }
+
+  function closeAll() { setExpanded(false); setOpen(false); setHighlightedIndex(-1); }
+
+  function selectState(state) { onChange(state); setSearch(''); closeAll(); }
+  function handleInput(e) { onChange(''); computePos(); setSearch(e.target.value); setOpen(true); setHighlightedIndex(-1); }
+  function handleClear(e) { e.preventDefault(); onChange(''); setSearch(''); setHighlightedIndex(-1); }
+
+  function handleKeyDown(e) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setOpen(true); setHighlightedIndex((i) => Math.min(i + 1, filtered.length - 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setHighlightedIndex((i) => Math.max(i - 1, 0)); }
+    else if (e.key === 'Enter') { e.preventDefault(); if (highlightedIndex >= 0 && highlightedIndex < filtered.length) selectState(filtered[highlightedIndex]); }
+    else if (e.key === 'Escape') { closeAll(); }
+  }
+
+  function handleExpand(e) {
+    e.preventDefault();
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      setExpandedRect({ left: rect.left, width: rect.width });
+    }
+    setExpanded(true);
+  }
+
+  const listItems = filtered.map((s, i) => (
+    <button key={s} type="button"
+      className={`w-full text-left px-3 py-1.5 text-sm cursor-pointer ${i === highlightedIndex ? 'bg-accent text-accent-foreground' : 'text-foreground hover:bg-accent hover:text-accent-foreground'}`}
+      onMouseDown={() => selectState(s)} onMouseEnter={() => setHighlightedIndex(i)}>
+      {s}
+    </button>
+  ));
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="relative" ref={containerRef}>
+        <input type="text" className={inputClass} placeholder="Search state…" value={displayText}
+          onChange={handleInput} onFocus={() => { computePos(); setOpen(true); }}
+          onBlur={() => { if (!expanded) setTimeout(() => { setOpen(false); setHighlightedIndex(-1); }, 150); }}
+          onKeyDown={handleKeyDown} />
+        {value && (
+          <button type="button" className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-destructive leading-none cursor-pointer" onMouseDown={handleClear}>×</button>
+        )}
+        {open && filtered.length > 0 && !expanded && dropdownPos && createPortal(
+          <div ref={dropdownRef}
+            style={{ position: 'fixed', top: dropdownPos.top, left: dropdownPos.left, width: dropdownPos.width, zIndex: 9999 }}
+            className="bg-popover border border-border rounded-md shadow-lg"
+            onWheel={(e) => e.stopPropagation()}>
+            <div className="flex justify-end px-1 py-0.5 border-b border-border/40">
+              <button type="button" title="Expand"
+                className="text-muted-foreground hover:text-foreground px-2.5 py-1 rounded hover:bg-accent cursor-pointer text-sm leading-none"
+                onMouseDown={handleExpand}>↕</button>
+            </div>
+            <div ref={listRef} className="max-h-44 overflow-y-auto overscroll-contain">{listItems}</div>
+          </div>,
+          document.body,
+        )}
+      </div>
+      {expanded && open && filtered.length > 0 && createPortal(
+        <>
+          <div style={{ position: 'fixed', inset: 0, zIndex: 9998 }} onMouseDown={closeAll} />
+          <div style={{ position: 'fixed', top: 0, bottom: 0, left: expandedRect?.left ?? 0, width: expandedRect?.width ?? 300, zIndex: 9999 }}
+            className="bg-popover border border-border rounded-md shadow-xl flex flex-col"
+            onWheel={(e) => e.stopPropagation()}>
+            <div className="flex justify-end px-1 py-0.5 border-b border-border/40 shrink-0">
+              <button type="button" title="Collapse"
+                className="text-muted-foreground hover:text-foreground px-2.5 py-1 rounded hover:bg-accent cursor-pointer text-xl font-bold leading-none"
+                onClick={closeAll}>×</button>
+            </div>
+            <div ref={listRef} className="flex-1 overflow-y-auto overscroll-contain">{listItems}</div>
+          </div>
+        </>,
+        document.body,
+      )}
+    </div>
+  );
+}
+
+// ── Phase detection ───────────────────────────────────────────────────────────
+
+function detectPhase(stdout) {
+  if (!stdout) return 'pre';
+  if (stdout.includes('LLM Deduplication') || stdout.includes('Collect Final FAQ')) return 'post';
+  if (stdout.match(/\[INFO\] (?:Filtered to|Found) \d+ unique crop/)) return 'pipeline';
+  return 'pre';
+}
+
+const MEGA_STAGES = ['Pre-Pipeline', 'Pipeline', 'Post-Pipeline'];
+const PHASE_TO_IDX = { pre: 0, pipeline: 1, post: 2 };
+
+function MegaStageBar({ phase, jobStatus }) {
+  const activeIdx = PHASE_TO_IDX[phase] ?? 0;
+  return (
+    <div className="flex items-center gap-0 w-full">
+      {MEGA_STAGES.map((label, i) => {
+        const isDone = jobStatus === 'done' ? true : i < activeIdx;
+        const isActive = jobStatus !== 'done' && i === activeIdx;
+        const dotCls = isDone
+          ? 'bg-green-500 border-green-500'
+          : isActive
+          ? 'bg-blue-400 border-blue-400 animate-pulse'
+          : 'bg-transparent border-muted-foreground/25';
+        const labelCls = isDone ? 'text-green-400' : isActive ? 'text-blue-400' : 'text-muted-foreground/35';
+        const lineLeft = isDone || isActive;
+        const lineRight = isDone;
+        return (
+          <div key={label} className="flex flex-col items-center flex-1 min-w-0">
+            <div className="flex items-center w-full">
+              <div className={`h-px flex-1 transition-colors ${i === 0 ? 'invisible' : lineLeft ? 'bg-green-500/50' : 'bg-border/40'}`} />
+              <div className={`w-3 h-3 rounded-full border-2 flex-shrink-0 transition-colors ${dotCls}`} />
+              <div className={`h-px flex-1 transition-colors ${i === MEGA_STAGES.length - 1 ? 'invisible' : lineRight ? 'bg-green-500/50' : 'bg-border/40'}`} />
+            </div>
+            <span className={`text-[10px] mt-1 text-center leading-none font-medium ${labelCls}`}>{label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Field helpers ─────────────────────────────────────────────────────────────
+
+function buildInitialValues(fields) {
+  const vals = {};
+  for (const f of fields) {
+    if (f.type === 'crops-selector' || f.type === 'domains-selector') vals[f.key] = [];
+    else if (f.type === 'states-selector') vals[f.key] = '';
+    else if (f.type === 'checkbox') vals[f.key] = f.defaultValue !== undefined ? f.defaultValue : false;
+    else vals[f.key] = f.defaultValue !== undefined ? f.defaultValue : '';
+  }
+  return vals;
+}
+
+// ── RunTile ───────────────────────────────────────────────────────────────────
+
+export default function RunTile({ title, description, fields, onRun, cropNames, domainNames, stateNames, onJobDone, tileKey }) {
+  const [values, setValues] = useState(() => buildInitialValues(fields));
+  const [submitting, setSubmitting] = useState(false);
+
+  const [jobId, setJobId] = useState(null);
+  const [jobData, setJobData] = useState(null);
+  const [stateName, setStateName] = useState(null);
+  const [lastRunDomains, setLastRunDomains] = useState([]);
+  const [showLog, setShowLog] = useState(false);
+  const pollRef = useRef(null);
+
+  function setValue(key, val) { setValues((prev) => ({ ...prev, [key]: val })); }
+
+  function stopPolling() {
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+  }
+
+  useEffect(() => () => stopPolling(), []);
+
+  function persistJob(jid, sName, domains) {
+    if (!tileKey) return;
+    localStorage.setItem(`tile:${tileKey}`, JSON.stringify({ jobId: jid, stateName: sName, lastRunDomains: domains }));
+  }
+
+  function startPolling(jid) {
+    stopPolling();
+    pollRef.current = setInterval(async () => {
+      try {
+        const data = await getJob(jid);
+        setJobData(data);
+        if (data.status === 'done' || data.status === 'failed' || data.status === 'stopped') {
+          stopPolling();
+          onJobDone?.();
+        }
+      } catch {
+        // ignore transient errors
+      }
+    }, 3000);
+  }
+
+  useEffect(() => {
+    if (!tileKey) return;
+    const saved = localStorage.getItem(`tile:${tileKey}`);
+    if (!saved) return;
+    try {
+      const { jobId: savedJid, stateName: savedName, lastRunDomains: savedDomains } = JSON.parse(saved);
+      if (!savedJid) return;
+      setStateName(savedName || '');
+      setLastRunDomains(savedDomains || []);
+      getJob(savedJid).then((data) => {
+        setJobId(savedJid);
+        setJobData(data);
+        if (data.status === 'running') {
+          startPolling(savedJid);
+        } else {
+          onJobDone?.();
+        }
+      }).catch(() => {
+        if (tileKey) localStorage.removeItem(`tile:${tileKey}`);
+      });
+    } catch {
+      if (tileKey) localStorage.removeItem(`tile:${tileKey}`);
+    }
+  }, []);
+
+  async function handleRun() {
+    const body = {};
+    for (const f of fields) {
+      const raw = values[f.key];
+      if (f.type === 'checkbox') body[f.key] = Boolean(raw);
+      else if (f.type === 'crops-selector' || f.type === 'domains-selector') { if (raw.length > 0) body[f.key] = raw; }
+      else if (f.type === 'states-selector') { if (raw) body[f.key] = raw; }
+      else { if (raw !== '' && raw !== undefined && raw !== null) body[f.key] = raw; }
+    }
+
+    setSubmitting(true);
+    try {
+      const stateValue = values['state'] || '';
+      const domains = values['domains'] || [];
+      const { name: stateFolder } = await getNextState(stateValue, domains);
+      body.pre_output = `${stateFolder}/${stateFolder}.csv`;
+
+      setStateName(stateFolder);
+      setLastRunDomains(domains);
+      const result = await onRun(body);
+      const jid = result.job_id;
+      setJobId(jid);
+      setJobData({ job_id: jid, status: 'running', stdout: '', stderr: '' });
+      toast.success(`Job queued → ${jid}`);
+      persistJob(jid, stateFolder, domains);
+      startPolling(jid);
+    } catch (err) {
+      toast.error(err.message || 'Unknown error');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleStop() {
+    if (!jobId) return;
+    try { await stopJob(jobId); } catch { /* ignore */ }
+  }
+
+  const isRunning = jobData?.status === 'running';
+  const isSettled = jobData && !isRunning;
+
+  if (isRunning) {
+    const phase = detectPhase(jobData.stdout);
+    const hasPre = parsePrePipelineOutput(jobData.stdout) !== null;
+    const hasPipeline = parsePipelineOutput(jobData.stdout) !== null;
+    const hasPost = parsePostPipelineOutput(jobData.stdout) !== null;
+
+    return (
+      <div className="bg-card text-card-foreground rounded-lg border border-border shadow-sm p-4 flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-blue-500 animate-pulse flex-shrink-0" />
+            <span className="text-sm font-bold text-foreground">Running</span>
+            {stateName && (
+              <span className="text-xs font-mono bg-accent/50 border border-border rounded px-1.5 py-0.5 text-foreground">{stateName}</span>
+            )}
+          </div>
+          <button
+            className="flex items-center gap-1 px-2.5 py-1 rounded border border-destructive/40 text-destructive hover:bg-destructive/10 text-xs transition-colors cursor-pointer"
+            onClick={handleStop}
+          >
+            <Square size={11} /> Stop
+          </button>
+        </div>
+
+        {lastRunDomains.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {lastRunDomains.map((d) => (
+              <span key={d} className="text-[10px] bg-accent/40 border border-border rounded px-1.5 py-0.5 text-muted-foreground">{d}</span>
+            ))}
+          </div>
+        )}
+
+        <div className="bg-background/35 border border-border/50 rounded-md px-3 py-2.5">
+          <MegaStageBar phase={phase} jobStatus="running" />
+        </div>
+
+        {hasPre && <PrePipelineOutput stdout={jobData.stdout} />}
+        {hasPipeline && <PipelineOutput stdout={jobData.stdout} />}
+        {hasPost && <PostPipelineOutput stdout={jobData.stdout} />}
+      </div>
+    );
+  }
+
+  const STATUS_COLORS = {
+    done: 'text-green-400', failed: 'text-destructive', stopped: 'text-amber-400',
+  };
+
+  return (
+    <div className="bg-card text-card-foreground rounded-lg border border-border shadow-sm p-4 flex flex-col gap-3">
+      <div>
+        <p className="text-sm font-bold text-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {fields.map((f) => {
+          if (f.type === 'checkbox') return (
+            <div key={f.key} className="flex items-center gap-2">
+              <input id={`tile-${f.key}`} type="checkbox" className="w-4 h-4 rounded accent-primary cursor-pointer"
+                checked={Boolean(values[f.key])} onChange={(e) => setValue(f.key, e.target.checked)} />
+              <label htmlFor={`tile-${f.key}`} className="text-xs font-medium text-muted-foreground cursor-pointer select-none">{f.label}</label>
+            </div>
+          );
+          if (f.type === 'select') return (
+            <div key={f.key} className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground">{f.label}</label>
+              <select className={inputClass} value={values[f.key]} onChange={(e) => setValue(f.key, e.target.value)}>
+                {(f.options || []).map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+              </select>
+            </div>
+          );
+          if (f.type === 'crops-selector') return (
+            <div key={f.key} className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground">{f.label}</label>
+              <MultiSelector value={values[f.key]} onChange={(v) => setValue(f.key, v)} names={cropNames} placeholder="Search crops…" />
+              {f.hint && <p className="text-xs text-muted-foreground/70 italic">{f.hint}</p>}
+            </div>
+          );
+          if (f.type === 'domains-selector') return (
+            <div key={f.key} className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground">{f.label}</label>
+              <MultiSelector value={values[f.key]} onChange={(v) => setValue(f.key, v)} names={domainNames} placeholder="Search domains…" />
+              {f.hint && <p className="text-xs text-muted-foreground/70 italic">{f.hint}</p>}
+            </div>
+          );
+          if (f.type === 'states-selector') return (
+            <div key={f.key} className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground">{f.label}</label>
+              <StateSelector value={values[f.key]} onChange={(v) => setValue(f.key, v)} stateNames={stateNames} />
+            </div>
+          );
+          return (
+            <div key={f.key} className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-muted-foreground">{f.label}</label>
+              <input type={f.type} className={inputClass} value={values[f.key]} onChange={(e) => setValue(f.key, e.target.value)} />
+              {f.hint && <p className="text-xs text-muted-foreground/70 italic">{f.hint}</p>}
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        className="w-full mt-auto bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] rounded-md py-2 text-sm font-medium transition-all disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+        onClick={handleRun}
+        disabled={submitting}
+      >
+        {submitting ? 'Starting…' : 'Run'}
+      </button>
+
+      {isSettled && (
+        <div className="border-t border-border pt-3 flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className={`text-xs font-semibold capitalize ${STATUS_COLORS[jobData.status] || 'text-muted-foreground'}`}>
+                Last run: {jobData.status}
+              </span>
+              {stateName && (
+                <span className="text-xs font-mono bg-accent/50 border border-border rounded px-1.5 py-0.5 text-muted-foreground">{stateName}</span>
+              )}
+            </div>
+            <button className="text-[10px] text-muted-foreground/50 hover:text-muted-foreground transition-colors cursor-pointer" onClick={() => setShowLog((v) => !v)}>
+              {showLog ? 'hide log' : 'view log'}
+            </button>
+          </div>
+          {showLog && (
+            <div className="flex flex-col gap-2">
+              {jobData.status === 'done' && (
+                <>
+                  {parsePrePipelineOutput(jobData.stdout) && <PrePipelineOutput stdout={jobData.stdout} />}
+                  {parsePipelineOutput(jobData.stdout) && <PipelineOutput stdout={jobData.stdout} />}
+                  {parsePostPipelineOutput(jobData.stdout) && <PostPipelineOutput stdout={jobData.stdout} />}
+                  {!parsePrePipelineOutput(jobData.stdout) && !parsePipelineOutput(jobData.stdout) && !parsePostPipelineOutput(jobData.stdout) && (
+                    <pre className="font-mono text-xs bg-slate-900 text-slate-400 p-2 max-h-60 overflow-y-auto rounded whitespace-pre-wrap">{jobData.stdout || '(empty)'}</pre>
+                  )}
+                </>
+              )}
+              {(jobData.status === 'failed' || jobData.status === 'stopped') && (
+                <pre className="font-mono text-xs bg-red-950 text-red-300 p-2 max-h-60 overflow-y-auto rounded whitespace-pre-wrap">{jobData.stderr || jobData.stdout || '(empty)'}</pre>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/faq-pop/components/FunctionsPanel/StateTable.tsx
+++ b/frontend/src/features/faq-pop/components/FunctionsPanel/StateTable.tsx
@@ -1,0 +1,338 @@
+// @ts-nocheck
+import { useState, useEffect, useRef } from 'react';
+import { RefreshCw, Download, Upload, Trash2 } from 'lucide-react';
+import { getStateTable, uploadAuditedFile, downloadUrl, outputDownloadUrl, deleteFolder, deleteFile } from '../../api';
+import ColumnFilter from './ColumnFilter';
+
+function AuditCell({ row, onUploaded }) {
+  const inputRef = useRef(null);
+  const [uploading, setUploading] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleFile(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      await uploadAuditedFile(file, row.state, row.crop);
+      onUploaded?.();
+    } catch (err) {
+      alert(`Upload failed: ${err.message}`);
+    } finally {
+      setUploading(false);
+      e.target.value = '';
+    }
+  }
+
+  async function handleDelete() {
+    if (!row.audit_file) return;
+    if (!window.confirm('Delete audited file?')) return;
+    setDeleting(true);
+    try {
+      await deleteFile(row.audit_file);
+      onUploaded?.();
+    } catch (err) {
+      alert(`Delete failed: ${err.message}`);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {row.audit_file && (
+        <a
+          href={downloadUrl(row.audit_file)}
+          className="flex items-center gap-1 text-[10px] text-green-400 hover:text-green-300 transition-colors"
+          download
+        >
+          <Download size={11} /> {row.audit_file.split('/').pop()}
+        </a>
+      )}
+      <input ref={inputRef} type="file" accept=".csv" className="hidden" onChange={handleFile} disabled={uploading} />
+      <button
+        className={`flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border transition-colors cursor-pointer
+          ${uploading
+            ? 'border-border/40 text-muted-foreground/30 cursor-not-allowed'
+            : 'border-border text-muted-foreground hover:border-primary hover:text-primary'
+          }`}
+        onClick={() => inputRef.current?.click()}
+        disabled={uploading}
+      >
+        <Upload size={11} />
+        {uploading ? 'uploading…' : row.audit_file ? 'replace' : 'upload'}
+      </button>
+      {row.audit_file && (
+        <button
+          className={`flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border transition-colors cursor-pointer
+            ${deleting
+              ? 'border-border/40 text-muted-foreground/30 cursor-not-allowed'
+              : 'border-destructive/40 text-destructive/70 hover:border-destructive hover:text-destructive hover:bg-destructive/5'
+            }`}
+          onClick={handleDelete}
+          disabled={deleting}
+        >
+          <Trash2 size={11} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function StateTable({ refreshKey }) {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selectedRows, setSelectedRows] = useState(new Set());
+  const [deleting, setDeleting] = useState(false);
+  const selectAllRef = useRef(null);
+
+  const [stateFilter, setStateFilter] = useState([]);
+  const [cropFilter, setCropFilter] = useState([]);
+  const [domainFilter, setDomainFilter] = useState([]);
+  const [downloadFilter, setDownloadFilter] = useState([]);
+  const [auditFilter, setAuditFilter] = useState([]);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const d = await getStateTable();
+      setRows(d.rows || []);
+    } catch (err) {
+      setError(err.message || 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(); }, [refreshKey]);
+
+  const stateOptions = [...new Set(rows.map(r => r.state))].sort();
+  const cropOptions = [...new Set(rows.map(r => r.crop))].sort();
+  const domainOptions = [...new Set(rows.flatMap(r => r.domains || []))].sort();
+
+  const filtered = rows.filter(r =>
+    (stateFilter.length === 0 || stateFilter.includes(r.state)) &&
+    (cropFilter.length === 0 || cropFilter.includes(r.crop)) &&
+    (domainFilter.length === 0 || domainFilter.some(d => (r.domains || []).includes(d))) &&
+    (downloadFilter.length === 0 || downloadFilter.includes(r.downloaded ? 'downloaded' : 'not downloaded')) &&
+    (auditFilter.length === 0 || auditFilter.includes(r.audited ? 'audited' : 'not audited'))
+  );
+
+  const anyFilter = stateFilter.length > 0 || cropFilter.length > 0 || domainFilter.length > 0
+    || downloadFilter.length > 0 || auditFilter.length > 0;
+
+  function rowKey(row) { return `${row.state}__${row.crop}`; }
+
+  const allSelected = filtered.length > 0 && filtered.every(r => selectedRows.has(rowKey(r)));
+  const someSelected = filtered.some(r => selectedRows.has(rowKey(r)));
+  const selectedCount = filtered.filter(r => selectedRows.has(rowKey(r))).length;
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someSelected && !allSelected;
+    }
+  }, [someSelected, allSelected]);
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      setSelectedRows(new Set());
+    } else {
+      setSelectedRows(new Set(filtered.map(rowKey)));
+    }
+  }
+
+  function toggleRow(row) {
+    const key = rowKey(row);
+    setSelectedRows(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  async function deleteRow(row) {
+    if (!window.confirm(`Delete crop "${row.crop}" (${row.state})?\n\nThis will permanently remove the crop folder and all its contents.`)) return;
+    setDeleting(true);
+    try {
+      await deleteFolder(`outputs/repair/${row.state}/${row.crop}`);
+      setSelectedRows(prev => { const n = new Set(prev); n.delete(rowKey(row)); return n; });
+      await load();
+    } catch (err) {
+      alert(`Delete failed: ${err.message}`);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function deleteSelected() {
+    const toDelete = filtered.filter(r => selectedRows.has(rowKey(r)));
+    if (!toDelete.length) return;
+    if (!window.confirm(`Delete ${toDelete.length} crop folder(s)?\n\nThis will permanently remove all selected crop folders and their contents.`)) return;
+    setDeleting(true);
+    try {
+      for (const row of toDelete) {
+        await deleteFolder(`outputs/repair/${row.state}/${row.crop}`);
+      }
+      setSelectedRows(new Set());
+      await load();
+    } catch (err) {
+      alert(`Delete failed: ${err.message}`);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  if (loading) return (
+    <div className="flex items-center justify-center py-8 text-muted-foreground text-sm">
+      <RefreshCw size={14} className="animate-spin mr-2" /> Loading…
+    </div>
+  );
+
+  if (error) return (
+    <div className="flex items-center justify-between rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3">
+      <span className="text-sm text-destructive">{error}</span>
+      <button className="text-xs text-muted-foreground hover:text-foreground cursor-pointer" onClick={load}>retry</button>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-foreground">Pipeline Outputs</h2>
+        <div className="flex items-center gap-3">
+          {someSelected && (
+            <button
+              className={`flex items-center gap-1.5 text-xs px-2 py-1 rounded border transition-colors cursor-pointer
+                ${deleting
+                  ? 'border-border/40 text-muted-foreground/40 cursor-not-allowed'
+                  : 'border-destructive/50 text-destructive hover:bg-destructive/10'
+                }`}
+              onClick={deleteSelected}
+              disabled={deleting}
+            >
+              <Trash2 size={11} />
+              {deleting ? 'Deleting…' : `Delete ${selectedCount} selected`}
+            </button>
+          )}
+          {anyFilter && (
+            <span className="text-[10px] text-muted-foreground">
+              Showing {filtered.length} of {rows.length}
+            </span>
+          )}
+          <button
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            onClick={load}
+          >
+            <RefreshCw size={12} /> Refresh
+          </button>
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card px-4 py-8 text-center text-sm text-muted-foreground italic">
+          No pipeline outputs yet.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="w-full text-xs border-collapse">
+            <thead>
+              <tr className="border-b border-border bg-muted/30">
+                <th className="px-3 py-2 w-8">
+                  <input
+                    ref={selectAllRef}
+                    type="checkbox"
+                    checked={allSelected}
+                    onChange={toggleSelectAll}
+                    className="cursor-pointer accent-primary"
+                  />
+                </th>
+                <th className="text-left px-3 py-2 whitespace-nowrap">
+                  <ColumnFilter label="State" options={stateOptions} selected={stateFilter} onChange={setStateFilter} />
+                </th>
+                <th className="text-left px-3 py-2 whitespace-nowrap">
+                  <ColumnFilter label="Crop" options={cropOptions} selected={cropFilter} onChange={setCropFilter} />
+                </th>
+                <th className="text-left px-3 py-2">
+                  <ColumnFilter label="Domains" options={domainOptions} selected={domainFilter} onChange={setDomainFilter} />
+                </th>
+                <th className="text-left px-3 py-2 whitespace-nowrap">
+                  <ColumnFilter label="Output" options={['downloaded', 'not downloaded']} selected={downloadFilter} onChange={setDownloadFilter} />
+                </th>
+                <th className="text-left px-3 py-2 whitespace-nowrap">
+                  <ColumnFilter label="Audit" options={['audited', 'not audited']} selected={auditFilter} onChange={setAuditFilter} />
+                </th>
+                <th className="px-3 py-2 w-12"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="px-4 py-8 text-center text-sm text-muted-foreground italic">
+                    No rows match the current filters.
+                  </td>
+                </tr>
+              ) : (
+                filtered.map((row, idx) => (
+                  <tr key={`${row.state}__${row.crop}`} className={`border-b border-border/50 hover:bg-muted/20 transition-colors ${selectedRows.has(rowKey(row)) ? 'bg-primary/5' : idx % 2 === 0 ? '' : 'bg-muted/10'}`}>
+                    <td className="px-3 py-2 align-middle">
+                      <input
+                        type="checkbox"
+                        checked={selectedRows.has(rowKey(row))}
+                        onChange={() => toggleRow(row)}
+                        className="cursor-pointer accent-primary"
+                      />
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px] text-foreground whitespace-nowrap align-top">
+                      {row.state}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px] text-foreground whitespace-nowrap align-top">
+                      {row.crop}
+                    </td>
+                    <td className="px-3 py-2 align-top max-w-[220px]">
+                      {row.domains?.length > 0
+                        ? <span className="text-[10px] text-muted-foreground leading-relaxed">{row.domains.join(', ')}</span>
+                        : <span className="text-muted-foreground/30 text-[10px]">—</span>
+                      }
+                    </td>
+                    <td className="px-3 py-2 align-top whitespace-nowrap">
+                      {row.output_file
+                        ? <a
+                            href={outputDownloadUrl(row.state, row.crop)}
+                            className={`flex items-center gap-1 text-[10px] transition-colors ${row.downloaded ? 'text-green-400 hover:text-green-300' : 'text-primary hover:text-primary/80'}`}
+                            download
+                          >
+                            <Download size={11} /> {row.state}_{row.crop}
+                          </a>
+                        : <span className="text-muted-foreground/30">—</span>
+                      }
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <AuditCell row={row} onUploaded={load} />
+                    </td>
+                    <td className="px-3 py-2 align-middle">
+                      <button
+                        className={`flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border transition-colors cursor-pointer
+                          ${deleting
+                            ? 'border-border/40 text-muted-foreground/30 cursor-not-allowed'
+                            : 'border-destructive/40 text-destructive/70 hover:border-destructive hover:text-destructive hover:bg-destructive/5'
+                          }`}
+                        onClick={() => deleteRow(row)}
+                        disabled={deleting}
+                        title="Delete crop folder"
+                      >
+                        <Trash2 size={11} />
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/faq-pop/components/JobsPanel/PipelineOutput.tsx
+++ b/frontend/src/features/faq-pop/components/JobsPanel/PipelineOutput.tsx
@@ -1,0 +1,448 @@
+// @ts-nocheck
+import { useState } from 'react';
+
+const STAGE_LABELS = ['Screen', 'LLM Eval', 'Repair', 'Uniq Q', 'Dedup', 'Corpus', 'Q&A'];
+
+const COMPLETION_PATTERNS = [
+  /✓ Phase 1 complete/,
+  /✓ Phase 2 complete/,
+  /✓ Repair complete/,
+  /✓ Unique question extraction complete/,
+  /✓ Dedup complete/,
+  /✓ Corpus filter complete/,
+  /✓ Q&A generation complete/,
+];
+
+const AUTO_SKIP_STAGE = [
+  [/phase1_results\.pkl/, 0],
+  [/phase2_scores\.csv/, 1],
+  [/cluster_questions\.csv/, 2],
+  [/unique_question_mapping\.csv/, 3],
+  [/downstream output exists/, 4],
+  [/corpus_filtered_out\.csv/, 5],
+];
+
+export function parsePipelineOutput(stdout) {
+  if (!stdout) return null;
+  const m = stdout.match(/\[INFO\] (?:Filtered to|Found) \d+ unique crop\(s\): (.+)/);
+  if (!m) return null;
+
+  const allCrops = m[1].split(', ').map(c => c.trim());
+  const data = {};
+  allCrops.forEach(crop => {
+    data[crop] = {
+      name: crop,
+      stages: STAGE_LABELS.map(name => ({ name, status: 'pending' })),
+      overallStatus: 'pending',
+      qaProgress: null,
+    };
+  });
+
+  let currentCrop = null;
+  let currentStageIdx = -1;
+
+  for (const line of stdout.split('\n')) {
+    const bannerMatch = line.match(/^\s+KCC FAQ Pipeline\s*—\s*(.+)$/);
+    if (bannerMatch) {
+      const name = bannerMatch[1].trim();
+      const match = allCrops.find(c => c.toLowerCase() === name.toLowerCase());
+      if (match) {
+        currentCrop = match;
+        data[match].overallStatus = 'running';
+      }
+      continue;
+    }
+
+    if (line.includes('[auto-skip]') && currentCrop) {
+      for (const [pattern, idx] of AUTO_SKIP_STAGE) {
+        if (pattern.test(line)) {
+          data[currentCrop].stages[idx].status = 'done';
+          break;
+        }
+      }
+    }
+
+    const stageMatch = line.match(/Stage (\d+)\/7/);
+    if (stageMatch) {
+      currentStageIdx = parseInt(stageMatch[1]) - 1;
+      if (currentCrop && data[currentCrop].stages[currentStageIdx].status === 'pending') {
+        data[currentCrop].stages[currentStageIdx].status = 'active';
+      }
+      continue;
+    }
+
+    const cropLineMatch = line.match(/^\s+Crop\s+:\s+(.+)$/);
+    if (cropLineMatch && !currentCrop) {
+      const name = cropLineMatch[1].trim();
+      const match = allCrops.find(c => c.toLowerCase() === name.toLowerCase());
+      if (match) {
+        currentCrop = match;
+        data[match].overallStatus = 'running';
+        if (currentStageIdx === 0) data[match].stages[0].status = 'active';
+      }
+    }
+
+    for (let i = 0; i < COMPLETION_PATTERNS.length; i++) {
+      if (COMPLETION_PATTERNS[i].test(line) && currentCrop) {
+        data[currentCrop].stages[i].status = 'done';
+        if (i === 6) data[currentCrop].overallStatus = 'done';
+        break;
+      }
+    }
+
+    const warnMatch = line.match(/\[WARN\] Crop '(.+?)' failed:/);
+    if (warnMatch) {
+      const match = allCrops.find(c => c.toLowerCase() === warnMatch[1].toLowerCase());
+      if (match) {
+        const active = data[match].stages.find(s => s.status === 'active');
+        if (active) active.status = 'failed';
+        data[match].overallStatus = 'skipped';
+      }
+    }
+
+    const qaMatch = line.match(/Progress:\s+(\d+)\/(\d+)\s+rows/);
+    if (qaMatch && currentCrop) {
+      data[currentCrop].qaProgress = { done: parseInt(qaMatch[1]), total: parseInt(qaMatch[2]) };
+    }
+  }
+
+  return allCrops.map(c => data[c]);
+}
+
+const DOT = {
+  done:    'bg-green-500 border-green-500',
+  failed:  'bg-red-500 border-red-500',
+  active:  'bg-blue-400 border-blue-400 animate-pulse',
+  pending: 'bg-transparent border-muted-foreground/25',
+};
+
+const LABEL_COLOR = {
+  done:    'text-green-400',
+  failed:  'text-red-400',
+  active:  'text-blue-400',
+  pending: 'text-muted-foreground/35',
+};
+
+function StageBar({ stages }) {
+  return (
+    <div className="flex items-start w-full">
+      {stages.map((stage, i) => {
+        const isFirst = i === 0;
+        const isLast  = i === stages.length - 1;
+        const leftFill  = !isFirst && stages[i - 1].status === 'done';
+        const rightFill = !isLast  && stage.status === 'done';
+        return (
+          <div key={i} className="flex flex-col items-center flex-1 min-w-0">
+            <div className="flex items-center w-full">
+              <div className={`h-px flex-1 transition-colors ${isFirst ? 'invisible' : leftFill ? 'bg-green-500/50' : 'bg-border/40'}`} />
+              <div
+                className={`w-2 h-2 rounded-full border flex-shrink-0 transition-colors ${DOT[stage.status]}`}
+                title={`${stage.name}: ${stage.status}`}
+              />
+              <div className={`h-px flex-1 transition-colors ${isLast ? 'invisible' : rightFill ? 'bg-green-500/50' : 'bg-border/40'}`} />
+            </div>
+            <span className={`text-[8px] mt-0.5 text-center leading-none truncate w-full ${LABEL_COLOR[stage.status]}`}>
+              {stage.name}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const BADGE = {
+  done:    { label: 'Done',    cls: 'bg-green-500/15 text-green-400 border-green-500/30' },
+  skipped: { label: 'Skipped', cls: 'bg-muted/60 text-muted-foreground/55 border-border/60' },
+  running: { label: 'Running', cls: 'bg-blue-500/15 text-blue-400 border-blue-500/30' },
+  pending: { label: 'Pending', cls: 'bg-muted/30 text-muted-foreground/40 border-border/40' },
+};
+
+function CropCard({ crop }) {
+  const badge = BADGE[crop.overallStatus] || BADGE.pending;
+  const qaActive = crop.stages[6]?.status === 'active' && crop.qaProgress;
+  const qaPct = qaActive ? Math.round(crop.qaProgress.done / crop.qaProgress.total * 100) : null;
+  return (
+    <div className="bg-background/35 border border-border/50 rounded-md px-2.5 py-2">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-semibold text-foreground leading-none">{crop.name}</span>
+        <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded-full border leading-none ${badge.cls}`}>
+          {badge.label}
+        </span>
+      </div>
+      <StageBar stages={crop.stages} />
+      {qaActive && (
+        <div className="mt-1.5 flex items-center gap-1.5">
+          <div className="flex-1 h-1 bg-border/30 rounded-full overflow-hidden">
+            <div className="h-full bg-blue-400 transition-all" style={{ width: `${qaPct}%` }} />
+          </div>
+          <span className="text-[10px] text-blue-400 font-medium shrink-0">
+            {crop.qaProgress.done}/{crop.qaProgress.total} ({qaPct}%)
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function parsePrePipelineOutput(stdout) {
+  if (!stdout) return null;
+  if (!stdout.includes('State Filter') && !stdout.includes('Crop Normalization')) return null;
+
+  const result = {
+    stage1: { status: 'pending', state: null, inputFile: null, outputFile: null, rowsWritten: null },
+    stage2: { status: 'pending', crops: [], outputFile: null, rowsRemoved: null, rowsKept: null },
+  };
+
+  let currentStage = 0;
+
+  for (const line of stdout.split('\n')) {
+    if (/Stage 1\/2/.test(line)) { currentStage = 1; result.stage1.status = 'active'; }
+    if (/Stage 2\/2/.test(line)) { currentStage = 2; result.stage2.status = 'active'; }
+    if (/✓ State filter complete/.test(line)) result.stage1.status = 'done';
+    if (/✓ Crop normalization complete/.test(line)) result.stage2.status = 'done';
+
+    if (currentStage === 1) {
+      const stateM = line.match(/^\s+State\s+:\s+(.+)$/);
+      if (stateM) result.stage1.state = stateM[1].trim();
+      const inputM = line.match(/^\s+Input\s+:\s+(.+)$/);
+      if (inputM) result.stage1.inputFile = inputM[1].trim().split('/').pop();
+      const outputM = line.match(/^\s+Output\s+:\s+(.+)$/);
+      if (outputM) result.stage1.outputFile = outputM[1].trim().split('/').pop();
+      const rowsM = line.match(/([\d,]+) rows written/);
+      if (rowsM) result.stage1.rowsWritten = rowsM[1];
+    }
+
+    if (currentStage === 2) {
+      const cropsM = line.match(/^\s+Primary crops\s+:\s+(.+)$/);
+      if (cropsM) result.stage2.crops = cropsM[1].split(',').map(c => c.trim());
+      const outputM = line.match(/^\s+Output\s+:\s+(.+)$/);
+      if (outputM) result.stage2.outputFile = outputM[1].trim().split('/').pop();
+      const removedM = line.match(/([\d,]+) rows removed/);
+      if (removedM) result.stage2.rowsRemoved = removedM[1];
+      const keptM = line.match(/([\d,]+) rows kept/);
+      if (keptM) result.stage2.rowsKept = keptM[1];
+    }
+  }
+
+  return result.stage1.status === 'pending' ? null : result;
+}
+
+export function PrePipelineOutput({ stdout }) {
+  const [showRaw, setShowRaw] = useState(false);
+  const data = parsePrePipelineOutput(stdout);
+  if (!data) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-[11px]">
+          <span className="text-muted-foreground font-medium">Pre-pipeline</span>
+          {data.stage1.state && <span className="text-foreground font-semibold">{data.stage1.state}</span>}
+        </div>
+        <button
+          className="text-[10px] text-muted-foreground/50 hover:text-muted-foreground transition-colors cursor-pointer"
+          onClick={() => setShowRaw(v => !v)}
+        >
+          {showRaw ? 'hide log' : 'raw log'}
+        </button>
+      </div>
+
+      <div className="bg-background/35 border border-border/50 rounded-md px-2.5 py-2">
+        <StageBar stages={[
+          { name: 'State Filter', status: data.stage1.status },
+          { name: 'Crop Norm',    status: data.stage2.status },
+        ]} />
+      </div>
+
+      <div className="bg-background/35 border border-border/50 rounded-md px-2.5 py-2">
+        <div className="flex items-center justify-between mb-1.5">
+          <span className="text-xs font-semibold text-foreground">State Filter</span>
+          <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded-full border leading-none ${(BADGE[data.stage1.status] || BADGE.pending).cls}`}>
+            {(BADGE[data.stage1.status] || BADGE.pending).label}
+          </span>
+        </div>
+        <div className="flex flex-col gap-0.5 text-[10px] text-muted-foreground">
+          {data.stage1.state && <span>State: <span className="text-foreground">{data.stage1.state}</span></span>}
+          {data.stage1.rowsWritten && <span>Rows written: <span className="text-green-400 font-medium">{data.stage1.rowsWritten}</span></span>}
+          {data.stage1.outputFile && <span className="text-muted-foreground/50 truncate">{data.stage1.outputFile}</span>}
+        </div>
+      </div>
+
+      {data.stage2.status !== 'pending' && (
+        <div className="bg-background/35 border border-border/50 rounded-md px-2.5 py-2">
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-xs font-semibold text-foreground">Crop Normalization</span>
+            <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded-full border leading-none ${(BADGE[data.stage2.status] || BADGE.pending).cls}`}>
+              {(BADGE[data.stage2.status] || BADGE.pending).label}
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5 text-[10px] text-muted-foreground">
+            {data.stage2.crops.length > 0 && <span>{data.stage2.crops.length} primary crops</span>}
+            {data.stage2.rowsRemoved && data.stage2.rowsKept && (
+              <div className="flex items-center gap-1">
+                <span className="text-red-400/70">{data.stage2.rowsRemoved} removed</span>
+                <span className="text-muted-foreground/40">·</span>
+                <span className="text-green-400 font-medium">{data.stage2.rowsKept} kept</span>
+              </div>
+            )}
+            {data.stage2.outputFile && <span className="text-muted-foreground/50 truncate">{data.stage2.outputFile}</span>}
+          </div>
+        </div>
+      )}
+
+      {showRaw && (
+        <pre className="font-mono text-xs bg-slate-900 text-slate-400 p-2 max-h-60 overflow-y-auto rounded whitespace-pre-wrap mt-0.5">
+          {stdout || '(empty)'}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export function parsePostPipelineOutput(stdout) {
+  if (!stdout) return null;
+  if (!stdout.includes('LLM Deduplication')) return null;
+
+  const result = { stage1: 'done', stage2: 'pending', files: [] };
+  let cur = null;
+
+  for (const line of stdout.split('\n')) {
+    if (/LLM Deduplication/.test(line) && result.stage2 === 'pending') {
+      result.stage2 = 'active';
+    }
+    const pm = line.match(/Processing:\s+(\S+)\//);
+    if (pm) {
+      cur = { name: pm[1].trim() + '_faq.csv', originalSize: null, cleanedSize: null, status: 'active' };
+      result.files.push(cur);
+    }
+    const om = line.match(/Original Dataset Size:\s*(\d+)/);
+    if (om && cur) cur.originalSize = parseInt(om[1]);
+    const cm = line.match(/Cleaned Dataset Size:\s*(\d+)/);
+    if (cm && cur) cur.cleanedSize = parseInt(cm[1]);
+    if (/Saved:.*\/dedup_faq\.csv/.test(line) && cur) cur.status = 'done';
+    if (/✓ Deduplication complete/.test(line)) {
+      result.stage2 = 'done';
+      if (cur?.status === 'active') cur.status = 'done';
+    }
+  }
+
+  return result;
+}
+
+function PostFileCard({ file }) {
+  const crop = file.name.replace(/_faq\.csv$/, '').replace(/_/g, ' ');
+  const pct = file.originalSize && file.cleanedSize
+    ? Math.round((1 - file.cleanedSize / file.originalSize) * 100)
+    : null;
+  const badge = BADGE[file.status] || BADGE.pending;
+  return (
+    <div className="bg-background/35 border border-border/50 rounded-md px-2.5 py-2">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs font-semibold text-foreground capitalize leading-none">{crop}</span>
+        <span className={`text-[9px] font-medium px-1.5 py-0.5 rounded-full border leading-none ${badge.cls}`}>
+          {badge.label}
+        </span>
+      </div>
+      {file.originalSize != null && file.cleanedSize != null ? (
+        <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+          <span>{file.originalSize}</span>
+          <span className="text-muted-foreground/40">→</span>
+          <span className="text-green-400 font-medium">{file.cleanedSize}</span>
+          {pct != null && <span className="text-muted-foreground/50">({pct}% reduced)</span>}
+        </div>
+      ) : (
+        <span className="text-[10px] text-blue-400/70 animate-pulse">processing…</span>
+      )}
+    </div>
+  );
+}
+
+export function PostPipelineOutput({ stdout }) {
+  const [showRaw, setShowRaw] = useState(false);
+  const data = parsePostPipelineOutput(stdout);
+  if (!data) return null;
+
+  const doneCount    = data.files.filter(f => f.status === 'done').length;
+  const runningCount = data.files.filter(f => f.status === 'active').length;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-[11px]">
+          <span className="text-muted-foreground font-medium">{data.files.length} files</span>
+          {doneCount > 0    && <span className="text-green-400 font-semibold">{doneCount} done</span>}
+          {runningCount > 0 && <span className="text-blue-400 font-semibold">{runningCount} running</span>}
+        </div>
+        <button
+          className="text-[10px] text-muted-foreground/50 hover:text-muted-foreground transition-colors cursor-pointer"
+          onClick={() => setShowRaw(v => !v)}
+        >
+          {showRaw ? 'hide log' : 'raw log'}
+        </button>
+      </div>
+
+      <div className="bg-background/35 border border-border/50 rounded-md px-2.5 py-2">
+        <StageBar stages={[
+          { name: 'Collect', status: data.stage1 },
+          { name: 'Dedup',   status: data.stage2 },
+        ]} />
+      </div>
+
+      {data.files.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          {data.files.map((file, i) => (
+            <PostFileCard key={i} file={file} />
+          ))}
+        </div>
+      )}
+
+      {showRaw && (
+        <pre className="font-mono text-xs bg-slate-900 text-slate-400 p-2 max-h-60 overflow-y-auto rounded whitespace-pre-wrap mt-0.5">
+          {stdout || '(empty)'}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export default function PipelineOutput({ stdout }) {
+  const [showRaw, setShowRaw] = useState(false);
+  const crops = parsePipelineOutput(stdout);
+  if (!crops) return null;
+
+  const doneCount    = crops.filter(c => c.overallStatus === 'done').length;
+  const skippedCount = crops.filter(c => c.overallStatus === 'skipped').length;
+  const runningCount = crops.filter(c => c.overallStatus === 'running').length;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-[11px]">
+          <span className="text-muted-foreground font-medium">{crops.length} crops</span>
+          {doneCount > 0    && <span className="text-green-400 font-semibold">{doneCount} done</span>}
+          {runningCount > 0 && <span className="text-blue-400 font-semibold">{runningCount} running</span>}
+          {skippedCount > 0 && <span className="text-muted-foreground/55">{skippedCount} skipped</span>}
+        </div>
+        <button
+          className="text-[10px] text-muted-foreground/50 hover:text-muted-foreground transition-colors cursor-pointer"
+          onClick={() => setShowRaw(v => !v)}
+        >
+          {showRaw ? 'hide log' : 'raw log'}
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        {crops.map(crop => (
+          <CropCard key={crop.name} crop={crop} />
+        ))}
+      </div>
+
+      {showRaw && (
+        <pre className="font-mono text-xs bg-slate-900 text-slate-400 p-2 max-h-60 overflow-y-auto rounded whitespace-pre-wrap mt-0.5">
+          {stdout || '(empty)'}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -11,12 +11,12 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WhatsappHistoryRouteImport } from './routes/whatsapp-history'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as RequestQueueIndexRouteImport } from './routes/request-queue/index'
 import { Route as ProfileIndexRouteImport } from './routes/profile/index'
 import { Route as PaeExpertIndexRouteImport } from './routes/pae-expert/index'
 import { Route as NotificationsIndexRouteImport } from './routes/notifications/index'
 import { Route as HomeIndexRouteImport } from './routes/home/index'
 import { Route as HistoryIndexRouteImport } from './routes/history/index'
+import { Route as FlagsReportedIndexRouteImport } from './routes/flags-reported/index'
 import { Route as AuthIndexRouteImport } from './routes/auth/index'
 import { Route as AuditIndexRouteImport } from './routes/audit/index'
 
@@ -28,11 +28,6 @@ const WhatsappHistoryRoute = WhatsappHistoryRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const RequestQueueIndexRoute = RequestQueueIndexRouteImport.update({
-  id: '/request-queue/',
-  path: '/request-queue/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileIndexRoute = ProfileIndexRouteImport.update({
@@ -60,6 +55,11 @@ const HistoryIndexRoute = HistoryIndexRouteImport.update({
   path: '/history/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const FlagsReportedIndexRoute = FlagsReportedIndexRouteImport.update({
+  id: '/flags-reported/',
+  path: '/flags-reported/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthIndexRoute = AuthIndexRouteImport.update({
   id: '/auth/',
   path: '/auth/',
@@ -76,24 +76,24 @@ export interface FileRoutesByFullPath {
   '/whatsapp-history': typeof WhatsappHistoryRoute
   '/audit': typeof AuditIndexRoute
   '/auth': typeof AuthIndexRoute
+  '/flags-reported': typeof FlagsReportedIndexRoute
   '/history': typeof HistoryIndexRoute
   '/home': typeof HomeIndexRoute
   '/notifications': typeof NotificationsIndexRoute
   '/pae-expert': typeof PaeExpertIndexRoute
   '/profile': typeof ProfileIndexRoute
-  '/request-queue': typeof RequestQueueIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/whatsapp-history': typeof WhatsappHistoryRoute
   '/audit': typeof AuditIndexRoute
   '/auth': typeof AuthIndexRoute
+  '/flags-reported': typeof FlagsReportedIndexRoute
   '/history': typeof HistoryIndexRoute
   '/home': typeof HomeIndexRoute
   '/notifications': typeof NotificationsIndexRoute
   '/pae-expert': typeof PaeExpertIndexRoute
   '/profile': typeof ProfileIndexRoute
-  '/request-queue': typeof RequestQueueIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -101,12 +101,12 @@ export interface FileRoutesById {
   '/whatsapp-history': typeof WhatsappHistoryRoute
   '/audit/': typeof AuditIndexRoute
   '/auth/': typeof AuthIndexRoute
+  '/flags-reported/': typeof FlagsReportedIndexRoute
   '/history/': typeof HistoryIndexRoute
   '/home/': typeof HomeIndexRoute
   '/notifications/': typeof NotificationsIndexRoute
   '/pae-expert/': typeof PaeExpertIndexRoute
   '/profile/': typeof ProfileIndexRoute
-  '/request-queue/': typeof RequestQueueIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -115,36 +115,36 @@ export interface FileRouteTypes {
     | '/whatsapp-history'
     | '/audit'
     | '/auth'
+    | '/flags-reported'
     | '/history'
     | '/home'
     | '/notifications'
     | '/pae-expert'
     | '/profile'
-    | '/request-queue'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/whatsapp-history'
     | '/audit'
     | '/auth'
+    | '/flags-reported'
     | '/history'
     | '/home'
     | '/notifications'
     | '/pae-expert'
     | '/profile'
-    | '/request-queue'
   id:
     | '__root__'
     | '/'
     | '/whatsapp-history'
     | '/audit/'
     | '/auth/'
+    | '/flags-reported/'
     | '/history/'
     | '/home/'
     | '/notifications/'
     | '/pae-expert/'
     | '/profile/'
-    | '/request-queue/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -152,12 +152,12 @@ export interface RootRouteChildren {
   WhatsappHistoryRoute: typeof WhatsappHistoryRoute
   AuditIndexRoute: typeof AuditIndexRoute
   AuthIndexRoute: typeof AuthIndexRoute
+  FlagsReportedIndexRoute: typeof FlagsReportedIndexRoute
   HistoryIndexRoute: typeof HistoryIndexRoute
   HomeIndexRoute: typeof HomeIndexRoute
   NotificationsIndexRoute: typeof NotificationsIndexRoute
   PaeExpertIndexRoute: typeof PaeExpertIndexRoute
   ProfileIndexRoute: typeof ProfileIndexRoute
-  RequestQueueIndexRoute: typeof RequestQueueIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -174,13 +174,6 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/request-queue/': {
-      id: '/request-queue/'
-      path: '/request-queue'
-      fullPath: '/request-queue'
-      preLoaderRoute: typeof RequestQueueIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/profile/': {
@@ -218,6 +211,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HistoryIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/flags-reported/': {
+      id: '/flags-reported/'
+      path: '/flags-reported'
+      fullPath: '/flags-reported'
+      preLoaderRoute: typeof FlagsReportedIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/auth/': {
       id: '/auth/'
       path: '/auth'
@@ -240,12 +240,12 @@ const rootRouteChildren: RootRouteChildren = {
   WhatsappHistoryRoute: WhatsappHistoryRoute,
   AuditIndexRoute: AuditIndexRoute,
   AuthIndexRoute: AuthIndexRoute,
+  FlagsReportedIndexRoute: FlagsReportedIndexRoute,
   HistoryIndexRoute: HistoryIndexRoute,
   HomeIndexRoute: HomeIndexRoute,
   NotificationsIndexRoute: NotificationsIndexRoute,
   PaeExpertIndexRoute: PaeExpertIndexRoute,
   ProfileIndexRoute: ProfileIndexRoute,
-  RequestQueueIndexRoute: RequestQueueIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,4 +22,23 @@ export default defineConfig({
       "@": resolve(__dirname, "./src"),
     },
   },
+
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:4000",
+        changeOrigin: true,
+      },
+      "/faq-api": {
+        target: "http://localhost:8031",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/faq-api/, ""),
+      },
+      "/pop-api": {
+        target: "http://localhost:8032",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/pop-api/, ""),
+      },
+    },
+  },
 });


### PR DESCRIPTION
  FAQ / POP Data Processing Dashboard
  
  Adds an internal dashboard for managing and running the FAQ clustering and POP translation data
  pipelines.

  What's included

  - DataProcessingDashboard — tabbed shell with two panels: FAQ-Cluster and POP-Translation
  - FAQ-Cluster panel — file tree browser (upload, rename, delete, chunked upload for large files),
  pipeline run controls (pre / pipeline / post / full), job status tracking, and output download
  - POP-Translation panel — state/crop tree management (create, upload docs, delete), translation
  job runs, and output download per document
  - api.ts — typed fetch client for both the FAQ server (VITE_FAQ_API_URL) and POP server
  (VITE_POP_API_URL); both are optional env vars so the dashboard degrades gracefully if not
  configured

  Notes

  - Both env vars are optional (required: false) — no crash if unset in a given environment
  - Dashboard is internal-facing (not exposed to farmers); accessible via the existing sidebar route