### PR TITLE
Implement Date Range Filtering on Chatbot Analytics Cards

### DIFF
--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -818,7 +818,11 @@ async getUserQuestionsData(
   async getClosedAndNotifedData(
     @QueryParam('source')
     source: string= 'vicharanashala',
+    @QueryParam('startDate')
+    startDate?: string,
+    @QueryParam('endDate')
+    endDate?: string,
   ): Promise<any> {
-    return await this.chatbotService.getClosedAndNotifedData(source);
+    return await this.chatbotService.getClosedAndNotifedData(source, startDate, endDate);
   }
 }

--- a/backend/src/modules/chatbot/interfaces/IChatbotService.ts
+++ b/backend/src/modules/chatbot/interfaces/IChatbotService.ts
@@ -154,5 +154,5 @@ export interface IChatbotService {
       startDate?: Date,
       endDate?: Date,): Promise<any>;
   getUserQuestionsData(userEmail: string, source?: string, userType?: string, page?: number, limit?: number): Promise<any>;
-  getClosedAndNotifedData(source?: string): Promise<any> 
+  getClosedAndNotifedData(source?: string, startDate?: string, endDate?: string): Promise<any> 
 }

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -2464,15 +2464,18 @@ export class ChatbotService extends BaseService implements IChatbotService {
     };
   }
 
