### PR TITLE
Move MCP secrets to environment configuration

### DIFF
--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -3,6 +3,10 @@ MONGODB_URI=mongodb://localhost:27017/
 FAQ_DATABASE_NAME=ajrasakha_faq
 FAQ_COLLECTION_NAME=faq_data
 
+# External service keys
+SARVAM_API_KEY=
+DATA_GOV_API_KEY=
+
 # CSV Data File
 # Path to the FAQ CSV file with columns: Title, Link, Refined KCC Query [HF], English Answer, Hindi Answer
 CSV_FILE_PATH=FAQ Question Sheet - Sheet1.csv

--- a/mcp/constants.py
+++ b/mcp/constants.py
@@ -1,14 +1,22 @@
-from urllib.parse import quote_plus
+import os
 from llama_index.core.prompts import PromptTemplate
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"{name} environment variable is required")
+    return value
 
 # Vector Database
-USERNAME = quote_plus("agriai")
-PASSWORD = quote_plus("agriai1224")
-MONGODB_URI = f"mongodb+srv://{USERNAME}:{PASSWORD}@staging.1fo96dy.mongodb.net/?retryWrites=true&w=majority&appName=staging"
+MONGODB_URI = require_env("MONGODB_URI")
 DB_NAME = "golden_db"
 INDEX_NAME = "vector_index"
 SARVAM_URL = "https://api.sarvam.ai/speech-to-text"
-API_KEY = "sk_s2j7cwtf_frU76CJMmVQi3Y4jwBfY3M3m"
+API_KEY = os.getenv("SARVAM_API_KEY")
 
 
 # Database Collections

--- a/mcp/faq.py
+++ b/mcp/faq.py
@@ -50,11 +50,8 @@ load_dotenv()
 # Initialize FastMCP server
 mcp = FastMCP("faq-video")
 
-user = "agriai"
-password = "agriai1224"
-
 # MongoDB connection settings
-MONGODB_URI = os.getenv("MONGODB_URI", f"mongodb+srv://{user}:{password}@staging.1fo96dy.mongodb.net/?retryWrites=true&w=majority&appName=staging")
+MONGODB_URI = os.getenv("MONGODB_URI")
 DATABASE_NAME = os.getenv("FAQ_DATABASE_NAME", "golden_db")
 COLLECTION_NAME = os.getenv("FAQ_COLLECTION_NAME", "faq")
 
@@ -71,6 +68,10 @@ def initialize_connections():
     """Initialize MongoDB connection and embedding model."""
     global db_client, db_collection, embedding_model
     
+    if not MONGODB_URI:
+        print("MONGODB_URI is required to start the FAQ MCP server")
+        return False
+
     try:
         # Initialize MongoDB client
         db_client = MongoClient(MONGODB_URI, serverSelectionTimeoutMS=5000)

--- a/mcp/mcp_containers/docker-compose.yml
+++ b/mcp/mcp_containers/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       context: ./golden_dataset
       dockerfile: Dockerfile
     container_name: golden-dataset-mcp
+    env_file:
+      - path: ../.env
+        required: false
     ports:
       - "9001:9001"
     volumes:
@@ -17,6 +20,9 @@ services:
       context: ./pop
       dockerfile: Dockerfile
     container_name: pop-mcp
+    env_file:
+      - path: ../.env
+        required: false
     ports:
       - "9002:9002"
     volumes:
@@ -28,6 +34,9 @@ services:
       context: ./market
       dockerfile: Dockerfile
     container_name: market-mcp
+    env_file:
+      - path: ../.env
+        required: false
     ports:
       - "9003:9003"
     restart: unless-stopped
@@ -37,6 +46,9 @@ services:
       context: ./weather
       dockerfile: Dockerfile
     container_name: weather-mcp
+    env_file:
+      - path: ../.env
+        required: false
     ports:
       - "9004:9004"
     restart: unless-stopped
@@ -46,6 +58,9 @@ services:
       context: ./faq
       dockerfile: Dockerfile
     container_name: faq-mcp
+    env_file:
+      - path: ../.env
+        required: false
     ports:
       - "9005:9005"
     volumes:
@@ -60,7 +75,8 @@ services:
     ports:
       - "9012:9012"
     env_file:
-      - ./review-search-mcp/.env
+      - path: ./review-search-mcp/.env
+        required: false
     environment:
       - MONGODB_URI=${MONGODB_URI}
       - DATABASE_NAME=${DATABASE_NAME:-agriai}

--- a/mcp/mcp_containers/faq/constants.py
+++ b/mcp/mcp_containers/faq/constants.py
@@ -1,14 +1,22 @@
-from urllib.parse import quote_plus
+import os
 from llama_index.core.prompts import PromptTemplate
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"{name} environment variable is required")
+    return value
 
 # Vector Database
