### PR TITLE
fix: correct active users trend aggregation and weekly sparkline division-by-zero tooltip bug

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -9802,7 +9802,7 @@ export class ChatbotRepository implements IChatbotRepository {
     }
   }
 
-  async getActiveUsersTrend( // use messages or conversations instead of lastactiveAt
+  async getActiveUsersTrend(
     source: string,
     userType: string,
     requestType: string,
@@ -9814,121 +9814,136 @@ export class ChatbotRepository implements IChatbotRepository {
       await this.init(source);
 
       const matchStage: any = {
-        lastActiveAt: {
-          $ne: null,
-        },
+        isCreatedByUser: true,
+        isDeleted: { $ne: true },
       };
 
       if (startDate && endDate) {
-        matchStage.lastActiveAt = {
-          $ne: null,
+        matchStage.createdAt = {
           $gte: startDate,
           $lte: endDate,
         };
-      }
-
-      if (userType === 'external') {
-        matchStage.userRole = {
-          $in: ['FARMER', 'COORDINATOR'],
-        };
-      }
-
-      if (userType === 'internal') {
-        matchStage.userRole = 'INTERNAL';
-      }
-
-      let groupStage: any;
-      let sortStage: any;
-      const projectStage: any = null;
-
-      switch (requestType) {
-        case 'daily':
-          groupStage = {
-            _id: {
-              $dateToString: {
-                format: '%Y-%m-%d',
-                date: '$lastActiveAt',
-              },
-            },
-            activeUsers: {$sum: 1},
-          };
-
-          sortStage = {_id: 1};
-          break;
-
-        case 'weekly':
-          groupStage = {
-            _id: {
-              year: {
-                $isoWeekYear: '$lastActiveAt',
-              },
-              week: {
-                $isoWeek: '$lastActiveAt',
-              },
-            },
-            activeUsers: {$sum: 1},
-          };
-
-          sortStage = {
-            '_id.year': 1,
-            '_id.week': 1,
-          };
-          break;
-
-        case 'monthly':
-          groupStage = {
-            _id: {
-              $dateToString: {
-                format: '%Y-%m',
-                date: '$lastActiveAt',
-              },
-            },
-            activeUsers: {$sum: 1},
-          };
-
-          sortStage = {_id: 1};
-          break;
-
-        default:
-          throw new Error(`Invalid requestType: ${requestType}`);
       }
 
       const pipeline: any[] = [
         {
           $match: matchStage,
         },
-        {
-          $group: groupStage,
-        },
-        {
-          $sort: sortStage,
-        },
       ];
 
-      if (requestType === 'weekly') {
-        pipeline.push({
-          $project: {
-            _id: {
-              $concat: [
-                {$toString: '$_id.year'},
-                '-W',
-                {
-                  $cond: [
-                    {$lt: ['$_id.week', 10]},
-                    {
-                      $concat: ['0', {$toString: '$_id.week'}],
-                    },
-                    {$toString: '$_id.week'},
-                  ],
-                },
-              ],
-            },
-            activeUsers: 1,
-          },
-        });
+      if (userType !== 'all') {
+        pipeline.push(...this.buildUserTypeLookupStages(userType));
       }
 
-      const data = await this.users.aggregate(pipeline, {session}).toArray();
+      let firstGroupStage: any;
+      let secondGroupStage: any;
+      let sortStage: any;
+      let projectStage: any = null;
+
+      switch (requestType) {
+        case 'daily':
+          firstGroupStage = {
+            $group: {
+              _id: {
+                date: {
+                  $dateToString: {
+                    format: '%Y-%m-%d',
+                    date: '$createdAt',
+                    timezone: '+05:30',
+                  },
+                },
+                user: '$user',
+              },
+            },
+          };
+          secondGroupStage = {
+            $group: {
+              _id: '$_id.date',
+              activeUsers: { $sum: 1 },
+            },
+          };
+          sortStage = { _id: 1 };
+          break;
+
+        case 'weekly':
+          firstGroupStage = {
+            $group: {
+              _id: {
+                year: { $isoWeekYear: { date: '$createdAt', timezone: '+05:30' } },
+                week: { $isoWeek: { date: '$createdAt', timezone: '+05:30' } },
+                user: '$user',
+              },
+            },
+          };
+          secondGroupStage = {
+            $group: {
+              _id: {
+                year: '$_id.year',
+                week: '$_id.week',
+              },
+              activeUsers: { $sum: 1 },
+            },
+          };
+          projectStage = {
+            $project: {
+              _id: {
+                $concat: [
+                  { $toString: '$_id.year' },
+                  '-W',
+                  {
+                    $cond: [
+                      { $lt: ['$_id.week', 10] },
+                      { $concat: ['0', { $toString: '$_id.week' }] },
+                      { $toString: '$_id.week' },
+                    ],
+                  },
+                ],
+              },
+              activeUsers: 1,
+            },
+          };
+          sortStage = { _id: 1 };
+          break;
+
+        case 'monthly':
+          firstGroupStage = {
+            $group: {
+              _id: {
+                month: {
+                  $dateToString: {
+                    format: '%Y-%m',
+                    date: '$createdAt',
+                    timezone: '+05:30',
+                  },
+                },
+                user: '$user',
+              },
+            },
+          };
+          secondGroupStage = {
+            $group: {
+              _id: '$_id.month',
+              activeUsers: { $sum: 1 },
+            },
+          };
+          sortStage = { _id: 1 };
+          break;
+
+        default:
+          throw new Error(`Invalid requestType: ${requestType}`);
+      }
+
+      pipeline.push(firstGroupStage, secondGroupStage);
+
+      if (projectStage) {
+        pipeline.push(projectStage);
+      }
+
+      pipeline.push({
+        $sort: sortStage,
+      });
+
+      const data = await this.messagesCollection.aggregate(pipeline, { session }).toArray();
       return data as IActiveUser[];
     } catch (error) {
       throw new InternalServerError(

--- a/frontend/src/features/chatbotDashboard/MetricCard .tsx
+++ b/frontend/src/features/chatbotDashboard/MetricCard .tsx
@@ -104,16 +104,33 @@ function Sparkline({
     null,
   );
   const svgRef = useRef<SVGSVGElement>(null);
+
+  if (!points || points.length === 0) {
+    return null;
+  }
+
   const max = Math.max(...points);
   const min = Math.min(...points);
   const width = 120;
   const height = 28;
-  const px = (i: number) => (i / (points.length - 1)) * width;
+
+  const px = (i: number) => {
+    if (points.length <= 1) return width / 2;
+    return (i / (points.length - 1)) * width;
+  };
+
   const py = (v: number) => height - ((v - min) / (max - min || 1)) * height;
-  const d = points
-    .map((v, i) => `${i === 0 ? "M" : "L"} ${px(i)} ${py(v)}`)
-    .join(" ");
-  const fill = `${d} L ${width} ${height} L 0 ${height} Z`;
+
+  const d = points.length === 1
+    ? `M 0 ${py(points[0])} L ${width} ${py(points[0])}`
+    : points
+        .map((v, i) => `${i === 0 ? "M" : "L"} ${px(i)} ${py(v)}`)
+        .join(" ");
+
+  const fill = points.length === 1
+    ? `M 0 ${py(points[0])} L ${width} ${py(points[0])} L ${width} ${height} L 0 ${height} Z`
+    : `${d} L ${width} ${height} L 0 ${height} Z`;
+
   const sliceWidth = width / points.length;
 
   const handleEnter = (i: number) => {

--- a/frontend/src/features/chatbotDashboard/active-users.tsx
+++ b/frontend/src/features/chatbotDashboard/active-users.tsx
@@ -114,15 +114,20 @@ export const ActiveUsersChart = ({
   };
 
   const formatCohortLabel = (value: string, requestType: ActiveUserType) => {
+    if (!value) return "";
     if (requestType === "monthly") {
-      return format(new Date(`${value}-01`), "MMM yyyy");
+      const date = new Date(`${value}-01`);
+      return isNaN(date.getTime()) ? value : format(date, "MMM yyyy");
     }
     if (requestType === "weekly") {
-      const [year, week] = value.split("-W");
+      const parts = value.split("-W");
+      if (parts.length < 2) return value;
+      const [year, week] = parts;
       return `W${week} ${year}`;
     }
     if (requestType === "daily") {
-      return format(new Date(value), "dd-MM-yy");
+      const date = new Date(value);
+      return isNaN(date.getTime()) ? value : format(date, "dd-MM-yy");
     }
     return value;
   };

--- a/frontend/src/features/chatbotDashboard/components/shared/Sparkline.tsx
+++ b/frontend/src/features/chatbotDashboard/components/shared/Sparkline.tsx
@@ -4,12 +4,26 @@ interface SparklineProps {
 }
 
 export function Sparkline({ points, color }: SparklineProps) {
+  if (!points || points.length === 0) {
+    return null;
+  }
+
   const max = Math.max(...points), min = Math.min(...points);
   const W = 120, H = 28;
-  const px = (i: number) => (i / (points.length - 1)) * W;
+  const px = (i: number) => {
+    if (points.length <= 1) return W / 2;
+    return (i / (points.length - 1)) * W;
+  };
   const py = (v: number) => H - ((v - min) / (max - min || 1)) * H;
-  const d = points.map((v, i) => `${i === 0 ? "M" : "L"} ${px(i)} ${py(v)}`).join(" ");
-  const fill = d + ` L ${W} ${H} L 0 ${H} Z`;
+
+  const d = points.length === 1
+    ? `M 0 ${py(points[0])} L ${W} ${py(points[0])}`
+    : points.map((v, i) => `${i === 0 ? "M" : "L"} ${px(i)} ${py(v)}`).join(" ");
+
+  const fill = points.length === 1
+    ? `M 0 ${py(points[0])} L ${W} ${py(points[0])} L ${W} ${H} L 0 ${H} Z`
+    : d + ` L ${W} ${H} L 0 ${H} Z`;
+
   return (
     <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-[52px]" preserveAspectRatio="none">
       <path d={fill} fill={color} fillOpacity={0.08} />


### PR DESCRIPTION
## 📖 Description
This PR addresses two critical issues in the Chatbot Analytics dashboard:
1. **User Growth / Active Users Trend Aggregation**: The dashboard was aggregating Active Users by querying the `users` collection grouped by the mutable `lastActiveAt` field. This caused historical daily/weekly/monthly active counts to decay over time and shift forward.
2. **Weekly Tab Blank Chart & Displaced Tooltip Bug**: When a date range/filter resulted in a single data point (e.g. only one week of data), the custom `Sparkline` component encountered a division-by-zero error (`points.length - 1` evaluated to `0`). This resulted in `NaN` SVG coordinates and positioned the tooltip incorrectly off-screen on the far left margin.

---

## 🛠️ Changes

### 1. Backend
- **[ChatbotRepository.ts](file:///d:/programm3d/ajrasakha/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts#L9805-L9938)**:
  - Corrected `getActiveUsersTrend` to query the `messagesCollection` using the message `createdAt` timestamp instead of the `users` collection's `lastActiveAt` timestamp.
  - Added filter logic (`isCreatedByUser: true`, `isDeleted: { $ne: true }`) to ensure only actual user interactions are aggregated (matching the DAU definition).
  - Used two `$group` stages to accurately find unique active users per day, week, or month.
  - Retained support for `buildUserTypeLookupStages(userType)` to preserve role filters.

### 2. Frontend
- **[MetricCard .tsx](file:///d:/programm3d/ajrasakha/frontend/src/features/chatbotDashboard/MetricCard%20.tsx#L104-L131) & [Sparkline.tsx](file:///d:/programm3d/ajrasakha/frontend/src/features/chatbotDashboard/components/shared/Sparkline.tsx#L4-L23)**:
  - Re-wrote the custom `Sparkline` component to handle datasets with `0` or `1` points safely.
  - If `points.length === 1`, it renders a clean horizontal line at the center of the chart and positions the hover tooltip at `width / 2` (exactly centered over the chart), preventing `NaN` layout styles.
  - If `points.length === 0`, it returns `null` safely.
- **[active-users.tsx](file:///d:/programm3d/ajrasakha/frontend/src/features/chatbotDashboard/active-users.tsx#L114-L130)**:
  - Added safety checks in `formatCohortLabel` to handle undefined inputs and fallback gracefully if the `"-W"` split pattern fails.

---

## 🧪 Verification & Testing
- **Backend Build**: Successfully compiled with `pnpm run build` inside `backend`.
- **Frontend Build**: Verified frontend build (`pnpm run build` inside `frontend`) successfully compiled all updated components with zero errors.