-  async getClosedAndNotifedData(source?: string): Promise<any> {
+  async getClosedAndNotifedData(source?: string, startDateStr?: string, endDateStr?: string): Promise<any> {
+    const startDate = startDateStr ? new Date(startDateStr) : undefined;
+    const endDate = endDateStr ? new Date(endDateStr) : undefined;
+
     const [
       closedVsTotalQuestions,
       notifiedVsClosed,
       closedInLastTwoHours,
     ] = await Promise.all([
-      this.chatbotRepository.getClosedVsTotalQuestions(source),
-      this.chatbotRepository.getNotifiedVsClosed(source),
-      this.chatbotRepository.getClosedInLastTwoHours(source),
+      this.chatbotRepository.getClosedVsTotalQuestions(source, startDate, endDate),
+      this.chatbotRepository.getNotifiedVsClosed(source, startDate, endDate),
+      this.chatbotRepository.getClosedInLastTwoHours(source, startDate, endDate),
     ]);
 
     return {

--- a/backend/src/shared/database/interfaces/IChatbotRepository.ts
+++ b/backend/src/shared/database/interfaces/IChatbotRepository.ts
@@ -500,11 +500,11 @@ export interface IChatbotRepository {
     userType?: string,
   ): Promise<{ label: string; totalQueries: number }>;
 
-  getClosedVsTotalQuestions(source: string):Promise<any>;
+  getClosedVsTotalQuestions(source: string, startDate?: Date, endDate?: Date):Promise<any>;
 
-  getNotifiedVsClosed(source?: string):Promise<any>;
+  getNotifiedVsClosed(source?: string, startDate?: Date, endDate?: Date):Promise<any>;
 
-  getClosedInLastTwoHours(source?: string): Promise<any>;
+  getClosedInLastTwoHours(source?: string, startDate?: Date, endDate?: Date): Promise<any>;
 }
 
 export interface ChatbotConversationData {

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -7576,7 +7576,7 @@ export class ChatbotRepository implements IChatbotRepository {
     }
   }
 
-  async getClosedVsTotalQuestions(source: string): Promise<any> {
+  async getClosedVsTotalQuestions(source: string, startDate?: Date, endDate?: Date): Promise<any> {
     try {
       await this.initReviewSystem();
       const matchStage: any = {};
@@ -7584,6 +7584,11 @@ export class ChatbotRepository implements IChatbotRepository {
         source = 'AJRASAKHA';
       }
       matchStage.source = source.toUpperCase();
+      if (startDate || endDate) {
+        matchStage.createdAt = {};
+        if (startDate) matchStage.createdAt.$gte = startDate;
+        if (endDate) matchStage.createdAt.$lte = endDate;
+      }
       const result = await this.QuestionCollection.aggregate([
         {
           $match: matchStage,
@@ -7618,7 +7623,11 @@ export class ChatbotRepository implements IChatbotRepository {
         },
       ]).toArray();
 
-      return result[0];
+      return result[0] || {
+        totalQuestions: 0,
+        closedQuestions: 0,
+        inReviewQuestions: 0,
+      };
     } catch (error) {
       throw new InternalServerError(
         `Failed to get closed vs total questions count: ${error}`,
@@ -7626,7 +7635,7 @@ export class ChatbotRepository implements IChatbotRepository {
     }
   }
 
-  async getNotifiedVsClosed(source?: string): Promise<any> {
+  async getNotifiedVsClosed(source?: string, startDate?: Date, endDate?: Date): Promise<any> {
     try {
       await this.initReviewSystem();
 
@@ -7635,6 +7644,12 @@ export class ChatbotRepository implements IChatbotRepository {
         source = 'AJRASAKHA';
       }
       matchStage.source = source.toUpperCase();
+
+      if (startDate || endDate) {
+        matchStage.createdAt = {};
+        if (startDate) matchStage.createdAt.$gte = startDate;
+        if (endDate) matchStage.createdAt.$lte = endDate;
+      }
 
       const [result] = await this.QuestionCollection.aggregate([
         {
@@ -7691,8 +7706,8 @@ export class ChatbotRepository implements IChatbotRepository {
 
       return {
         ...(result || {
-          closed: 0,
           notified: 0,
+          notNotified: 0,
         }),
         untrackedClosedQuestions,
       };
@@ -7703,21 +7718,29 @@ export class ChatbotRepository implements IChatbotRepository {
     }
   }
 
-  async getClosedInLastTwoHours(source?: string): Promise<any> {
+  async getClosedInLastTwoHours(source?: string, startDate?: Date, endDate?: Date): Promise<any> {
     try {
       await this.initReviewSystem();
 
       const finalSource: QuestionSource =
         source === 'whatsapp' ? 'WHATSAPP' : 'AJRASAKHA';
 
-      const count = await this.QuestionCollection.countDocuments({
+      const matchStage: any = {
         status: 'closed',
         source: finalSource,
 
         $expr: {
           $lte: [{$subtract: ['$closedAt', '$createdAt']}, 2 * 60 * 60 * 1000],
         },
-      });
+      };
+
+      if (startDate || endDate) {
+        matchStage.createdAt = {};
+        if (startDate) matchStage.createdAt.$gte = startDate;
+        if (endDate) matchStage.createdAt.$lte = endDate;
+      }
+
+      const count = await this.QuestionCollection.countDocuments(matchStage);
       return count;
     } catch (error) {
       throw new InternalServerError(

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -155,7 +155,64 @@ export function AnnamDashboard_dev({ className, source = 'annam', onSourceChange
     setInactiveUsersPage,
   ] = useState(1);
   const {data: inactiveWhatsappUsers }= useInactiveWhatsappUsers(inactiveUsersPage);
-  const {data: closedAndNotifedData} = useClosedAndNotifedData(source);
+  const [closed2hDate, setClosed2hDate] = useState<string | undefined>(undefined);
+  const [questionStatusDate, setQuestionStatusDate] = useState<string | undefined>(undefined);
+  const [customerNotificationsDate, setCustomerNotificationsDate] = useState<string | undefined>(undefined);
+
+  const getDateRangeForExactDate = useCallback((dateStr?: string) => {
+    if (!dateStr) return { startTime: undefined, endTime: undefined };
+    const selectedDate = parseInputDateToLocalDate(dateStr);
+    const startTime = new Date(selectedDate);
+    startTime.setHours(0, 0, 0, 0);
+
+    const endTime = new Date(selectedDate);
+    const now = new Date();
+    const isSelectedToday =
+      selectedDate.getFullYear() === now.getFullYear() &&
+      selectedDate.getMonth() === now.getMonth() &&
+      selectedDate.getDate() === now.getDate();
+
+    if (isSelectedToday) {
+      endTime.setHours(
+        now.getHours(),
+        now.getMinutes(),
+        now.getSeconds(),
+        now.getMilliseconds(),
+      );
+    } else {
+      endTime.setHours(23, 59, 59, 999);
+    }
+    return {
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+    };
+  }, []);
+
+  const closed2hRange = useMemo(() => getDateRangeForExactDate(closed2hDate), [closed2hDate, getDateRangeForExactDate]);
+  const questionStatusRange = useMemo(() => getDateRangeForExactDate(questionStatusDate), [questionStatusDate, getDateRangeForExactDate]);
+  const customerNotificationsRange = useMemo(() => getDateRangeForExactDate(customerNotificationsDate), [customerNotificationsDate, getDateRangeForExactDate]);
+
+  const { data: closed2hData, isFetching: isClosed2hFetching } = useClosedAndNotifedData(
+    source,
+    closed2hRange.startTime,
+    closed2hRange.endTime,
+  );
+  const { data: questionStatusData, isFetching: isQuestionStatusFetching } = useClosedAndNotifedData(
+    source,
+    questionStatusRange.startTime,
+    questionStatusRange.endTime,
+  );
+  const { data: customerNotificationsData, isFetching: isCustomerNotificationsFetching } = useClosedAndNotifedData(
+    source,
+    customerNotificationsRange.startTime,
+    customerNotificationsRange.endTime,
+  );
+
+  useEffect(() => {
+    setClosed2hDate(undefined);
+    setQuestionStatusDate(undefined);
+    setCustomerNotificationsDate(undefined);
+  }, [source]);
   const [
     isInactiveWhatsappModalOpen,
     setIsInactiveWhatsappModalOpen,
@@ -636,40 +693,48 @@ const {data: unqueWhatsAppUsers} = useUniqueWhatsappUsers();
                               totalUsers={unqueWhatsAppUsers}
                             />
                           )}
-
-                          <ClosedInLastTwoHoursCard
-                            count={closedAndNotifedData?.closedInLastTwoHours}
+                           <ClosedInLastTwoHoursCard
+                            count={closed2hData?.closedInLastTwoHours}
                             totalClosed={
-                              closedAndNotifedData?.closedVsTotalQuestions
+                              closed2hData?.closedVsTotalQuestions
                                 ?.closedQuestions
                             }
+                            selectedDate={closed2hDate}
+                            onSelectedDateChange={setClosed2hDate}
+                            isLoading={isClosed2hFetching}
                           />
                           <ClosedQuestionsCard
                             closedQuestions={
-                              closedAndNotifedData?.closedVsTotalQuestions
+                              questionStatusData?.closedVsTotalQuestions
                                 ?.closedQuestions
                             }
                             totalQuestions={
-                              closedAndNotifedData?.closedVsTotalQuestions
+                              questionStatusData?.closedVsTotalQuestions
                                 ?.totalQuestions
                             }
                             inReview={
-                              closedAndNotifedData?.closedVsTotalQuestions
+                              questionStatusData?.closedVsTotalQuestions
                                 ?.inReviewQuestions
                             }
+                            selectedDate={questionStatusDate}
+                            onSelectedDateChange={setQuestionStatusDate}
+                            isLoading={isQuestionStatusFetching}
                           />
                           <CustomerNotificationsCard
                             notified={
-                              closedAndNotifedData?.notifiedVsClosed?.notified
+                              customerNotificationsData?.notifiedVsClosed?.notified
                             }
                             notNotified={
-                              closedAndNotifedData?.notifiedVsClosed
+                              customerNotificationsData?.notifiedVsClosed
                                 ?.notNotified
                             }
                             untrackedClosedQuestions={
-                              closedAndNotifedData?.notifiedVsClosed
+                              customerNotificationsData?.notifiedVsClosed
                                 ?.untrackedClosedQuestions
                             }
+                            selectedDate={customerNotificationsDate}
+                            onSelectedDateChange={setCustomerNotificationsDate}
+                            isLoading={isCustomerNotificationsFetching}
                           />
                         </div>
                         {source !== "whatsapp" && (

--- a/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
+++ b/frontend/src/features/chatbotDashboard/AnnamDashboard_dev.tsx
@@ -155,22 +155,23 @@ export function AnnamDashboard_dev({ className, source = 'annam', onSourceChange
     setInactiveUsersPage,
   ] = useState(1);
   const {data: inactiveWhatsappUsers }= useInactiveWhatsappUsers(inactiveUsersPage);
-  const [closed2hDate, setClosed2hDate] = useState<string | undefined>(undefined);
-  const [questionStatusDate, setQuestionStatusDate] = useState<string | undefined>(undefined);
-  const [customerNotificationsDate, setCustomerNotificationsDate] = useState<string | undefined>(undefined);
+  const [closed2hDateRange, setClosed2hDateRange] = useState<DateRange | undefined>(undefined);
+  const [questionStatusDateRange, setQuestionStatusDateRange] = useState<DateRange | undefined>(undefined);
+  const [customerNotificationsDateRange, setCustomerNotificationsDateRange] = useState<DateRange | undefined>(undefined);
 
-  const getDateRangeForExactDate = useCallback((dateStr?: string) => {
-    if (!dateStr) return { startTime: undefined, endTime: undefined };
-    const selectedDate = parseInputDateToLocalDate(dateStr);
-    const startTime = new Date(selectedDate);
+  const getISOStringsForDateRange = useCallback((range?: DateRange) => {
+    if (!range || !range.from) return { startTime: undefined, endTime: undefined };
+
+    const startTime = new Date(range.from);
     startTime.setHours(0, 0, 0, 0);
 
-    const endTime = new Date(selectedDate);
+    const endDate = range.to ? new Date(range.to) : new Date(range.from);
+    const endTime = new Date(endDate);
     const now = new Date();
     const isSelectedToday =
-      selectedDate.getFullYear() === now.getFullYear() &&
-      selectedDate.getMonth() === now.getMonth() &&
-      selectedDate.getDate() === now.getDate();
+      endDate.getFullYear() === now.getFullYear() &&
+      endDate.getMonth() === now.getMonth() &&
+      endDate.getDate() === now.getDate();
 
     if (isSelectedToday) {
       endTime.setHours(
@@ -188,9 +189,9 @@ export function AnnamDashboard_dev({ className, source = 'annam', onSourceChange
     };
   }, []);
 
-  const closed2hRange = useMemo(() => getDateRangeForExactDate(closed2hDate), [closed2hDate, getDateRangeForExactDate]);
-  const questionStatusRange = useMemo(() => getDateRangeForExactDate(questionStatusDate), [questionStatusDate, getDateRangeForExactDate]);
-  const customerNotificationsRange = useMemo(() => getDateRangeForExactDate(customerNotificationsDate), [customerNotificationsDate, getDateRangeForExactDate]);
+  const closed2hRange = useMemo(() => getISOStringsForDateRange(closed2hDateRange), [closed2hDateRange, getISOStringsForDateRange]);
+  const questionStatusRange = useMemo(() => getISOStringsForDateRange(questionStatusDateRange), [questionStatusDateRange, getISOStringsForDateRange]);
+  const customerNotificationsRange = useMemo(() => getISOStringsForDateRange(customerNotificationsDateRange), [customerNotificationsDateRange, getISOStringsForDateRange]);
 
   const { data: closed2hData, isFetching: isClosed2hFetching } = useClosedAndNotifedData(
     source,
@@ -209,9 +210,9 @@ export function AnnamDashboard_dev({ className, source = 'annam', onSourceChange
   );
 
   useEffect(() => {
-    setClosed2hDate(undefined);
-    setQuestionStatusDate(undefined);
-    setCustomerNotificationsDate(undefined);
+    setClosed2hDateRange(undefined);
+    setQuestionStatusDateRange(undefined);
+    setCustomerNotificationsDateRange(undefined);
   }, [source]);
   const [
     isInactiveWhatsappModalOpen,
@@ -699,8 +700,8 @@ const {data: unqueWhatsAppUsers} = useUniqueWhatsappUsers();
                               closed2hData?.closedVsTotalQuestions
                                 ?.closedQuestions
                             }
-                            selectedDate={closed2hDate}
-                            onSelectedDateChange={setClosed2hDate}
+                            dateRange={closed2hDateRange}
+                            onDateRangeChange={setClosed2hDateRange}
                             isLoading={isClosed2hFetching}
                           />
                           <ClosedQuestionsCard
@@ -716,8 +717,8 @@ const {data: unqueWhatsAppUsers} = useUniqueWhatsappUsers();
                               questionStatusData?.closedVsTotalQuestions
                                 ?.inReviewQuestions
                             }
-                            selectedDate={questionStatusDate}
-                            onSelectedDateChange={setQuestionStatusDate}
+                            dateRange={questionStatusDateRange}
+                            onDateRangeChange={setQuestionStatusDateRange}
                             isLoading={isQuestionStatusFetching}
                           />
                           <CustomerNotificationsCard
@@ -732,8 +733,8 @@ const {data: unqueWhatsAppUsers} = useUniqueWhatsappUsers();
                               customerNotificationsData?.notifiedVsClosed
                                 ?.untrackedClosedQuestions
                             }
-                            selectedDate={customerNotificationsDate}
-                            onSelectedDateChange={setCustomerNotificationsDate}
+                            dateRange={customerNotificationsDateRange}
+                            onDateRangeChange={setCustomerNotificationsDateRange}
                             isLoading={isCustomerNotificationsFetching}
                           />
                         </div>

--- a/frontend/src/features/chatbotDashboard/ClosedInLastTwoHoursCard.tsx
+++ b/frontend/src/features/chatbotDashboard/ClosedInLastTwoHoursCard.tsx
@@ -11,33 +11,21 @@ import { Calendar } from "@/components/atoms/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/atoms/popover";
 import { CalendarIcon, X } from "lucide-react";
 import { format } from "date-fns";
-
-const parseInputDateToLocalDate = (value?: string): Date => {
-  if (!value) return new Date();
-  const [year, month, day] = value.split("-").map(Number);
-  return new Date(year, (month || 1) - 1, day || 1);
-};
-
-const todayAsInputDate = (now: Date = new Date()) => {
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
+import type { DateRange } from "react-day-picker";
 
 type ClosedInLastTwoHoursCardProps = {
   count: number;
   totalClosed: number;
-  selectedDate?: string;
-  onSelectedDateChange?: (date?: string) => void;
+  dateRange?: DateRange;
+  onDateRangeChange?: (range: DateRange | undefined) => void;
   isLoading?: boolean;
 };
 
 export function ClosedInLastTwoHoursCard({
   count,
   totalClosed,
-  selectedDate,
-  onSelectedDateChange,
+  dateRange,
+  onDateRangeChange,
   isLoading,
 }: ClosedInLastTwoHoursCardProps) {
   return (
@@ -78,8 +66,12 @@ export function ClosedInLastTwoHoursCard({
                     className="h-7 px-2 text-[11px] font-normal border-border/70 bg-background/80 backdrop-blur-sm shadow-sm hover:bg-muted/40 gap-1 flex items-center shrink-0"
                   >
                     <CalendarIcon className="h-3 w-3 text-muted-foreground" />
-                    {selectedDate ? (
-                      format(parseInputDateToLocalDate(selectedDate), "MMM dd")
+                    {dateRange?.from ? (
+                      dateRange.to ? (
+                        `${format(dateRange.from, "MMM dd")} - ${format(dateRange.to, "MMM dd")}`
+                      ) : (
+                        format(dateRange.from, "MMM dd")
+                      )
                     ) : (
                       "All Time"
                     )}
@@ -88,23 +80,21 @@ export function ClosedInLastTwoHoursCard({
                 <PopoverContent className="w-auto p-0 z-[100]" align="end">
                   <Calendar
                     initialFocus
-                    mode="single"
-                    selected={selectedDate ? parseInputDateToLocalDate(selectedDate) : undefined}
-                    onSelect={(date) => {
-                      if (!date) return;
-                      onSelectedDateChange?.(todayAsInputDate(date));
-                    }}
+                    mode="range"
+                    defaultMonth={dateRange?.from ?? new Date()}
+                    selected={dateRange}
+                    onSelect={onDateRangeChange}
                     disabled={{ after: new Date() }}
                     className="pointer-events-auto"
                   />
                 </PopoverContent>
               </Popover>
-              {selectedDate && (
+              {dateRange && (
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted rounded-full shrink-0"
-                  onClick={() => onSelectedDateChange?.(undefined)}
+                  onClick={() => onDateRangeChange?.(undefined)}
                 >
                   <X className="h-3 w-3" />
                 </Button>

--- a/frontend/src/features/chatbotDashboard/ClosedInLastTwoHoursCard.tsx
+++ b/frontend/src/features/chatbotDashboard/ClosedInLastTwoHoursCard.tsx
@@ -5,16 +5,40 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/atoms/tooltip";
-  import { motion } from "framer-motion";
+import { motion } from "framer-motion";
+import { Button } from "@/components/atoms/button";
+import { Calendar } from "@/components/atoms/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/atoms/popover";
+import { CalendarIcon, X } from "lucide-react";
+import { format } from "date-fns";
+
+const parseInputDateToLocalDate = (value?: string): Date => {
+  if (!value) return new Date();
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(year, (month || 1) - 1, day || 1);
+};
+
+const todayAsInputDate = (now: Date = new Date()) => {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
 
 type ClosedInLastTwoHoursCardProps = {
   count: number;
   totalClosed: number;
+  selectedDate?: string;
+  onSelectedDateChange?: (date?: string) => void;
+  isLoading?: boolean;
 };
 
 export function ClosedInLastTwoHoursCard({
   count,
   totalClosed,
+  selectedDate,
+  onSelectedDateChange,
+  isLoading,
 }: ClosedInLastTwoHoursCardProps) {
   return (
     <motion.div
@@ -36,14 +60,55 @@ export function ClosedInLastTwoHoursCard({
 
         <CardHeader className="pb-10">
           <motion.div
-            className="text-sm text-muted-foreground"
+            className="text-sm text-muted-foreground flex items-center justify-between gap-2 mb-4"
             initial={{ opacity: 0, x: -6 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.3, delay: 0.1 }}
           >
-            <div className="flex items-center gap-2 mb-2">
+            <div className="flex items-center gap-2">
               <span className="h-4 w-1 rounded-full bg-gradient-to-b from-primary to-primary/40" />
               Closed within 2 Hours
+            </div>
+
+            <div className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="h-7 px-2 text-[11px] font-normal border-border/70 bg-background/80 backdrop-blur-sm shadow-sm hover:bg-muted/40 gap-1 flex items-center shrink-0"
+                  >
+                    <CalendarIcon className="h-3 w-3 text-muted-foreground" />
+                    {selectedDate ? (
+                      format(parseInputDateToLocalDate(selectedDate), "MMM dd")
+                    ) : (
+                      "All Time"
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0 z-[100]" align="end">
+                  <Calendar
+                    initialFocus
+                    mode="single"
+                    selected={selectedDate ? parseInputDateToLocalDate(selectedDate) : undefined}
+                    onSelect={(date) => {
+                      if (!date) return;
+                      onSelectedDateChange?.(todayAsInputDate(date));
+                    }}
+                    disabled={{ after: new Date() }}
+                    className="pointer-events-auto"
+                  />
+                </PopoverContent>
+              </Popover>
+              {selectedDate && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted rounded-full shrink-0"
+                  onClick={() => onSelectedDateChange?.(undefined)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
             </div>
           </motion.div>
 
@@ -56,11 +121,12 @@ export function ClosedInLastTwoHoursCard({
               "
           >
             <motion.div
-              className="
+              className={`
                 text-3xl
                 font-bold
                 tracking-tight
-                "
+                ${isLoading ? "opacity-50" : ""}
+                `}
               initial={{ opacity: 0, scale: 0.9 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{
@@ -69,9 +135,9 @@ export function ClosedInLastTwoHoursCard({
                 type: "spring",
                 stiffness: 200,
               }}
-              key={`${count}-${totalClosed}`}
+              key={`${count ?? 0}-${totalClosed ?? 0}`}
             >
-              {count} / {totalClosed}
+              {count ?? 0} / {totalClosed ?? 0}
             </motion.div>
 
             <TooltipProvider>

--- a/frontend/src/features/chatbotDashboard/ClosedQuestionsCard.tsx
+++ b/frontend/src/features/chatbotDashboard/ClosedQuestionsCard.tsx
@@ -6,17 +6,41 @@ import {
   TooltipTrigger,
 } from "@/components/atoms/tooltip";
 import { motion } from "framer-motion";
+import { Button } from "@/components/atoms/button";
+import { Calendar } from "@/components/atoms/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/atoms/popover";
+import { CalendarIcon, X } from "lucide-react";
+import { format } from "date-fns";
+
+const parseInputDateToLocalDate = (value?: string): Date => {
+  if (!value) return new Date();
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(year, (month || 1) - 1, day || 1);
+};
+
+const todayAsInputDate = (now: Date = new Date()) => {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
 
 type ClosedQuestionsCardProps = {
   closedQuestions: number;
   totalQuestions: number;
   inReview: number;
+  selectedDate?: string;
+  onSelectedDateChange?: (date?: string) => void;
+  isLoading?: boolean;
 };
 
 export function ClosedQuestionsCard({
   closedQuestions,
   totalQuestions,
   inReview,
+  selectedDate,
+  onSelectedDateChange,
+  isLoading,
 }: ClosedQuestionsCardProps) {
   return (
     <motion.div
@@ -40,7 +64,7 @@ export function ClosedQuestionsCard({
 
         <CardHeader className="pb-4">
           {/* Header */}
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-2">
             <div className="text-sm text-muted-foreground">
               <div className="flex items-center gap-2">
                 <span className="h-4 w-1 rounded-full bg-gradient-to-b from-primary to-primary/40" />
@@ -48,32 +72,73 @@ export function ClosedQuestionsCard({
               </div>
             </div>
 
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <motion.span
-                    whileHover={{ scale: 1.15 }}
-                    whileTap={{ scale: 0.92 }}
-                    className="
-                      flex h-4 w-4 cursor-pointer
-                      items-center justify-center
-                      rounded-full border text-[10px]
-                    "
+            <div className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="h-7 px-2 text-[11px] font-normal border-border/70 bg-background/80 backdrop-blur-sm shadow-sm hover:bg-muted/40 gap-1 flex items-center shrink-0"
                   >
-                    i
-                  </motion.span>
-                </TooltipTrigger>
+                    <CalendarIcon className="h-3 w-3 text-muted-foreground" />
+                    {selectedDate ? (
+                      format(parseInputDateToLocalDate(selectedDate), "MMM dd")
+                    ) : (
+                      "All Time"
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0 z-[100]" align="end">
+                  <Calendar
+                    initialFocus
+                    mode="single"
+                    selected={selectedDate ? parseInputDateToLocalDate(selectedDate) : undefined}
+                    onSelect={(date) => {
+                      if (!date) return;
+                      onSelectedDateChange?.(todayAsInputDate(date));
+                    }}
+                    disabled={{ after: new Date() }}
+                    className="pointer-events-auto"
+                  />
+                </PopoverContent>
+              </Popover>
+              {selectedDate && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted rounded-full shrink-0"
+                  onClick={() => onSelectedDateChange?.(undefined)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
 
-                <TooltipContent className="max-w-[260px]">
-                  <p>Distribution of total, closed, and in-review questions.</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <motion.span
+                      whileHover={{ scale: 1.15 }}
+                      whileTap={{ scale: 0.92 }}
+                      className="
+                        flex h-4 w-4 cursor-pointer
+                        items-center justify-center
+                        rounded-full border text-[10px]
+                      "
+                    >
+                      i
+                    </motion.span>
+                  </TooltipTrigger>
+
+                  <TooltipContent className="max-w-[260px]">
+                    <p>Distribution of total, closed, and in-review questions.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
           </div>
 
           {/* Stats */}
           <motion.div
-            className="mt-5 flex items-center justify-between gap-4"
+            className={`mt-5 flex items-center justify-between gap-4 ${isLoading ? "opacity-50" : ""}`}
             initial="hidden"
             animate="visible"
             variants={{
@@ -97,7 +162,7 @@ export function ClosedQuestionsCard({
               <span className="text-xs text-muted-foreground">Total</span>
 
               <motion.span
-                key={totalQuestions}
+                key={totalQuestions ?? 0}
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 0.35, ease: "easeOut" }}
@@ -107,7 +172,7 @@ export function ClosedQuestionsCard({
                   tracking-tight
                 "
               >
-                {totalQuestions}
+                {totalQuestions ?? 0}
               </motion.span>
             </motion.div>
 
@@ -123,7 +188,7 @@ export function ClosedQuestionsCard({
               <span className="text-xs text-muted-foreground">Closed</span>
 
               <motion.span
-                key={closedQuestions}
+                key={closedQuestions ?? 0}
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 0.35, ease: "easeOut" }}
@@ -133,7 +198,7 @@ export function ClosedQuestionsCard({
                   tracking-tight
                 "
               >
-                {closedQuestions}
+                {closedQuestions ?? 0}
               </motion.span>
             </motion.div>
 
@@ -164,7 +229,7 @@ export function ClosedQuestionsCard({
               </TooltipProvider>
 
               <motion.span
-                key={Math.max(inReview, 0)}
+                key={Math.max(inReview ?? 0, 0)}
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 0.35, ease: "easeOut" }}
@@ -174,7 +239,7 @@ export function ClosedQuestionsCard({
                   tracking-tight
                 "
               >
-                {Math.max(inReview, 0)}
+                {Math.max(inReview ?? 0, 0)}
               </motion.span>
             </motion.div>
           </motion.div>

--- a/frontend/src/features/chatbotDashboard/ClosedQuestionsCard.tsx
+++ b/frontend/src/features/chatbotDashboard/ClosedQuestionsCard.tsx
@@ -12,25 +12,14 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/atoms/popo
 import { CalendarIcon, X } from "lucide-react";
 import { format } from "date-fns";
 
-const parseInputDateToLocalDate = (value?: string): Date => {
-  if (!value) return new Date();
-  const [year, month, day] = value.split("-").map(Number);
-  return new Date(year, (month || 1) - 1, day || 1);
-};
-
-const todayAsInputDate = (now: Date = new Date()) => {
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
+import type { DateRange } from "react-day-picker";
 
 type ClosedQuestionsCardProps = {
   closedQuestions: number;
   totalQuestions: number;
   inReview: number;
-  selectedDate?: string;
-  onSelectedDateChange?: (date?: string) => void;
+  dateRange?: DateRange;
+  onDateRangeChange?: (range: DateRange | undefined) => void;
   isLoading?: boolean;
 };
 
@@ -38,8 +27,8 @@ export function ClosedQuestionsCard({
   closedQuestions,
   totalQuestions,
   inReview,
-  selectedDate,
-  onSelectedDateChange,
+  dateRange,
+  onDateRangeChange,
   isLoading,
 }: ClosedQuestionsCardProps) {
   return (
@@ -80,8 +69,12 @@ export function ClosedQuestionsCard({
                     className="h-7 px-2 text-[11px] font-normal border-border/70 bg-background/80 backdrop-blur-sm shadow-sm hover:bg-muted/40 gap-1 flex items-center shrink-0"
                   >
                     <CalendarIcon className="h-3 w-3 text-muted-foreground" />
-                    {selectedDate ? (
-                      format(parseInputDateToLocalDate(selectedDate), "MMM dd")
+                    {dateRange?.from ? (
+                      dateRange.to ? (
+                        `${format(dateRange.from, "MMM dd")} - ${format(dateRange.to, "MMM dd")}`
+                      ) : (
+                        format(dateRange.from, "MMM dd")
+                      )
                     ) : (
                       "All Time"
                     )}
@@ -90,23 +83,21 @@ export function ClosedQuestionsCard({
                 <PopoverContent className="w-auto p-0 z-[100]" align="end">
                   <Calendar
                     initialFocus
-                    mode="single"
-                    selected={selectedDate ? parseInputDateToLocalDate(selectedDate) : undefined}
-                    onSelect={(date) => {
-                      if (!date) return;
-                      onSelectedDateChange?.(todayAsInputDate(date));
-                    }}
+                    mode="range"
+                    defaultMonth={dateRange?.from ?? new Date()}
+                    selected={dateRange}
+                    onSelect={onDateRangeChange}
                     disabled={{ after: new Date() }}
                     className="pointer-events-auto"
                   />
                 </PopoverContent>
               </Popover>
-              {selectedDate && (
+              {dateRange && (
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted rounded-full shrink-0"
-                  onClick={() => onSelectedDateChange?.(undefined)}
+                  onClick={() => onDateRangeChange?.(undefined)}
                 >
                   <X className="h-3 w-3" />
                 </Button>

--- a/frontend/src/features/chatbotDashboard/CustomerNotificationsCard.tsx
+++ b/frontend/src/features/chatbotDashboard/CustomerNotificationsCard.tsx
@@ -6,17 +6,41 @@ import {
   TooltipTrigger,
 } from "@/components/atoms/tooltip";
 import { motion } from "framer-motion";
+import { Button } from "@/components/atoms/button";
+import { Calendar } from "@/components/atoms/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/atoms/popover";
+import { CalendarIcon, X } from "lucide-react";
+import { format } from "date-fns";
+
+const parseInputDateToLocalDate = (value?: string): Date => {
+  if (!value) return new Date();
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(year, (month || 1) - 1, day || 1);
+};
+
+const todayAsInputDate = (now: Date = new Date()) => {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
 
 type CustomerNotificationsCardProps = {
   notified: number;
   notNotified: number;
   untrackedClosedQuestions: number;
+  selectedDate?: string;
+  onSelectedDateChange?: (date?: string) => void;
+  isLoading?: boolean;
 };
 
 export function CustomerNotificationsCard({
   notified,
   notNotified,
   untrackedClosedQuestions,
+  selectedDate,
+  onSelectedDateChange,
+  isLoading,
 }: CustomerNotificationsCardProps) {
   return (
     <motion.div
@@ -41,45 +65,86 @@ export function CustomerNotificationsCard({
         <CardHeader className="pb-4">
           {/* Header */}
           <motion.div
-            className="flex items-center justify-between"
+            className="flex items-center justify-between gap-2"
             initial={{ opacity: 0, x: -6 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.35, delay: 0.1 }}
           >
-            <div className="text-sm text-muted-foreground">
+            <div className="text-sm text-muted-foreground flex-1">
               <div className="flex items-center gap-2">
                 <span className="h-4 w-1 rounded-full bg-gradient-to-b from-primary to-primary/40" />
                 Customer Notifications
               </div>
             </div>
 
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <motion.span
-                    className="
-                  flex h-4 w-4 cursor-pointer
-                  items-center justify-center
-                  rounded-full border text-[10px]
-                "
-                    whileHover={{ scale: 1.15 }}
-                    whileTap={{ scale: 0.92 }}
-                    transition={{ type: "spring", stiffness: 400, damping: 15 }}
+            <div className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="h-7 px-2 text-[11px] font-normal border-border/70 bg-background/80 backdrop-blur-sm shadow-sm hover:bg-muted/40 gap-1 flex items-center shrink-0"
                   >
-                    i
-                  </motion.span>
-                </TooltipTrigger>
+                    <CalendarIcon className="h-3 w-3 text-muted-foreground" />
+                    {selectedDate ? (
+                      format(parseInputDateToLocalDate(selectedDate), "MMM dd")
+                    ) : (
+                      "All Time"
+                    )}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0 z-[100]" align="end">
+                  <Calendar
+                    initialFocus
+                    mode="single"
+                    selected={selectedDate ? parseInputDateToLocalDate(selectedDate) : undefined}
+                    onSelect={(date) => {
+                      if (!date) return;
+                      onSelectedDateChange?.(todayAsInputDate(date));
+                    }}
+                    disabled={{ after: new Date() }}
+                    className="pointer-events-auto"
+                  />
+                </PopoverContent>
+              </Popover>
+              {selectedDate && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted rounded-full shrink-0"
+                  onClick={() => onSelectedDateChange?.(undefined)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
 
-                <TooltipContent className="max-w-[260px]">
-                  <p>Notification delivery breakdown for closed questions.</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <motion.span
+                      className="
+                    flex h-4 w-4 cursor-pointer
+                    items-center justify-center
+                    rounded-full border text-[10px]
+                  "
+                      whileHover={{ scale: 1.15 }}
+                      whileTap={{ scale: 0.92 }}
+                      transition={{ type: "spring", stiffness: 400, damping: 15 }}
+                    >
+                      i
+                    </motion.span>
+                  </TooltipTrigger>
+
+                  <TooltipContent className="max-w-[260px]">
+                    <p>Notification delivery breakdown for closed questions.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
           </motion.div>
 
           {/* Stats */}
           <motion.div
-            className="mt-5 flex items-center justify-between gap-4"
+            className={`mt-5 flex items-center justify-between gap-4 ${isLoading ? "opacity-50" : ""}`}
             variants={{
               hidden: { opacity: 0 },
               visible: {
@@ -106,7 +171,7 @@ export function CustomerNotificationsCard({
               <span className="text-xs text-muted-foreground">Notified</span>
 
               <motion.span
-                key={notified}
+                key={notified ?? 0}
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ type: "spring", stiffness: 400, damping: 15 }}
@@ -116,7 +181,7 @@ export function CustomerNotificationsCard({
               tracking-tight
             "
               >
-                {notified}
+                {notified ?? 0}
               </motion.span>
             </motion.div>
 
@@ -138,7 +203,7 @@ export function CustomerNotificationsCard({
               </span>
 
               <motion.span
-                key={notNotified}
+                key={notNotified ?? 0}
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ type: "spring", stiffness: 400, damping: 15 }}
@@ -148,7 +213,7 @@ export function CustomerNotificationsCard({
               tracking-tight
             "
               >
-                {notNotified}
+                {notNotified ?? 0}
               </motion.span>
             </motion.div>
 
@@ -168,7 +233,7 @@ export function CustomerNotificationsCard({
               <span className="text-xs text-muted-foreground">Untracked</span>
 
               <motion.span
-                key={untrackedClosedQuestions}
+                key={untrackedClosedQuestions ?? 0}
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ type: "spring", stiffness: 400, damping: 15 }}
@@ -178,7 +243,7 @@ export function CustomerNotificationsCard({
               tracking-tight
             "
               >
-                {untrackedClosedQuestions}
+                {untrackedClosedQuestions ?? 0}
               </motion.span>
             </motion.div>
           </motion.div>

--- a/frontend/src/features/chatbotDashboard/CustomerNotificationsCard.tsx
+++ b/frontend/src/features/chatbotDashboard/CustomerNotificationsCard.tsx
@@ -12,25 +12,14 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/atoms/popo
 import { CalendarIcon, X } from "lucide-react";
 import { format } from "date-fns";
 
-const parseInputDateToLocalDate = (value?: string): Date => {
-  if (!value) return new Date();
-  const [year, month, day] = value.split("-").map(Number);
-  return new Date(year, (month || 1) - 1, day || 1);
-};
-
-const todayAsInputDate = (now: Date = new Date()) => {
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
+import type { DateRange } from "react-day-picker";
 
 type CustomerNotificationsCardProps = {
   notified: number;
   notNotified: number;
   untrackedClosedQuestions: number;
-  selectedDate?: string;
-  onSelectedDateChange?: (date?: string) => void;
+  dateRange?: DateRange;
+  onDateRangeChange?: (range: DateRange | undefined) => void;
   isLoading?: boolean;
 };
 
@@ -38,8 +27,8 @@ export function CustomerNotificationsCard({
   notified,
   notNotified,
   untrackedClosedQuestions,
-  selectedDate,
-  onSelectedDateChange,
+  dateRange,
+  onDateRangeChange,
   isLoading,
 }: CustomerNotificationsCardProps) {
   return (
@@ -85,8 +74,12 @@ export function CustomerNotificationsCard({
                     className="h-7 px-2 text-[11px] font-normal border-border/70 bg-background/80 backdrop-blur-sm shadow-sm hover:bg-muted/40 gap-1 flex items-center shrink-0"
                   >
                     <CalendarIcon className="h-3 w-3 text-muted-foreground" />
-                    {selectedDate ? (
-                      format(parseInputDateToLocalDate(selectedDate), "MMM dd")
+                    {dateRange?.from ? (
+                      dateRange.to ? (
+                        `${format(dateRange.from, "MMM dd")} - ${format(dateRange.to, "MMM dd")}`
+                      ) : (
+                        format(dateRange.from, "MMM dd")
+                      )
                     ) : (
                       "All Time"
                     )}
@@ -95,23 +88,21 @@ export function CustomerNotificationsCard({
                 <PopoverContent className="w-auto p-0 z-[100]" align="end">
                   <Calendar
                     initialFocus
-                    mode="single"
-                    selected={selectedDate ? parseInputDateToLocalDate(selectedDate) : undefined}
-                    onSelect={(date) => {
-                      if (!date) return;
-                      onSelectedDateChange?.(todayAsInputDate(date));
-                    }}
+                    mode="range"
+                    defaultMonth={dateRange?.from ?? new Date()}
+                    selected={dateRange}
+                    onSelect={onDateRangeChange}
                     disabled={{ after: new Date() }}
                     className="pointer-events-auto"
                   />
                 </PopoverContent>
               </Popover>
-              {selectedDate && (
+              {dateRange && (
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6 text-muted-foreground hover:text-foreground hover:bg-muted rounded-full shrink-0"
-                  onClick={() => onSelectedDateChange?.(undefined)}
+                  onClick={() => onDateRangeChange?.(undefined)}
                 >
                   <X className="h-3 w-3" />
                 </Button>

--- a/frontend/src/features/chatbotDashboard/hooks/useActiveUsersAnalytics.tsx
+++ b/frontend/src/features/chatbotDashboard/hooks/useActiveUsersAnalytics.tsx
@@ -122,13 +122,15 @@ export const useAllWhatsappUsers = () => {
   });
 };
 
-export const useClosedAndNotifedData = (source: string)=>{
+export const useClosedAndNotifedData = (source: string, startDate?: string, endDate?: string)=>{
   return useQuery({
     queryKey: ["closed-notified-data",
       source,
+      startDate,
+      endDate,
     ],
     queryFn: () => {
-      return chatbotService.getClosedAndNotifedData(source);
+      return chatbotService.getClosedAndNotifedData(source, startDate, endDate);
     },
   });
 }

--- a/frontend/src/hooks/services/chatbotService.ts
+++ b/frontend/src/hooks/services/chatbotService.ts
@@ -173,9 +173,15 @@ export class ChatbotService {
     );
   }
 
-  async getClosedAndNotifedData(source: string): Promise<any>{
+  async getClosedAndNotifedData(source: string, startDate?: string, endDate?: string): Promise<any>{
     const params = new URLSearchParams();
     params.append("source", source);
+    if (startDate) {
+      params.append("startDate", startDate);
+    }
+    if (endDate) {
+      params.append("endDate", endDate);
+    }
     return apiFetch<any>(
       `${this._baseUrl}/closed-notified-data?${params.toString()}`,
     );


### PR DESCRIPTION
# PR: Implement Date Range Filtering on Chatbot Analytics Cards

## 📝 Overview
This PR implements independent date range filtering for three key metrics cards in the Chatbot Analytics dashboard (`Annam`, `Vicharanashala`, and `WhatsApp` sections):
1. **Closed within 2 Hours**
2. **Question Status**
3. **Customer Notifications**

Previously, these cards showed all-time totals and did not support time-bound analytics. This implementation introduces a calendar dropdown inside each card, allowing users to filter metrics dynamically by selecting an exact date range (or a single day). 

Additionally, it resolves bugs causing metrics to display as `NaN` or empty when query values are empty/undefined.

---

## 🛠️ Key Changes

### 1. Backend API & Database Layer
* **MongoDB Repository (`ChatbotRepository.ts` & `IChatbotRepository.ts`)**:
  * Updated `getClosedVsTotalQuestions`, `getNotifiedVsClosed`, and `getClosedInLastTwoHours` to accept optional `startDate` and `endDate` parameters.
  * Added `$match` pipeline stages on `createdAt` using `$gte` and `$lte`.
  * Added safe default return objects (e.g., `0` counts) when aggregations yield no data, solving the `NaN`/missing property display bugs on the frontend.
* **Service Layer (`ChatbotService.ts` & `IChatbotService.ts`)**:
  * Modified `getClosedAndNotifedData` to parse incoming date strings to `Date` objects and pass them to the repository queries.
* **Controller Layer (`ChatbotController.ts`)**:
  * Updated `/closed-notified-data` endpoint to accept optional `startDate` and `endDate` parameters as request queries.

### 2. Frontend Services & React-Query Hooks
* **API Service (`chatbotService.ts`)**:
  * Enhanced `getClosedAndNotifedData` to construct URL query strings representing `startDate` and `endDate`.
* **Query Hook (`useActiveUsersAnalytics.tsx`)**:
  * Updated `useClosedAndNotifedData` to track `startDate` and `endDate` in its query key parameters to handle caching and automatic refetching on date changes.

### 3. Components & UI Refactor
* **Analytics Metric Cards (`ClosedInLastTwoHoursCard.tsx`, `ClosedQuestionsCard.tsx`, `CustomerNotificationsCard.tsx`)**:
  * Converted the header calendar popovers to use `react-day-picker` in `range` selection mode.
  * Configured header tags to show a range string (e.g. `May 25 - May 27`), a single day (e.g. `May 25`), or fallback to `All Time`.
  * Integrated a clear (`X`) button to easily reset the card's filter back to all-time aggregates.
  * Handled loading state overlays and added `?? 0` fallbacks to numbers to ensure robust, clean renderings under empty datasets.
* **Dashboard Container (`AnnamDashboard_dev.tsx`)**:
  * Added independent React states to manage date range selection for each card (`closed2hDateRange`, `questionStatusDateRange`, `customerNotificationsDateRange`).
  * Created a utility `getISOStringsForDateRange` to parse the user's `DateRange` object into proper ISO bounds (e.g. setting `startTime` to `00:00:00.000` of the start date, and `endTime` to `23:59:59.999` of the end date, or defaulting to start date if no end date is selected).
  * Automatically resets all three cards' date filters when swapping between dashboard sources (e.g., Annam vs. WhatsApp).

---

## 🧪 Verification Plan

### Manual Verification
1. Navigate to the **Chatbot Analytics** page in the dashboard.
2. Select any card, click on the calendar picker in the top-right corner, and choose a date range (e.g. May 20 – May 25).
3. Confirm that the card value updates to reflect the queried date range, and the date indicator reads `May 20 - May 25`.
4. Click the `X` clear button on the tag and confirm the card resets back to showing `All Time`.
5. Select a date with no query data (e.g. a future date) and verify that the counts gracefully render as `0` instead of displaying `NaN`.