### PR TITLE
fix(adapter): authenticate desk question PUT with REVIEWER_DESK_API_KEY

### DIFF
--- a/mcp/langgraph-openai-adapter/.env.example
+++ b/mcp/langgraph-openai-adapter/.env.example
@@ -18,6 +18,8 @@ LOCATION_SYNC_TO_DB=true
 
 # Desk API for linking reviewer question_id to client userId / messageId after upload
 REVIEWER_DESK_API_BASE_URL=https://desk.vicharanashala.ai/api
+# Sent as x-internal-api-key on desk PUT /questions/{id}
+REVIEWER_DESK_API_KEY=
 
 # Passed to LangGraph as configurable.question_source (reviewer MCP POST only; not sent on desk PUT)
 QUESTION_SOURCE=AJRASAKHA

--- a/mcp/langgraph-openai-adapter/config.py
+++ b/mcp/langgraph-openai-adapter/config.py
@@ -19,6 +19,7 @@ LANGGRAPH_API_KEY = os.getenv("LANGGRAPH_API_KEY", "not_required")
 REVIEWER_DESK_API_BASE_URL = os.getenv(
     "REVIEWER_DESK_API_BASE_URL", "https://desk.vicharanashala.ai/api"
 ).rstrip("/")
+REVIEWER_DESK_API_KEY = os.getenv("REVIEWER_DESK_API_KEY", "").strip()
 
 # Source sent to upload_question_to_reviewer_system (adapter sets this; client does not)
 QUESTION_SOURCE = os.getenv("QUESTION_SOURCE", "AJRASAKHA").strip()

--- a/mcp/langgraph-openai-adapter/reviewer_question.py
+++ b/mcp/langgraph-openai-adapter/reviewer_question.py
@@ -8,7 +8,11 @@ from typing import Any
 
 import httpx
 
-from config import REQUEST_TIMEOUT, REVIEWER_DESK_API_BASE_URL
+from config import (
+    REQUEST_TIMEOUT,
+    REVIEWER_DESK_API_BASE_URL,
+    REVIEWER_DESK_API_KEY,
+)
 
 logger = logging.getLogger("langgraph-openai-adapter")
 
@@ -133,6 +137,13 @@ async def fetch_thread_messages(
     return messages if isinstance(messages, list) else []
 
 
+def _desk_request_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if REVIEWER_DESK_API_KEY:
+        headers["x-internal-api-key"] = REVIEWER_DESK_API_KEY
+    return headers
+
+
 async def update_desk_question(
     question_id: str,
     user_id: str,
@@ -146,9 +157,15 @@ async def update_desk_question(
         "threadId": thread_id,
     }
 
+    if not REVIEWER_DESK_API_KEY:
+        logger.warning(
+            "REVIEWER_DESK_API_KEY is not set; desk PUT for question %s may fail authentication",
+            question_id,
+        )
+
     timeout = httpx.Timeout(REQUEST_TIMEOUT, connect=10.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
-        response = await client.put(url, json=payload, headers={"Content-Type": "application/json"})
+        response = await client.put(url, json=payload, headers=_desk_request_headers())
 
     if response.is_success:
         logger.info(

--- a/mcp/langgraph-openai-adapter/test_reviewer_question.py
+++ b/mcp/langgraph-openai-adapter/test_reviewer_question.py
@@ -1,9 +1,26 @@
 """Unit tests for reviewer question_id extraction (no live API)."""
 
 from reviewer_question import (
+    _desk_request_headers,
     extract_question_id_from_messages,
     resolve_client_ids,
 )
+
+
+def test_desk_request_headers_includes_api_key(monkeypatch):
+    monkeypatch.setattr(
+        "reviewer_question.REVIEWER_DESK_API_KEY",
+        "annam_conversation_api_key_1810",
+    )
+    headers = _desk_request_headers()
+    assert headers["Content-Type"] == "application/json"
+    assert headers["x-internal-api-key"] == "annam_conversation_api_key_1810"
+
+
+def test_desk_request_headers_without_api_key(monkeypatch):
+    monkeypatch.setattr("reviewer_question.REVIEWER_DESK_API_KEY", "")
+    headers = _desk_request_headers()
+    assert headers == {"Content-Type": "application/json"}
 
 
 def test_resolve_client_ids_from_headers():


### PR DESCRIPTION
Send x-internal-api-key when linking userId, messageId, and threadId after LangGraph upload so desk updates do not fail with 401.