-import os
-
-MONGODB_URI = os.getenv("MONGODB_URI")
+MONGODB_URI = require_env("MONGODB_URI")
 DB_NAME = "golden_db"
 INDEX_NAME = "vector_index"
 SARVAM_URL = "https://api.sarvam.ai/speech-to-text"
-API_KEY = "sk_s2j7cwtf_frU76CJMmVQi3Y4jwBfY3M3m"
+API_KEY = os.getenv("SARVAM_API_KEY")
 
 
 # Database Collections

--- a/mcp/mcp_containers/faq/faq.py
+++ b/mcp/mcp_containers/faq/faq.py
@@ -50,11 +50,8 @@ load_dotenv()
 # Initialize FastMCP server
 mcp = FastMCP("faq-video")
 
-user = "agriai"
-password = "agriai1224"
-
 # MongoDB connection settings
-MONGODB_URI = os.getenv("MONGODB_URI", f"mongodb+srv://{user}:{password}@staging.1fo96dy.mongodb.net/?retryWrites=true&w=majority&appName=staging")
+MONGODB_URI = os.getenv("MONGODB_URI")
 DATABASE_NAME = os.getenv("FAQ_DATABASE_NAME", "golden_db")
 COLLECTION_NAME = os.getenv("FAQ_COLLECTION_NAME", "faq")
 
@@ -71,6 +68,10 @@ def initialize_connections():
     """Initialize MongoDB connection and embedding model."""
     global db_client, db_collection, embedding_model
     
+    if not MONGODB_URI:
+        print("MONGODB_URI is required to start the FAQ MCP server")
+        return False
+
     try:
         # Initialize MongoDB client
         db_client = MongoClient(MONGODB_URI, serverSelectionTimeoutMS=5000)

--- a/mcp/mcp_containers/golden_dataset/constants.py
+++ b/mcp/mcp_containers/golden_dataset/constants.py
@@ -1,13 +1,22 @@
-from urllib.parse import quote_plus
-from llama_index.core.prompts import PromptTemplate
-
 import os
+from llama_index.core.prompts import PromptTemplate
+from dotenv import load_dotenv
 
-MONGODB_URI = os.getenv("MONGODB_URI")
+load_dotenv()
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
+MONGODB_URI = require_env("MONGODB_URI")
 DB_NAME = "golden_db"
 INDEX_NAME = "vector_index"
 SARVAM_URL = "https://api.sarvam.ai/speech-to-text"
-API_KEY = "sk_s2j7cwtf_frU76CJMmVQi3Y4jwBfY3M3m"
+API_KEY = os.getenv("SARVAM_API_KEY")
 
 
 # Database Collections

--- a/mcp/mcp_containers/market/constants.py
+++ b/mcp/mcp_containers/market/constants.py
@@ -1,14 +1,22 @@
-from urllib.parse import quote_plus
+import os
 from llama_index.core.prompts import PromptTemplate
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"{name} environment variable is required")
+    return value
 
 # Vector Database
-USERNAME = quote_plus("agriai")
-PASSWORD = quote_plus("agriai1224")
-MONGODB_URI = f"mongodb+srv://{USERNAME}:{PASSWORD}@staging.1fo96dy.mongodb.net/?retryWrites=true&w=majority&appName=staging"
+MONGODB_URI = require_env("MONGODB_URI")
 DB_NAME = "golden_db"
 INDEX_NAME = "vector_index"
 SARVAM_URL = "https://api.sarvam.ai/speech-to-text"
-API_KEY = "sk_s2j7cwtf_frU76CJMmVQi3Y4jwBfY3M3m"
+API_KEY = os.getenv("SARVAM_API_KEY")
 
 
 # Database Collections

--- a/mcp/mcp_containers/pop/constants.py
+++ b/mcp/mcp_containers/pop/constants.py
@@ -1,11 +1,21 @@
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
-MONGODB_URI = os.getenv("MONGODB_URI")
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
+MONGODB_URI = require_env("MONGODB_URI")
 DB_NAME = "golden_db"
 INDEX_NAME = "vector_index"
 SARVAM_URL = "https://api.sarvam.ai/speech-to-text"
-API_KEY = "sk_s2j7cwtf_frU76CJMmVQi3Y4jwBfY3M3m"
+API_KEY = os.getenv("SARVAM_API_KEY")
 
 
 # Database Collections

--- a/mcp/mcp_containers/weather/constants.py
+++ b/mcp/mcp_containers/weather/constants.py
@@ -1,14 +1,22 @@
-from urllib.parse import quote_plus
+import os
 from llama_index.core.prompts import PromptTemplate
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"{name} environment variable is required")
+    return value
 
 # Vector Database
