### PR TITLE
feat: bypass synthesizer for GDB hits via gdb_passthrough

### DIFF
--- a/ai/ajrasakha/agents/PLANNER_PRODUCT_DECISIONS.md
+++ b/ai/ajrasakha/agents/PLANNER_PRODUCT_DECISIONS.md
@@ -51,7 +51,7 @@ Set `ENABLE_CHEMICAL_CHECKER = True` in `plan_executor.py` to re-enable.
 
 ## Feature flag
 
-- `USE_PLANNER_GRAPH=true` (default): planner → ensure_location → execute_plan → synthesize → **translate_answer** → END. Golden retrieval uses FastAPI + Gemma classification (no retrieval_sanitizer). `empty_gdb_reply` → **translate_answer** (sheet footers only, no LLM). (`sanitize_answer` is commented out.)
+- `USE_PLANNER_GRAPH=true` (default): planner → ensure_location → execute_plan → **gdb_passthrough** (GDB hit) or **synthesize** (specialist-only) or **empty_gdb_reply** → **translate_answer** → END. Golden retrieval uses FastAPI + Gemma classification (no retrieval_sanitizer, no synthesizer LLM on GDB hits). (`sanitize_answer` is commented out.)
 
 ## Language (vocal + script)
 
@@ -59,13 +59,14 @@ Set `ENABLE_CHEMICAL_CHECKER = True` in `plan_executor.py` to re-enable.
 - **Romanized / Latin typing:** `script_language=English`, `vocal_language=<spoken>` (e.g. Romanized Telugu → English + Telugu; Hinglish → English + Hindi).
 - **Native script:** `script_language` and `vocal_language` match (e.g. both Hindi for Devanagari).
 - **Fixed strings** (exact cells, no LLM paraphrase): testing disclaimer, 2-hour expert-queue text, state/crop follow-ups — keyed by `(script_language, vocal_language)`.
-- **Synthesis** writes an English advisory body only (no sources, no testing disclaimer, no 2-hour text).
-- **translate_answer** has two deterministic paths (see `plan.translate_path`):
-  - **`empty_gdb_reply`** sets `translate_path=empty_gdb` → sheet **2-hour + testing** only (no translate LLM).
-  - **`synthesize`** → translate body when needed → GDB **sources + author** → sheet **testing disclaimer** only (no 2-hour on this path).
-- Expert-queue turns route to `empty_gdb_reply` only (not synthesize).
+- **GDB passthrough** uses the Golden expert answer text as-is (no synthesizer rephrase LLM); **translate_answer** may still translate + append sources/testing.
+- **Synthesize** runs only when GDB is empty but weather/mandi/soil/schemes returned data.
+- **translate_answer** paths (see `plan.translate_path`):
+  - **`empty_gdb_reply`** → sheet **2-hour + testing** only (no translate LLM).
+  - **`gdb_passthrough` / synthesize** → translate body when needed → GDB **sources + author** → sheet **testing disclaimer** only (no 2-hour on this path).
+- Expert-queue turns route to `empty_gdb_reply` only.
 - `USE_PLANNER_GRAPH=false`: legacy single-LLM `ajrasakha` + `tools` loop.
 
-## Synthesizer
+## Synthesizer (GDB bypass)
 
-The synthesizer LLM does not bind tools. It only composes the English advisory body from tool results; footers are appended in `translate_answer`.
+The synthesizer node is **not used when GDB returns an exact or similar expert answer** (`gdb_passthrough` → `translate_answer`). It still runs for **specialist-only** turns (e.g. weather with no GDB hit). Footers are appended in `translate_answer`.

--- a/ai/ajrasakha/agents/ajrasakha.py
+++ b/ai/ajrasakha/agents/ajrasakha.py
@@ -41,6 +41,7 @@ from ajrasakha.agents.prompts import (
     WHATSAPP_SYSTEM_PROMPT,
 )
 from ajrasakha.agents.state import AjraSakhaState, Location
+from ajrasakha.agents.gdb_passthrough import gdb_passthrough_node
 from ajrasakha.agents.synthesizer import synthesize_node
 from ajrasakha.agents.tool_registry import get_main_tool_node
 
@@ -397,6 +398,9 @@ def _build_graph():
         builder.add_node("clarify", clarify_node)
         builder.add_node("ensure_location", ensure_location_node)
         builder.add_node("execute_plan", execute_plan_node)
+        # GDB: Golden API + Gemma already picked the expert answer — no synthesizer LLM.
+        builder.add_node("gdb_passthrough", gdb_passthrough_node)
+        # Weather/mandi/soil/schemes when GDB has no usable answer (keep this node).
         builder.add_node("synthesize", synthesize_node)
         from ajrasakha.agents.translate_answer import translate_answer_node
 
@@ -415,10 +419,12 @@ def _build_graph():
             route_after_tools_planner,
             {
                 END: END,
+                "gdb_passthrough": "gdb_passthrough",
                 "synthesize": "synthesize",
                 "empty_gdb_reply": "empty_gdb_reply",
             },
         )
