### PR TITLE
fix: set chosen_for_answer on strict exact GDB matches

### DIFF
--- a/ai/ajrasakha/agents/gdb_agent.py
+++ b/ai/ajrasakha/agents/gdb_agent.py
@@ -113,10 +113,21 @@ def _normalize_gdb_response(raw_json: dict, rephrased: str, crop: str, state: st
     exact = raw_json.get("exact_match") or {}
     if exact and (exact.get("answer") or exact.get("question")):
         result["is_exact"] = True
-        pair = _match_to_pair_dict(exact)
+        pair = _match_to_pair_dict(exact, chosen=True)
         if pair.get("similarity_score") is None:
             pair["similarity_score"] = 1
+        if not pair.get("answer_from_class"):
+            pair["answer_from_class"] = "strict_exact"
         result["exact_match"] = pair
+        audit = result.get("classification_audit") or {}
+        result["chosen_question_id"] = exact.get("question_id") or audit.get(
+            "selected_question_id"
+        )
+        result["answer_from_class"] = (
+            exact.get("answer_from_class") or audit.get("answer_from_class") or "strict_exact"
+        )
+        result["chosen_for_answer"] = True
+        result["selection_method"] = audit.get("selection_method") or "strict_exact"
 
     selected = raw_json.get("selected_match")
     if isinstance(selected, dict) and selected and (selected.get("answer") or selected.get("question")):

--- a/ai/ajrasakha/agents/tests/test_gdb_agent.py
+++ b/ai/ajrasakha/agents/tests/test_gdb_agent.py
@@ -29,6 +29,9 @@ def test_normalize_gdb_response_exact_match():
     assert result["is_exact"] is True
     assert result["exact_match"]["question_id"] == "507f1f77bcf86cd799439011"
     assert result["exact_match"]["similarity_score"] == 1
+    assert result["exact_match"]["chosen_for_answer"] is True
+    assert result["chosen_for_answer"] is True
+    assert result["chosen_question_id"] == "507f1f77bcf86cd799439011"
     assert result["is_similar"] is False
     assert result["classification_audit"]["status"] == "exact_bypass"
 

--- a/ai/ajrasakha/tools/golden/golden_search.py
+++ b/ai/ajrasakha/tools/golden/golden_search.py
@@ -88,7 +88,11 @@ async def gdb_search(
     if strict_results:
         pair = strict_results[0]
         response["exact_match"] = match_entry(
-            pair, RETRIEVAL_SOURCE_STRICT_EXACT, similarity_score=1.0
+            pair,
+            RETRIEVAL_SOURCE_STRICT_EXACT,
+            similarity_score=1.0,
+            chosen_for_answer=True,
+            answer_from_class="strict_exact",
         )
         response["classification_audit"] = {
             "status": "exact_bypass",
@@ -96,6 +100,9 @@ async def gdb_search(
             "evaluations": [],
             "selected_question_id": pair.question_id,
             "selection_rule": "strict_exact",
+            "selection_method": "strict_exact",
+            "chosen_for_answer": True,
+            "answer_from_class": "strict_exact",
         }
         log.info("gdb_search done path=strict_exact question_id=%s", pair.question_id)
         return response


### PR DESCRIPTION
Mark exact_match and audit as chosen when strict_exact bypasses Gemma, and mirror flags in gdb_agent normalization for LangGraph audit.