-USERNAME = quote_plus("agriai")
-PASSWORD = quote_plus("agriai1224")
-MONGODB_URI = f"mongodb+srv://{USERNAME}:{PASSWORD}@staging.1fo96dy.mongodb.net/?retryWrites=true&w=majority&appName=staging"
+MONGODB_URI = require_env("MONGODB_URI")
 DB_NAME = "golden_db"
 INDEX_NAME = "vector_index"
 SARVAM_URL = "https://api.sarvam.ai/speech-to-text"
-API_KEY = "sk_s2j7cwtf_frU76CJMmVQi3Y4jwBfY3M3m"
+API_KEY = os.getenv("SARVAM_API_KEY")
 
 
 # Database Collections

--- a/mcp/other_markets/docker-compose.yml
+++ b/mcp/other_markets/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   mcp-server:
     build: .
     container_name: mcp-server
+    env_file:
+      - path: ../.env
+        required: false
     ports:
       - "8010:8000"
     command: python unified_mandi_prices.py

--- a/mcp/other_markets/market_data_gov.py
+++ b/mcp/other_markets/market_data_gov.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from datetime import datetime, timedelta
 from difflib import SequenceMatcher
 from pathlib import Path
@@ -20,7 +21,7 @@ except ImportError:
 
 # ================= CONFIG =================
 
-API_KEY = "579b464db66ec23bdd000001d7142eeff5b24f194f92d9870b3571fd"
+API_KEY = os.getenv("DATA_GOV_API_KEY")
 RESOURCE_ID = "35985678-0d79-46b4-9ed6-6f13308a1d24"
 
 BASE_URL = f"https://api.data.gov.in/resource/{RESOURCE_ID}"
@@ -124,6 +125,13 @@ def _parse_dd_mm_yyyy(value: str) -> datetime | None:
 # ================= CORE REQUEST =================
 
 async def _request(params: dict[str, Any]) -> dict[str, Any]:
+    if not API_KEY:
+        return {
+            "success": False,
+            "error_type": "missing_api_key",
+            "error": "DATA_GOV_API_KEY environment variable is required.",
+        }
+
     query = {
         "api-key": API_KEY,
         "format": "json",

--- a/mcp/other_markets/server.py
+++ b/mcp/other_markets/server.py
@@ -1,5 +1,6 @@
 from fastmcp import FastMCP
 import aiohttp
+import os
 from playwright.async_api import async_playwright
 from get_data import parse_mandi_html
 
@@ -140,11 +141,15 @@ async def get_daily_market_prices(
     - arrival_date: Arrival Date in "dd/MM/yyyy" format (e.g. "18/06/2010")
     - limit: Number of records to return (default 10)
     """
+    api_key = os.getenv("DATA_GOV_API_KEY")
+    if not api_key:
+        return {"error": "DATA_GOV_API_KEY environment variable is required."}
+
     url = "https://api.data.gov.in/resource/35985678-0d79-46b4-9ed6-6f13308a1d24"
     import urllib.parse
     import yarl
     
-    query = f"api-key=579b464db66ec23bdd0000019caa65074d924b6d6b8473dc337b0bca&format=json&limit={limit}"
+    query = f"api-key={urllib.parse.quote(api_key)}&format=json&limit={limit}"
     
     if state:
         query += f"&filters[State]={urllib.parse.quote(state)}"

--- a/mcp/scripts/ingest_csv_faq.py
+++ b/mcp/scripts/ingest_csv_faq.py
@@ -33,7 +33,7 @@ from pymongo import MongoClient
 load_dotenv()
 
 # Configuration
-MONGODB_URI = os.getenv("MONGODB_URI", "mongodb+srv://agriai:agriai1224@staging.1fo96dy.mongodb.net/?retryWrites=true&w=majority&appName=staging")
+MONGODB_URI = os.getenv("MONGODB_URI")
 DATABASE_NAME = os.getenv("FAQ_DATABASE_NAME", "golden_db")
 COLLECTION_NAME = os.getenv("FAQ_COLLECTION_NAME", "faq")
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "BAAI/bge-large-en")
@@ -56,6 +56,10 @@ class CSVFAQIngestion:
     
     def _initialize_mongodb(self):
         """Initialize MongoDB connection."""
+        if not MONGODB_URI:
+            print("MONGODB_URI is required for FAQ ingestion")
+            sys.exit(1)
+
         try:
             self.db_client = MongoClient(MONGODB_URI, serverSelectionTimeoutMS=5000)
             self.db_client.server_info()
@@ -157,7 +161,7 @@ class CSVFAQIngestion:
             # Check if entry already exists (by link)
             existing = self.db_collection.find_one({"link": faq_entry['link']})
             if existing:
-                print(f"⚠️  Entry already exists: {faq_entry['link']}")z
+                print(f"⚠️  Entry already exists: {faq_entry['link']}")
                 return False  # Already exists
             
             # Generate embedding for the query


### PR DESCRIPTION
# Security: move MCP credentials and API keys to environment variables

## Summary

This PR removes committed secrets from AjraSakha MCP code paths and replaces them with environment-driven configuration.

It covers:

- MongoDB connection credentials previously embedded in MCP constants and FAQ runtime code.
- Sarvam API key values repeated across MCP container constants.
- data.gov.in API keys embedded in market-price tools.
- A syntax typo in the FAQ CSV ingestion script that prevented the duplicate-entry branch from running.

## Where the problem was

- `mcp/constants.py`
- `mcp/faq.py`
- `mcp/scripts/ingest_csv_faq.py`
- `mcp/mcp_containers/faq/constants.py`
- `mcp/mcp_containers/faq/faq.py`
- `mcp/mcp_containers/weather/constants.py`
- `mcp/mcp_containers/market/constants.py`
- `mcp/mcp_containers/pop/constants.py`
- `mcp/mcp_containers/golden_dataset/constants.py`
- `mcp/other_markets/market_data_gov.py`
- `mcp/other_markets/server.py`
- `mcp/.env.example`

## Root cause

Runtime secrets were stored directly in source files instead of being loaded from deployment configuration.

Redacted vulnerable shape before this change:

```py
USERNAME = quote_plus("<database-user>")
PASSWORD = quote_plus("<database-password>")
MONGODB_URI = f"mongodb+srv://{USERNAME}:{PASSWORD}@<cluster-host>/..."
API_KEY = "<committed-api-key>"
```

The FAQ server and ingestion paths also had a fallback URI with embedded database credentials, so even setting `MONGODB_URI` was optional.

## Risk

Committed credentials can be copied from repository history, logs, forks, or local clones. If still valid, they may allow unauthorized database access or API usage. Even after rotation, keeping the pattern in code increases the chance of future secret leaks.

## What changed

- Replaced embedded MongoDB connection values with `os.getenv("MONGODB_URI")`.
- Replaced embedded Sarvam API keys with `os.getenv("SARVAM_API_KEY")`.
- Replaced embedded data.gov.in API keys with `os.getenv("DATA_GOV_API_KEY")`.
- Added explicit missing-config checks for FAQ MCP startup, FAQ ingestion, and data.gov request helpers.
- Added fail-fast `MONGODB_URI` loading in MCP constants so direct entrypoints stop with a clear configuration error instead of calling `MongoClient(None)`.
- Wired shared MCP Docker services and the `other_markets` Docker service to load environment variables from the parent MCP `.env` file when present.
- Updated `mcp/.env.example` with the required variable names.
- Fixed the stray `z` suffix in `mcp/scripts/ingest_csv_faq.py`.

## Why this fixes it

The repository no longer contains the exposed credential values, and local/deployed environments must provide secrets through environment variables. This keeps deployment behavior configurable while preventing accidental leakage through source control.

The previous keys should still be rotated server-side because removing them from the repository does not invalidate values that may already have been copied.

## Safe validation plan

Run these checks only in local development or an authorized staging environment:

- `rg` for the previously exposed MongoDB password, MongoDB URI prefix, Sarvam key prefix, and data.gov keys should return no source-code matches.
- Starting the FAQ MCP server without `MONGODB_URI` should fail closed with a clear configuration error.
- Running FAQ ingestion without `MONGODB_URI` should exit with a clear configuration error.
- Running market data tools without `DATA_GOV_API_KEY` should return a missing-configuration error instead of silently using a committed key.
- `docker compose -f mcp/mcp_containers/docker-compose.yml config --quiet` should parse successfully. A warning about missing `MONGODB_URI` is acceptable in a local clone without secrets; the containerized service itself will fail closed until a real secret is provided.
- `docker compose -f mcp/other_markets/docker-compose.yml config --quiet` should parse successfully.
- With valid local `.env` values, the same MCP tools should continue to start and call their external services.

## Files changed

- `mcp/.env.example`
- `mcp/constants.py`
- `mcp/faq.py`
- `mcp/scripts/ingest_csv_faq.py`
- `mcp/mcp_containers/docker-compose.yml`
- `mcp/mcp_containers/faq/constants.py`
- `mcp/mcp_containers/faq/faq.py`
- `mcp/mcp_containers/weather/constants.py`
- `mcp/mcp_containers/market/constants.py`
- `mcp/mcp_containers/pop/constants.py`
- `mcp/mcp_containers/golden_dataset/constants.py`
- `mcp/other_markets/market_data_gov.py`
- `mcp/other_markets/server.py`
- `mcp/other_markets/docker-compose.yml`
