### PR TITLE
Require explicit state for planner completeness instead of device GPS.

### DIFF
--- a/ai/ajrasakha/agents/planner.py
+++ b/ai/ajrasakha/agents/planner.py
@@ -18,7 +18,7 @@ from typing import Optional
 from anthropic import APITimeoutError, APIConnectionError, APIStatusError
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from langchain_core.runnables import RunnableConfig
+from langchain_core.runnables import RunnableConfig, patch_config
 from pydantic import BaseModel, Field
 
 from ajrasakha.agents.config import PLANNER_MODEL
@@ -269,6 +269,13 @@ def _extract_state_from_history(
     return None
 
 
+def _planner_invoke_config(config: RunnableConfig) -> RunnableConfig:
+    """Strip thread location from config so the planner LLM never sees coordinates."""
+    configurable = dict((config.get("configurable") or {}))
+    configurable.pop("location", None)
+    return patch_config(config, configurable=configurable)
+
+
 def _resolve_state_deterministic(
     messages: list[BaseMessage],
     location: Optional[dict],
@@ -355,15 +362,13 @@ def _check_question_completeness(
     state_resolved: Optional[str],
     crop_resolved: Optional[str],
     crop_required: bool,
-    has_gps: bool,
     plan: PlannerPlan,
 ) -> tuple[bool, list[str], Optional[str]]:
-    """Deterministic completeness check following the specified flow."""
+    """Deterministic completeness check — state from text/entities only, not device GPS."""
     script, vocal = language_pair_from_plan(plan)
     missing: list[str] = []
     follow_up: Optional[str] = None
-
-    has_state = bool(state_resolved) or has_gps
+    has_state = bool(state_resolved)
     if not has_state:
         missing.append("location")
         follow_up = get_state_follow_up(script, vocal)
@@ -423,12 +428,6 @@ async def planner_node(
     state_resolved = _resolve_state_deterministic(messages, location, prev_entities)
     crop_resolved = resolve_crop_for_turn(messages)
 
-    has_gps = bool(
-        location
-        and location.get("latitude") is not None
-        and location.get("longitude") is not None
-    )
-
     llm_messages: list[BaseMessage] = [SystemMessage(content=PLANNER_SYSTEM_PROMPT)]
     conv_block = format_conversation_for_planner(messages) or user_text
 
@@ -436,7 +435,6 @@ async def planner_node(
         f"PRE-EXTRACTED HINTS from latest raw message (server will re-merge from rephrased_query):\n"
         f"- state hint: {state_resolved or 'NOT RESOLVED'}\n"
         f"- crop hint: {crop_resolved or 'NOT RESOLVED'}\n"
-        f"- has_gps: {has_gps}\n"
     )
     llm_messages.append(
         HumanMessage(
@@ -453,7 +451,7 @@ async def planner_node(
 
     try:
         llm = ChatAnthropic(model=PLANNER_MODEL).with_structured_output(PlannerOutput)
-        output = await llm.ainvoke(llm_messages, config=config)
+        output = await llm.ainvoke(llm_messages, config=_planner_invoke_config(config))
         plan = planner_output_to_plan(output)
 
         prev_vocal = plan.get("vocal_language")
@@ -504,7 +502,6 @@ async def planner_node(
             state_resolved=final_state,
             crop_resolved=effective_crop,
             crop_required=crop_required,
-            has_gps=has_gps,
             plan=plan,
         )
 

--- a/ai/ajrasakha/agents/planner_rules.py
+++ b/ai/ajrasakha/agents/planner_rules.py
@@ -342,8 +342,9 @@ def _location_status(
     loc = location or {}
     lat, lon = loc.get("latitude"), loc.get("longitude")
     has_gps = lat is not None and lon is not None
-    has_state = bool(entities.get("state") or (has_gps and loc.get("state")))
-    has_district = bool(entities.get("district") or (has_gps and loc.get("city")))
+    # Completeness uses entities only; device GPS / reverse-geocode on thread does not count.
+    has_state = bool(entities.get("state"))
+    has_district = bool(entities.get("district"))
     return has_state, has_district, has_gps
 
 
@@ -366,9 +367,8 @@ def _finalize_location_and_crop_completeness(
     entities: PlannerEntities,
     domains: list[str],
     has_state: bool,
-    has_gps: bool,
 ) -> PlannerPlan:
-    """Single completeness pass: state (or GPS) required; district defaults to all."""
+    """Single completeness pass: state in entities required; district defaults to all."""
     script, vocal = language_pair_from_plan(out)
     crop = entities.get("crop")
     canonical_domains = [normalize_domain(d) for d in (domains or [])] or ["General"]
@@ -377,7 +377,7 @@ def _finalize_location_and_crop_completeness(
         and not crop_slot_satisfied(crop)
     )
 
-    if not has_state and not has_gps:
+    if not has_state:
         out["is_complete"] = False
         out["missing_info"] = ["location"]
         out["follow_up_question"] = get_state_follow_up(script, vocal)
@@ -416,7 +416,7 @@ def apply_planner_completeness_rules(
     entities = apply_crop_one_shot_fallback(messages, entities, domains_for_crop)
     out["entities"] = entities
 
-    has_state, _, has_gps = _location_status(entities, location)
+    has_state, _, _has_gps = _location_status(entities, location)
     domain = normalize_domain(out.get("domain") or "General")
     domains = list(out.get("domains") or [domain])
 
@@ -447,7 +447,6 @@ def apply_planner_completeness_rules(
         entities=entities,
         domains=domains,
         has_state=has_state,
-        has_gps=has_gps,
     )
 
     out["reasoning"] = (out.get("reasoning") or "") + f"; domain={domain}"

--- a/ai/ajrasakha/agents/prompts.py
+++ b/ai/ajrasakha/agents/prompts.py
@@ -686,22 +686,19 @@ You are the planner agent responsible for analyzing incoming farmer queries, det
    - First district found → derive its state → use both.
    - First state found (no district) → use state, district = "all".
    - Most recent mention ALWAYS wins over older mentions.
-   
-3. **GPS fallback (last resort only)**: Only if no state/district found in query or history.
-   - Use thread GPS lat/long to resolve state and district.
-   - If district known from GPS, use it; otherwise district = "all".
+   - If nothing found in message or history, leave `entities.state` and `entities.district` empty.
 
-4. **Strict rules**:
+3. **Strict rules**:
    - [STRICT] If the user mentions a specific district/city in the LATEST message (e.g. "Varanasi"), you MUST put that location in your `entities` JSON output. DO NOT copy the location from the conversation history or the PRE-EXTRACTED state hint.
    - [STRICT] If the user asks for weather, market prices, or farming info "in [Word]" or "for [Word]", you MUST extract [Word] as the district, even if you do not recognize the name as a valid Indian district.
-   - [STRICT] If state was found from text/conversation but district was NOT mentioned → district = "all" (do NOT use GPS district).
+   - [STRICT] If state was found from text/conversation but district was NOT mentioned → district = "all".
    - [STRICT] District mention → always derive and use its correct state (even if different from history).
    - [STRICT] Never reuse state/district from unrelated older questions outside last 4 turns.
    - [STRICT] Most recent state/district in conversation takes priority.
    
-5. **When to block execution**:
-   - **No state in text, no state in history, no GPS** → `is_complete=false`, ask for state.
-   - **GPS present on thread** OR state known → location is complete; do **not** ask for location.
+4. **When to block execution**:
+   - **No state in text and no state in history** → `is_complete=false`, ask for state.
+   - **State known from text or history** → location is complete; do **not** ask for location.
 
 2. **Crop** — ask only when the query domain **requires** a named crop and none appears in the **latest message or recent clarify replies**:
    - Required for: crop insurance (when farmer wants insurance for a crop), pests/diseases, varieties, fertilizer for a specific crop, etc.


### PR DESCRIPTION
Strip coordinates from planner LLM config and stop GPS from bypassing the state clarify follow-up in completeness rules.