+        builder.add_edge("gdb_passthrough", "translate_answer")
         builder.add_edge("synthesize", "translate_answer")
         builder.add_edge("translate_answer", END)
         builder.add_edge("empty_gdb_reply", "translate_answer")

--- a/ai/ajrasakha/agents/gdb_passthrough.py
+++ b/ai/ajrasakha/agents/gdb_passthrough.py
@@ -1,0 +1,65 @@
+"""Pass Golden DB expert answer to translate_answer without synthesizer LLM rephrase."""
+
+from __future__ import annotations
+
+import logging
+
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableConfig
+
+from ajrasakha.agents.retrieval_sanitizer import gdb_has_usable_answers
+from ajrasakha.agents.state import AjraSakhaState
+from ajrasakha.agents.synthesizer import (
+    _defer_empty_gdb_to_translate,
+    _extract_gdb_from_messages,
+    _format_non_gdb_tool_results,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _gdb_answer_body(gdb_data: dict) -> str:
+    if gdb_data.get("is_exact"):
+        exact = gdb_data.get("exact_match") or {}
+        return (exact.get("answer") or "").strip()
+    pair = gdb_data.get("similar_pair1") or {}
+    return (pair.get("answer") or "").strip()
+
+
+async def gdb_passthrough_node(
+    state: AjraSakhaState,
+    config: RunnableConfig,
+) -> dict:
+    """Use GDB exact/similar expert text as-is; translate_answer adds sources + disclaimer."""
+    messages = state.get("messages") or []
+    plan = state.get("plan") or {}
+    gdb_data = _extract_gdb_from_messages(messages)
+
+    if not gdb_data or not gdb_has_usable_answers(gdb_data):
+        logger.info("gdb_passthrough: no usable GDB — deferring to empty_gdb path")
+        return _defer_empty_gdb_to_translate(state, plan=plan)
+
+    body = _gdb_answer_body(gdb_data)
+    if not body:
+        logger.info("gdb_passthrough: empty answer text — deferring to empty_gdb path")
+        return _defer_empty_gdb_to_translate(state, plan=plan)
+
+    # RAG path: if specialist tools also ran, legacy synthesize sent expert-queue
+    if not gdb_data.get("is_exact"):
+        other_tools = _format_non_gdb_tool_results(messages)
+        if other_tools.strip():
+            logger.info(
+                "gdb_passthrough: similar GDB + specialist tools — expert-queue (no GDB body)"
+            )
+            return _defer_empty_gdb_to_translate(state, plan={**plan, "gdb_has_data": False})
+
+    logger.info(
+        "gdb_passthrough: using GDB %s answer (len=%d), skipping synthesizer",
+        "exact" if gdb_data.get("is_exact") else "similar",
+        len(body),
+    )
+    return {
+        "messages": [AIMessage(content=body)],
+        "location": state.get("location"),
+        "plan": {**plan, "gdb_has_data": True},
+    }

--- a/ai/ajrasakha/agents/plan_executor.py
+++ b/ai/ajrasakha/agents/plan_executor.py
@@ -581,5 +581,10 @@ def route_after_execute(state: AjraSakhaState) -> str:
         return "end"
     if should_expert_queue_reply(state):
         return "empty_gdb_reply"
-    return "synthesize"
+    messages = state.get("messages") or []
+    if _gdb_has_usable_data(messages):
+        return "gdb_passthrough"
+    if _turn_has_specialist_tool_message(messages):
+        return "synthesize"
+    return "empty_gdb_reply"
 

--- a/ai/ajrasakha/agents/tests/test_planner.py
+++ b/ai/ajrasakha/agents/tests/test_planner.py
@@ -335,4 +335,5 @@ def test_compiled_graph_uses_planner_pipeline_by_default():
     assert use_planner_graph() is True
     assert "planner" in graph.nodes
     assert "execute_plan" in graph.nodes
+    assert "gdb_passthrough" in graph.nodes
     assert "synthesize" in graph.nodes

--- a/ai/ajrasakha/agents/tests/test_retrieval_sanitizer.py
+++ b/ai/ajrasakha/agents/tests/test_retrieval_sanitizer.py
@@ -76,12 +76,12 @@ def test_route_exact_match_skips_sanitizer():
     data = _gdb_payload(is_exact=True, is_similar=False)
     data["exact_match"] = {"question": "Q", "answer": "Expert wheat guide."}
     state = _state_with_gdb(data)
-    assert route_after_execute(state) == "synthesize"
+    assert route_after_execute(state) == "gdb_passthrough"
 
 
-def test_route_similar_only_goes_to_synthesize():
+def test_route_similar_only_goes_to_gdb_passthrough():
     state = _state_with_gdb(_gdb_payload())
-    assert route_after_execute(state) == "synthesize"
+    assert route_after_execute(state) == "gdb_passthrough"
 
 
 def test_route_no_gdb_with_weather_goes_to_synthesize():


### PR DESCRIPTION
Route exact/similar Golden answers directly to translate_answer; keep synthesize node for specialist-only turns when GDB has no usable data.