### PR TITLE
fix(golden): title-case crop filter to match MongoDB normalised_crop

### DIFF
--- a/ai/ajrasakha/tools/golden/golden_api.py
+++ b/ai/ajrasakha/tools/golden/golden_api.py
@@ -34,11 +34,11 @@ class GDBSearchRequest(BaseModel):
     crop: str = Field(
         ...,
         description=(
-            "Crop filter. Normalised to lowercase with underscores as spaces "
-            "(e.g. round_gourd → round gourd). Matched on MongoDB details.normalised_crop. "
+            "Crop filter. Normalised to title case with underscores as spaces "
+            "(e.g. bengal_gram → Bengal Gram). Matched on MongoDB details.normalised_crop. "
             "Use all to skip crop filter."
         ),
-        examples=["wheat", "round_gourd", "all"],
+        examples=["Wheat", "round_gourd", "all"],
     )
     state: str = Field(
         ...,
@@ -54,7 +54,7 @@ class GDBSearchResponse(BaseModel):
         ...,
         description="Echo of request `rephrased_query` used for the full pipeline.",
     )
-    crop: str = Field(..., description="Normalised crop sent to MongoDB (lowercase, spaces not underscores).")
+    crop: str = Field(..., description="Normalised crop sent to MongoDB (title case, spaces not underscores).")
     state: str
     exact_match: dict = Field(
         default_factory=dict,

--- a/ai/ajrasakha/tools/golden/golden_core.py
+++ b/ai/ajrasakha/tools/golden/golden_core.py
@@ -105,7 +105,8 @@ def _normalize_crop_for_search(crop: str) -> str:
     if not crop or crop.lower() == "all":
         return "all"
     crop = crop.lower().replace("_", " ")
-    return re.sub(r"\s+", " ", crop).strip()
+    crop = re.sub(r"\s+", " ", crop).strip()
+    return " ".join(word.capitalize() for word in crop.split())
 
 
 def _normalize_crop_state(crop: str, state: str) -> tuple[str, str]:

--- a/ai/ajrasakha/tools/golden/tests/test_crop_normalize.py
+++ b/ai/ajrasakha/tools/golden/tests/test_crop_normalize.py
@@ -2,13 +2,18 @@ from ajrasakha.tools.golden.golden_core import _normalize_crop_for_search
 
 
 def test_round_gourd():
-    assert _normalize_crop_for_search("round_gourd") == "round gourd"
+    assert _normalize_crop_for_search("round_gourd") == "Round Gourd"
 
 
 def test_mixed_case_and_spaces():
-    assert _normalize_crop_for_search("  Round_Gourd  ") == "round gourd"
+    assert _normalize_crop_for_search("  Round_Gourd  ") == "Round Gourd"
 
 
 def test_all_unchanged():
     assert _normalize_crop_for_search("all") == "all"
     assert _normalize_crop_for_search("") == "all"
+
+
+def test_bengal_gram_title_case():
+    assert _normalize_crop_for_search("bengal gram") == "Bengal Gram"
+    assert _normalize_crop_for_search("BENGAL GRAM") == "Bengal Gram"


### PR DESCRIPTION
Golden DB stores normalised_crop in title case (e.g. Bengal Gram) while search was filtering on lowercase values, causing zero vector/exact hits.