### PR TITLE
Pass thread_id deterministically to reviewer upload MCP.

### DIFF
--- a/ai/ajrasakha/agents/config.py
+++ b/ai/ajrasakha/agents/config.py
@@ -34,6 +34,16 @@ def resolve_question_source(config: Optional[dict[str, Any]] = None) -> Optional
         return env_source
     return None
 
+
+def resolve_thread_id(config: Optional[dict[str, Any]] = None) -> Optional[str]:
+    """LangGraph conversation id from configurable (set by bridge from x-conversation-id)."""
+    configurable = (config or {}).get("configurable") or {}
+    for key in ("thread_id", "thread"):
+        val = configurable.get(key)
+        if val is not None and str(val).strip():
+            return str(val).strip()
+    return None
+
 MCP_URLS = {
     "gdb":        f"http://{REMOTE_IP}:9005/mcp",
     "weather":    f"http://100.100.108.41:9017/mcp",

--- a/ai/ajrasakha/agents/plan_executor.py
+++ b/ai/ajrasakha/agents/plan_executor.py
@@ -19,7 +19,7 @@ from ajrasakha.agents.location_context import (
     merge_location_dict,
 )
 from ajrasakha.agents.language import text_matches_user_language
-from ajrasakha.agents.config import resolve_question_source
+from ajrasakha.agents.config import resolve_question_source, resolve_thread_id
 from ajrasakha.agents.domains import reviewer_upload_domain
 from ajrasakha.agents.state import AjraSakhaState, Location, PlannerPlan
 from ajrasakha.agents.retrieval_sanitizer import (
@@ -129,6 +129,7 @@ async def build_tool_calls_from_plan(
     location_tool_name: str,
     reviewer_tool_name: str,
     question_source: str | None = None,
+    thread_id: str | None = None,
     extra_chemicals: Optional[list[str]] = None,
 ) -> list[dict[str, Any]]:
     """Build LangChain tool_call dicts for one parallel batch."""
@@ -164,21 +165,24 @@ async def build_tool_calls_from_plan(
         })
 
     if question_source and str(question_source).strip():
+        reviewer_args: dict[str, Any] = {
+            "question": reviewer_question,
+            "state_name": state_name,
+            "crop": crop,
+            "details": {
+                "state": state_name,
+                "district": district,
+                "crop": crop,
+                "season": "General",
+                "domain": domain,
+            },
+            "source": str(question_source).strip(),
+        }
+        if thread_id and str(thread_id).strip():
+            reviewer_args["thread_id"] = str(thread_id).strip()
         calls.append({
             "name": reviewer_tool_name,
-            "args": {
-                "question": reviewer_question,
-                "state_name": state_name,
-                "crop": crop,
-                "details": {
-                    "state": state_name,
-                    "district": district,
-                    "crop": crop,
-                    "season": "General",
-                    "domain": domain,
-                },
-                "source": str(question_source).strip(),
-            },
+            "args": reviewer_args,
             "id": _new_tool_call_id(),
             "type": "tool_call",
         })
@@ -383,6 +387,7 @@ async def execute_plan_node(
     location_tool = await get_location_tool()
     reviewer_tool = await get_reviewer_tool()
     question_source = resolve_question_source(config)
+    thread_id = resolve_thread_id(config)
     tool_calls = await build_tool_calls_from_plan(
         plan,
         user_query,
@@ -390,6 +395,7 @@ async def execute_plan_node(
         location_tool_name=location_tool.name,
         reviewer_tool_name=reviewer_tool.name,
         question_source=question_source,
+        thread_id=thread_id,
     )
     if not tool_calls:
         return {}
@@ -433,6 +439,7 @@ async def execute_plan_node(
             location_tool_name=location_tool.name,
             reviewer_tool_name=reviewer_tool.name,
             question_source=question_source,
+            thread_id=thread_id,
             extra_chemicals=extra_chems,
         )
         chem_only = [c for c in second_calls if c.get("name") == "chemical_checker"]

--- a/ai/ajrasakha/agents/tests/test_planner.py
+++ b/ai/ajrasakha/agents/tests/test_planner.py
@@ -129,6 +129,55 @@ async def test_reviewer_upload_falls_back_to_user_query_without_rephrased():
     assert reviewer["args"]["question"] == user_text
 
 
+@pytest.mark.asyncio
+async def test_reviewer_upload_includes_thread_id_when_provided():
+    plan = {
+        "weather": False,
+        "mandi": False,
+        "soil": False,
+        "schemes": False,
+        "chemical_checker": False,
+        "knowledge_base": True,
+        "is_complete": True,
+        "entities": {"crop": "wheat", "state": "Punjab", "district": "Ropar"},
+    }
+    calls = await build_tool_calls_from_plan(
+        plan,
+        "Yellow rust on wheat",
+        {"state": "Punjab", "city": "Ropar"},
+        location_tool_name="location_information_tool",
+        reviewer_tool_name="upload_question_to_reviewer_system",
+        question_source="AJRASAKHA",
+        thread_id="conv-abc-123",
+    )
+    reviewer = next(c for c in calls if c["name"] == "upload_question_to_reviewer_system")
+    assert reviewer["args"]["thread_id"] == "conv-abc-123"
+
+
+@pytest.mark.asyncio
+async def test_reviewer_upload_omits_thread_id_when_not_provided():
+    plan = {
+        "weather": False,
+        "mandi": False,
+        "soil": False,
+        "schemes": False,
+        "chemical_checker": False,
+        "knowledge_base": True,
+        "is_complete": True,
+        "entities": {"crop": "wheat", "state": "Punjab", "district": "Ropar"},
+    }
+    calls = await build_tool_calls_from_plan(
+        plan,
+        "Yellow rust on wheat",
+        {"state": "Punjab", "city": "Ropar"},
+        location_tool_name="location_information_tool",
+        reviewer_tool_name="upload_question_to_reviewer_system",
+        question_source="AJRASAKHA",
+    )
+    reviewer = next(c for c in calls if c["name"] == "upload_question_to_reviewer_system")
+    assert "thread_id" not in reviewer["args"]
+
+
 def test_planner_output_to_plan():
     out = PlannerOutput(
         weather=True,

--- a/ai/ajrasakha/tools/reviewer/reviewer_system_tool.py
+++ b/ai/ajrasakha/tools/reviewer/reviewer_system_tool.py
@@ -1,12 +1,26 @@
 import os
+import json
 import logging
 import requests
+from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-logging.basicConfig(level=logging.ERROR, format="%(levelname)s: %(message)s")
+IST = timezone(timedelta(hours=5, minutes=30))
+
+
+class ISTFormatter(logging.Formatter):
+    def formatTime(self, record, datefmt=None):
+        dt = datetime.fromtimestamp(record.created, IST)
+        return dt.strftime(datefmt or "%Y-%m-%d %H:%M:%S") + " IST"
+
+
+_handler = logging.StreamHandler()
+_handler.setFormatter(ISTFormatter("%(asctime)s %(levelname)s: %(message)s"))
+logging.basicConfig(level=logging.INFO, handlers=[_handler])
+log = logging.getLogger(__name__)
 load_dotenv()
 
 CREATE_QUESTION_URL = "https://desk.vicharanashala.ai/api/questions"
@@ -14,7 +28,7 @@ CREATE_QUESTION_URL = "https://desk.vicharanashala.ai/api/questions"
 INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY")
 
 if not INTERNAL_API_KEY:
-    logging.error("INTERNAL_API_KEY is missing! Tool will fail authentication.")
+    log.warning("INTERNAL_API_KEY is missing! Tool will fail authentication.")
 
 _REVIEWER_MCP_HOST = os.getenv("REVIEWER_MCP_HOST", "0.0.0.0").strip()
 _REVIEWER_MCP_PORT = int(os.getenv("REVIEWER_MCP_PORT", "9007"))
@@ -37,6 +51,7 @@ def upload_question_to_reviewer_system(
     crop: str,
     details: Dict[str, Any],
     source: str,
+    thread_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Pushes a farmer's question to the reviewer system for the Agri team to review.
@@ -48,6 +63,7 @@ def upload_question_to_reviewer_system(
     - details (Dict[str, Any]): Strict contextual info. MUST contain exactly:
         {"state": "...", "district": "...", "crop": "...", "season": "...", "domain": "..."}
     - source (str): Question channel identifier (e.g. AJRASAKHA, WHATSAPP, AJRASAKHA_WEBAPP).
+    - thread_id (str, optional): LangGraph conversation id (from x-conversation-id). Injected by the agent, not inferred by the LLM.
     """
 
     if not isinstance(question, str) or not question.strip():
@@ -83,11 +99,19 @@ def upload_question_to_reviewer_system(
         "details": details,
         "source": normalized_source,
     }
+    if thread_id and str(thread_id).strip():
+        payload["threadId"] = str(thread_id).strip()
 
     headers = {
         "x-internal-api-key": INTERNAL_API_KEY,
         "Content-Type": "application/json"
     }
+
+    log.info(
+        "Uploading question to reviewer system: url=%s payload=%s",
+        CREATE_QUESTION_URL,
+        json.dumps(payload, ensure_ascii=False),
+    )
 
     try:
         response = requests.post(
@@ -98,14 +122,21 @@ def upload_question_to_reviewer_system(
         )
         response.raise_for_status()
 
+        response_data = response.json()
+        log.info(
+            "Reviewer upload success: status_code=%s response=%s",
+            response.status_code,
+            json.dumps(response_data, ensure_ascii=False),
+        )
+
         return {
             "status": "success",
             "status_code": response.status_code,
-            "data": response.json()
+            "data": response_data
         }
 
     except requests.exceptions.HTTPError:
-        logging.error(f"API Error {response.status_code}: {response.text}")
+        log.error("API Error %s: %s | payload=%s", response.status_code, response.text, json.dumps(payload, ensure_ascii=False))
         return {
             "status": "error",
             "status_code": response.status_code,
@@ -113,7 +144,7 @@ def upload_question_to_reviewer_system(
         }
 
     except requests.exceptions.Timeout:
-        logging.error("Request Timed Out to Reviewer System.")
+        log.error("Request timed out to reviewer system | payload=%s", json.dumps(payload, ensure_ascii=False))
         return {
             "status": "error",
             "status_code": 504,
@@ -121,7 +152,7 @@ def upload_question_to_reviewer_system(
         }
 
     except requests.exceptions.RequestException as e:
-        logging.error(f"Network Error: {str(e)}")
+        log.error("Network error: %s | payload=%s", e, json.dumps(payload, ensure_ascii=False))
         return {
             "status": "error",
             "status_code": 500,


### PR DESCRIPTION
Inject configurable.thread_id into reviewer tool args from plan_executor (not the LLM), forward threadId on desk create, and add planner tests.