### PR TITLE
Persist user location from explicit query resolution and improve thre…

### DIFF
--- a/ai/ajrasakha/agents/config.py
+++ b/ai/ajrasakha/agents/config.py
@@ -1,5 +1,8 @@
 import os
+import re
 from typing import Any, Optional
+
+_WHATSAPP_THREAD_ID_RE = re.compile(r"^(\d+)-\d{4}-\d{2}-\d{2}$")
 
 CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
 
@@ -46,6 +49,41 @@ def resolve_thread_id(config: Optional[dict[str, Any]] = None) -> Optional[str]:
         val = configurable.get(key)
         if val is not None and str(val).strip():
             return str(val).strip()
+    return None
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value is not None and str(value).strip():
+            cleaned = str(value).strip()
+            # LibreChat leaves unresolved placeholders when user context is missing.
+            if cleaned.startswith("{{") and cleaned.endswith("}}"):
+                continue
+            return cleaned
+    return None
+
+
+def resolve_user_id(config: Optional[dict[str, Any]] = None) -> str | None:
+    """Resolve user identity from run config (configurable, metadata, thread_id)."""
+    cfg = config or {}
+    configurable = cfg.get("configurable") or {}
+    metadata = cfg.get("metadata") or {}
+
+    user_id = _first_non_empty(
+        configurable.get("user_id"),
+        configurable.get("phone_number"),
+        metadata.get("user_id"),
+        metadata.get("userId"),
+        metadata.get("phoneNumber"),
+    )
+    if user_id:
+        return user_id
+
+    thread_id = resolve_thread_id(cfg)
+    if thread_id:
+        match = _WHATSAPP_THREAD_ID_RE.match(thread_id)
+        if match:
+            return match.group(1)
     return None
 
 # gdb_agent reads this (not MCP_URLS["gdb"]). Set in ai/.env, e.g. http://100.100.108.41:8110

--- a/ai/ajrasakha/agents/location_context.py
+++ b/ai/ajrasakha/agents/location_context.py
@@ -87,6 +87,22 @@ def extract_state_from_text(text: str) -> Optional[str]:
     return None
 
 
+def normalize_state_name(state: str | None) -> Optional[str]:
+    """Map a state string to the canonical Indian state name, if recognized."""
+    if not state:
+        return None
+    cleaned = " ".join(str(state).strip().split())
+    if not cleaned or cleaned.lower() in _PLACEHOLDER_LOCATION_VALUES:
+        return None
+    for name, _pattern in _STATE_PATTERNS:
+        if cleaned.lower() == name.lower():
+            return name
+    from_text = extract_state_from_text(cleaned)
+    if from_text:
+        return from_text
+    return cleaned.title()
+
+
 def _message_to_text(message: BaseMessage) -> str:
     content = message.content
     if content is None:

--- a/ai/ajrasakha/agents/memory.py
+++ b/ai/ajrasakha/agents/memory.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
 
+from ajrasakha.agents.config import resolve_thread_id, resolve_user_id
+
 
 def _coerce_store_text(value: object) -> str:
     if value is None:
@@ -22,9 +24,8 @@ async def load_long_term_summary(store: BaseStore | None, config: RunnableConfig
     if store is None:
         return ""
 
-    configurable = config.get("configurable") or {}
-    thread_id = configurable.get("thread_id") or configurable.get("thread")
-    user_id = configurable.get("user_id") or configurable.get("phone_number")
+    thread_id = resolve_thread_id(config)
+    user_id = resolve_user_id(config)
 
     namespace = ("farmer_profiles", str(user_id or "unknown_user"))
     summary_parts: list[str] = []

--- a/ai/ajrasakha/agents/planner.py
+++ b/ai/ajrasakha/agents/planner.py
@@ -21,7 +21,7 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from langchain_core.runnables import RunnableConfig, patch_config
 from pydantic import BaseModel, Field
 
-from ajrasakha.agents.config import PLANNER_MODEL
+from ajrasakha.agents.config import PLANNER_MODEL, resolve_user_id
 from ajrasakha.agents.thread_logging import (
     begin_conversation_turn,
     end_conversation_turn,
@@ -67,6 +67,7 @@ from ajrasakha.agents.planner_rules import (
 )
 from ajrasakha.agents.prompts import PLANNER_SYSTEM_PROMPT
 from ajrasakha.agents.state import AjraSakhaState, PlannerEntities, PlannerPlan
+from ajrasakha.agents.user_location import load_user_location, maybe_persist_resolved_location
 
 logger = logging.getLogger(__name__)
 
@@ -465,6 +466,13 @@ async def planner_node(
     begin_conversation_turn(user_text)
 
     if is_greeting_message(user_text):
+        prev_plan = state.get("plan") or {}
+        prev_entities: PlannerEntities = dict(prev_plan.get("entities") or {})
+        greeting_entities: PlannerEntities = {"crop": "all"}
+        for key in ("state", "district"):
+            if prev_entities.get(key):
+                greeting_entities[key] = prev_entities[key]
+
         plan: PlannerPlan = {
             "domain": "General",
             "weather": False,
@@ -479,7 +487,7 @@ async def planner_node(
             "missing_info": [],
             "follow_up_question": None,
             "reasoning": "greeting",
-            "entities": {"crop": "all"},
+            "entities": greeting_entities,
             "skip_synthesize": False,
             "rephrased_query": user_text,
             "original_query_en": user_text,
@@ -606,7 +614,23 @@ async def planner_node(
         if not plan.get("original_query_en"):
             plan["original_query_en"] = user_text
 
-        entities = merge_entities_from_rephrased_query(plan, messages, location, prev_entities)
+        user_id = resolve_user_id(config)
+        stored_location = load_user_location(user_id)
+        location_sources: dict[str, str | None] = {}
+        trace_event(
+            "planner_user_location_lookup",
+            user_id=user_id,
+            stored_location=stored_location,
+            configurable_user_id=(config.get("configurable") or {}).get("user_id"),
+        )
+        entities = merge_entities_from_rephrased_query(
+            plan,
+            messages,
+            location,
+            prev_entities,
+            stored_location=stored_location,
+            sources_out=location_sources,
+        )
         plan["entities"] = entities
         trace_event("planner_entities_merged", entities=entities)
 
@@ -646,7 +670,24 @@ async def planner_node(
         plan["missing_info"] = missing
         plan["follow_up_question"] = follow_up
 
-        plan = apply_planner_completeness_rules(plan, messages, location, prev_entities)
+        plan = apply_planner_completeness_rules(
+            plan,
+            messages,
+            location,
+            prev_entities,
+            stored_location=stored_location,
+            sources_out=location_sources,
+        )
+
+        if plan.get("is_complete"):
+            final_entities = plan.get("entities") or {}
+            maybe_persist_resolved_location(
+                user_id,
+                final_entities.get("state"),
+                final_entities.get("district"),
+                state_source=location_sources.get("state_source"),
+                district_source=location_sources.get("district_source"),
+            )
 
         trace_event(
             "planner_final_plan",

--- a/ai/ajrasakha/agents/planner_rules.py
+++ b/ai/ajrasakha/agents/planner_rules.py
@@ -275,11 +275,14 @@ def merge_entities_from_rephrased_query(
     messages: list[BaseMessage],
     location: Optional[Location],
     prev_entities: Optional[PlannerEntities] = None,
+    *,
+    stored_location: Optional[dict[str, str]] = None,
+    sources_out: Optional[dict[str, str | None]] = None,
 ) -> PlannerEntities:
-    """Resolve state/crop/district from farmer text and planner LLM entities only (no GPS).
+    """Resolve state/crop/district from farmer text, LLM entities, stored profile, or clarify carry-over.
 
     State/district never come from device coordinates — only from rephrased query text,
-    LLM entity fields, or ``prev_entities`` during an incomplete clarification turn.
+    LLM entity fields, stored user location, or ``prev_entities`` during clarification.
     """
     # Start with previous entities, override with new plan entities
     merged: PlannerEntities = {**(prev_entities or {}), **dict(plan.get("entities") or {})}
@@ -331,6 +334,11 @@ def merge_entities_from_rephrased_query(
         merged["district"] = "all"
         state_source = "rephrased_query_text" if state_from_text else "plan.entities.state (llm)"
         district_source = "default_all_when_state_only"
+    elif stored_location and stored_location.get("state"):
+        merged["state"] = stored_location["state"]
+        merged["district"] = stored_location.get("district") or "all"
+        state_source = "stored_user_location"
+        district_source = "stored_user_location"
     elif prev_entities and prev_entities.get("state"):
         merged["state"] = prev_entities.get("state")
         state_source = "prev_entities (incomplete_clarify_carryover)"
@@ -362,6 +370,10 @@ def merge_entities_from_rephrased_query(
         crop_source=crop_source,
         entity_text=text[:200] if text else None,
     )
+
+    if sources_out is not None:
+        sources_out["state_source"] = state_source
+        sources_out["district_source"] = district_source
 
     return merged
 
@@ -443,8 +455,18 @@ def _merge_entities(
     messages: list[BaseMessage],
     location: Optional[Location],
     prev_entities: Optional[PlannerEntities] = None,
+    *,
+    stored_location: Optional[dict[str, str]] = None,
+    sources_out: Optional[dict[str, str | None]] = None,
 ) -> PlannerEntities:
-    return merge_entities_from_rephrased_query(plan, messages, location, prev_entities)
+    return merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        location,
+        prev_entities,
+        stored_location=stored_location,
+        sources_out=sources_out,
+    )
 
 
 def _location_status(
@@ -510,6 +532,9 @@ def apply_planner_completeness_rules(
     messages: list[BaseMessage],
     location: Optional[Location],
     prev_entities: Optional[PlannerEntities] = None,
+    *,
+    stored_location: Optional[dict[str, str]] = None,
+    sources_out: Optional[dict[str, str | None]] = None,
 ) -> PlannerPlan:
     """Post-process planner output: merge entities, enforce scheme overrides.
 
@@ -524,7 +549,14 @@ def apply_planner_completeness_rules(
     """
     out: PlannerPlan = dict(plan)
     latest = latest_human_text(messages)
-    entities = _merge_entities(out, messages, location, prev_entities)
+    entities = _merge_entities(
+        out,
+        messages,
+        location,
+        prev_entities,
+        stored_location=stored_location,
+        sources_out=sources_out,
+    )
     domains_for_crop = list(out.get("domains") or [normalize_domain(out.get("domain") or "General")])
     entities = apply_crop_one_shot_fallback(messages, entities, domains_for_crop)
     out["entities"] = entities

--- a/ai/ajrasakha/agents/tests/test_planner_rules.py
+++ b/ai/ajrasakha/agents/tests/test_planner_rules.py
@@ -12,6 +12,7 @@ from ajrasakha.agents.planner_rules import (
     format_prev_plan_context,
     infer_domain_for_plan,
     is_schemes_intent,
+    merge_entities_from_rephrased_query,
 )
 
 
@@ -232,3 +233,39 @@ def test_crop_clarify_reply_still_extracts_cotton():
     assert plan["is_complete"] is True
     assert plan["entities"]["crop"] == "Cotton"
     assert plan.get("follow_up_question") is None
+
+
+def test_stored_location_makes_plan_complete_without_clarify():
+    messages = [HumanMessage(content="What is the weather today?")]
+    plan = apply_planner_completeness_rules(
+        {
+            "domain": "Weather",
+            "domains": ["Weather"],
+            "is_complete": False,
+            "missing_info": ["location"],
+            "entities": {},
+            "rephrased_query": "What is the weather today?",
+        },
+        messages,
+        None,
+        stored_location={"state": "Haryana", "district": "Sirsa"},
+    )
+    assert plan["is_complete"] is True
+    assert plan["entities"]["state"] == "Haryana"
+    assert plan["entities"]["district"] == "Sirsa"
+    assert plan.get("follow_up_question") is None
+
+
+def test_merge_entities_records_stored_location_source():
+    plan = {"rephrased_query": "Weather today", "entities": {}}
+    messages = [HumanMessage(content="Weather today")]
+    sources: dict[str, str | None] = {}
+    entities = merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        None,
+        stored_location={"state": "Haryana", "district": "Sirsa"},
+        sources_out=sources,
+    )
+    assert entities["state"] == "Haryana"
+    assert sources["state_source"] == "stored_user_location"

--- a/ai/ajrasakha/agents/tests/test_thread_log_mongo.py
+++ b/ai/ajrasakha/agents/tests/test_thread_log_mongo.py
@@ -48,6 +48,7 @@ def test_sync_turn_to_mongo_pushes_turn_without_text(tmp_path: Path, monkeypatch
     tlm.sync_turn_to_mongo(
         "thread-abc",
         turn_record,
+        full_logs="turn 1 trace\n",
         background=False,
     )
 
@@ -55,6 +56,7 @@ def test_sync_turn_to_mongo_pushes_turn_without_text(tmp_path: Path, monkeypatch
     filter_doc, update_doc = mock_col.update_one.call_args[0]
     assert filter_doc == {"_id": "thread-abc"}
     assert update_doc["$push"]["turns"] == turn_record
+    assert update_doc["$set"]["full_logs"] == "turn 1 trace\n"
     assert "text" not in update_doc.get("$set", {})
     assert update_doc["$unset"] == {"text": ""}
     assert "updated_at" in update_doc["$set"]
@@ -159,9 +161,21 @@ def test_read_thread_log_text_from_turns(monkeypatch):
     assert tlm.read_thread_log_text("thread-abc") == "trace 1\ntrace 2\n"
     mock_col.find_one.assert_called_once_with(
         {"_id": "thread-abc"},
-        {"turns": 1, "text": 1},
+        {"turns": 1, "text": 1, "full_logs": 1},
         max_time_ms=tlm._MONGO_OP_TIMEOUT_MS,
     )
+
+
+def test_read_thread_log_text_prefers_full_logs(monkeypatch):
+    monkeypatch.setenv("GOLDEN_MONGODB_URI", "mongodb://localhost:27017")
+    mock_col = MagicMock()
+    mock_col.find_one.return_value = {
+        "full_logs": "complete txt snapshot\n",
+        "turns": [{"turn": 1, "log_text": "trace 1\n"}],
+    }
+    monkeypatch.setattr(tlm, "_collection", mock_col)
+
+    assert tlm.read_thread_log_text("thread-abc") == "complete txt snapshot\n"
 
 
 def test_read_thread_log_text(monkeypatch):

--- a/ai/ajrasakha/agents/tests/test_thread_logging.py
+++ b/ai/ajrasakha/agents/tests/test_thread_logging.py
@@ -93,10 +93,16 @@ def test_thread_file_handler_routes_by_context(tmp_path: Path):
 
 
 def test_end_conversation_turn_syncs_turn_to_mongo(tmp_path: Path, monkeypatch):
-    sync_calls: list[tuple[str, dict]] = []
+    sync_calls: list[tuple[str, dict, str | None]] = []
 
-    def _capture_sync(thread_id: str, turn_record: dict, *, background=True):
-        sync_calls.append((thread_id, turn_record))
+    def _capture_sync(
+        thread_id: str,
+        turn_record: dict,
+        *,
+        full_logs: str | None = None,
+        background=True,
+    ):
+        sync_calls.append((thread_id, turn_record, full_logs))
 
     monkeypatch.setattr(tl, "thread_log_dir", lambda: tmp_path)
     monkeypatch.setattr(tl, "mongo_thread_log_enabled", lambda: True)
@@ -108,7 +114,7 @@ def test_end_conversation_turn_syncs_turn_to_mongo(tmp_path: Path, monkeypatch):
     tl.clear_thread_log_context()
 
     assert len(sync_calls) == 1
-    thread_id, turn_record = sync_calls[0]
+    thread_id, turn_record, full_logs = sync_calls[0]
     assert thread_id == "thread-mongo"
     assert turn_record["turn"] == 1
     assert turn_record["user_message"] == "Hi"
@@ -117,6 +123,8 @@ def test_end_conversation_turn_syncs_turn_to_mongo(tmp_path: Path, monkeypatch):
     assert "FARMER MESSAGE" in turn_record["log_text"]
     assert "BOT MESSAGE" in turn_record["log_text"]
     assert "END TURN 1" in turn_record["log_text"]
+    assert full_logs is not None
+    assert "END TURN 1" in full_logs
     assert (tmp_path / "thread-mongo.txt").is_file()
 
 
@@ -124,7 +132,13 @@ def test_turn_state_survives_node_context_reset(tmp_path: Path, monkeypatch):
     """Simulate LangGraph: planner sets turn, later node clears ContextVar but ends turn."""
     sync_calls: list[dict] = []
 
-    def _capture_sync(thread_id: str, turn_record: dict, *, background=True):
+    def _capture_sync(
+        thread_id: str,
+        turn_record: dict,
+        *,
+        full_logs: str | None = None,
+        background=True,
+    ):
         sync_calls.append(turn_record)
 
     monkeypatch.setattr(tl, "thread_log_dir", lambda: tmp_path)
@@ -149,7 +163,13 @@ def test_turn_state_survives_node_context_reset(tmp_path: Path, monkeypatch):
 def test_turn_buffer_captures_handler_logs(tmp_path: Path, monkeypatch):
     sync_calls: list[dict] = []
 
-    def _capture_sync(thread_id: str, turn_record: dict, *, background=True):
+    def _capture_sync(
+        thread_id: str,
+        turn_record: dict,
+        *,
+        full_logs: str | None = None,
+        background=True,
+    ):
         sync_calls.append(turn_record)
 
     monkeypatch.setattr(tl, "thread_log_dir", lambda: tmp_path)

--- a/ai/ajrasakha/agents/tests/test_user_location_mongo.py
+++ b/ai/ajrasakha/agents/tests/test_user_location_mongo.py
@@ -1,0 +1,144 @@
+"""Tests for user_details MongoDB persistence."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ajrasakha.agents import user_location_mongo as mongo
+
+
+@pytest.fixture(autouse=True)
+def reset_mongo_singleton():
+    mongo._client = None
+    mongo._collection = None
+    mongo._init_logged = False
+    mongo._index_ensured = False
+    yield
+    mongo._client = None
+    mongo._collection = None
+    mongo._init_logged = False
+    mongo._index_ensured = False
+
+
+def _mock_collection():
+    col = MagicMock()
+    store: dict[str, dict] = {}
+
+    def find_one(query, projection=None, max_time_ms=None):
+        return store.get(query.get("user_id"))
+
+    def update_one(query, update, upsert=False):
+        user_id = query["user_id"]
+        doc = store.get(user_id, {"user_id": user_id, "location_history": []})
+        if "$setOnInsert" in update:
+            for key, value in update["$setOnInsert"].items():
+                doc.setdefault(key, value)
+        if "$set" in update:
+            doc.update(update["$set"])
+        if "$push" in update:
+            push_spec = update["$push"]["location_history"]
+            history = doc.setdefault("location_history", [])
+            history.extend(push_spec["$each"])
+            slice_val = push_spec["$slice"]
+            doc["location_history"] = history[slice_val:] if slice_val < 0 else history[:slice_val]
+        store[user_id] = doc
+        result = MagicMock()
+        result.matched_count = 1
+        return result
+
+    col.find_one.side_effect = find_one
+    col.update_one.side_effect = update_one
+    col._store = store
+    return col
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_save_new_location_creates_doc(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+
+    assert mongo.save_user_location("919876543210", "Sirsa", "Haryana") is True
+    doc = col._store["919876543210"]
+    assert doc["current_location"] == {"district": "Sirsa", "state": "Haryana"}
+    assert doc["location_history"] == []
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_update_moves_old_location_to_history(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+
+    mongo.save_user_location("919876543210", "Sirsa", "Haryana")
+    assert mongo.save_user_location("919876543210", "Ambala", "Haryana") is True
+
+    doc = col._store["919876543210"]
+    assert doc["current_location"] == {"district": "Ambala", "state": "Haryana"}
+    assert len(doc["location_history"]) == 1
+    assert doc["location_history"][0]["district"] == "Sirsa"
+    assert doc["location_history"][0]["state"] == "Haryana"
+    assert doc["location_history"][0]["timestamp"].endswith("Z")
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_same_location_does_not_duplicate_history(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+
+    mongo.save_user_location("919876543210", "Sirsa", "Haryana")
+    assert mongo.save_user_location("919876543210", "Sirsa", "Haryana") is False
+    doc = col._store["919876543210"]
+    assert doc["location_history"] == []
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_update_does_not_setoninsert_location_history_when_pushing(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+
+    mongo.save_user_location("919876543210", "Sirsa", "Haryana")
+    col.update_one.reset_mock()
+    mongo.save_user_location("919876543210", "Punjab", "Punjab")
+
+    update_doc = col.update_one.call_args[0][1]
+    assert "$push" in update_doc
+    assert "location_history" not in update_doc.get("$setOnInsert", {})
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_history_cap_enforced(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+    user_id = "919876543210"
+
+    mongo.save_user_location(user_id, "Loc0", "Haryana")
+    for idx in range(1, 25):
+        mongo.save_user_location(user_id, f"Loc{idx}", "Haryana")
+
+    doc = col._store[user_id]
+    assert len(doc["location_history"]) == mongo._HISTORY_CAP
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_get_user_location_returns_current(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+    mongo.save_user_location("919876543210", "Sirsa", "Haryana")
+
+    assert mongo.get_user_location("919876543210") == {
+        "district": "Sirsa",
+        "state": "Haryana",
+    }
+
+
+@patch.dict("os.environ", {}, clear=True)
+def test_get_user_location_without_mongo_returns_none():
+    assert mongo.get_user_location("919876543210") is None

--- a/ai/ajrasakha/agents/tests/test_user_location_resolution.py
+++ b/ai/ajrasakha/agents/tests/test_user_location_resolution.py
@@ -1,0 +1,147 @@
+"""Tests for user location resolution and persistence helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from langchain_core.messages import HumanMessage
+
+from ajrasakha.agents.config import resolve_user_id
+from ajrasakha.agents.planner_rules import merge_entities_from_rephrased_query
+from ajrasakha.agents.user_location import (
+    is_explicit_location_source,
+    load_user_location,
+    maybe_persist_resolved_location,
+    sanitize_stored_location,
+    validate_location,
+)
+
+
+def test_resolve_user_id_from_configurable():
+    config = {"configurable": {"user_id": "507f1f77bcf86cd799439011"}}
+    assert resolve_user_id(config) == "507f1f77bcf86cd799439011"
+
+
+def test_resolve_user_id_from_metadata():
+    config = {"metadata": {"user_id": "919876543210", "channel": "whatsapp"}}
+    assert resolve_user_id(config) == "919876543210"
+
+
+def test_resolve_user_id_from_whatsapp_thread_id():
+    config = {"configurable": {"thread_id": "919876543210-2026-06-12"}}
+    assert resolve_user_id(config) == "919876543210"
+
+
+def test_validate_location_rejects_placeholders():
+    assert validate_location("Haryana", "all") is False
+    assert validate_location("Haryana", "all", allow_district_all=True) is True
+    assert validate_location("unknown", "Sirsa") is False
+    assert validate_location("Haryana", "Sirsa") is True
+
+
+def test_sanitize_stored_location_normalizes_names():
+    assert sanitize_stored_location({"state": "haryana", "district": "sirsa"}) == {
+        "state": "Haryana",
+        "district": "Sirsa",
+    }
+    assert sanitize_stored_location({"state": "all", "district": "Sirsa"}) is None
+
+
+def test_merge_uses_stored_location_when_query_has_no_state():
+    plan = {
+        "rephrased_query": "What is the weather today?",
+        "entities": {},
+    }
+    messages = [HumanMessage(content="What is the weather today?")]
+    stored = {"state": "Haryana", "district": "Sirsa"}
+    sources: dict[str, str | None] = {}
+    entities = merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        None,
+        stored_location=stored,
+        sources_out=sources,
+    )
+    assert entities["state"] == "Haryana"
+    assert entities["district"] == "Sirsa"
+    assert sources["state_source"] == "stored_user_location"
+
+
+def test_merge_query_overrides_stored_location():
+    plan = {
+        "rephrased_query": "Weather in Ambala, Haryana",
+        "entities": {"state": "Haryana", "district": "Ambala"},
+    }
+    messages = [HumanMessage(content="Weather in Ambala, Haryana")]
+    stored = {"state": "Haryana", "district": "Sirsa"}
+    sources: dict[str, str | None] = {}
+    entities = merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        None,
+        stored_location=stored,
+        sources_out=sources,
+    )
+    assert entities["district"] == "Ambala"
+    assert sources["state_source"] in ("plan.entities.state (llm)", "rephrased_query_text")
+
+
+def test_merge_prefers_stored_over_prev_entities():
+    plan = {"rephrased_query": "What is PM-KISAN?", "entities": {}}
+    messages = [HumanMessage(content="What is PM-KISAN?")]
+    prev = {"state": "Punjab", "district": "Ludhiana"}
+    stored = {"state": "Haryana", "district": "Sirsa"}
+    entities = merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        None,
+        prev_entities=prev,
+        stored_location=stored,
+    )
+    assert entities["state"] == "Haryana"
+    assert entities["district"] == "Sirsa"
+
+
+def test_is_explicit_location_source():
+    assert is_explicit_location_source("rephrased_query_text", None) is True
+    assert is_explicit_location_source("stored_user_location", "stored_user_location") is False
+
+
+@patch("ajrasakha.agents.user_location.save_user_location")
+def test_maybe_persist_only_on_explicit_source(mock_save):
+    maybe_persist_resolved_location(
+        "919876543210",
+        "Haryana",
+        "Sirsa",
+        state_source="stored_user_location",
+        district_source="stored_user_location",
+        background=False,
+    )
+    mock_save.assert_not_called()
+
+    maybe_persist_resolved_location(
+        "919876543210",
+        "Haryana",
+        "Sirsa",
+        state_source="plan.entities.state (llm)",
+        district_source="plan.entities.district (llm)",
+        background=False,
+    )
+    mock_save.assert_called_once_with("919876543210", "Sirsa", "Haryana")
+
+    mock_save.reset_mock()
+    maybe_persist_resolved_location(
+        "919876543210",
+        "Uttar Pradesh",
+        "all",
+        state_source="rephrased_query_text",
+        district_source="default_all_when_state_only",
+        background=False,
+    )
+    mock_save.assert_called_once_with("919876543210", "all", "Uttar Pradesh")
+
+
+@patch("ajrasakha.agents.user_location.get_user_location")
+def test_load_user_location_sanitizes_invalid(mock_get):
+    mock_get.return_value = {"state": "all", "district": "Sirsa"}
+    assert load_user_location("919876543210") is None

--- a/ai/ajrasakha/agents/thread_log_mongo.py
+++ b/ai/ajrasakha/agents/thread_log_mongo.py
@@ -1,8 +1,8 @@
 """MongoDB sink for per-thread conversation logs.
 
 During a request, logs are written only to the local file (THREAD_LOG_DIR).
-When a turn completes, the turn record is pushed to ``turns[]`` on the thread
-document (one document per thread_id, no top-level ``text`` field).
+When a turn completes, the turn record is pushed to ``turns[]`` and the
+document-level ``full_logs`` field is refreshed from the local ``.txt`` file.
 """
 
 from __future__ import annotations
@@ -89,19 +89,28 @@ def _get_collection() -> Collection | None:
     return _collection
 
 
-def _sync_turn_to_mongo(thread_id: str, turn_record: dict[str, Any]) -> None:
-    """Push one turn to turns[] on the thread document."""
+def _sync_turn_to_mongo(
+    thread_id: str,
+    turn_record: dict[str, Any],
+    *,
+    full_logs: str | None = None,
+) -> None:
+    """Push one turn to turns[] and refresh document-level full_logs from the txt file."""
     col = _get_collection()
     if col is None:
         return
 
     now = datetime.now(timezone.utc)
+    set_fields: dict[str, Any] = {"updated_at": now}
+    if full_logs is not None:
+        set_fields["full_logs"] = full_logs
+
     try:
         col.update_one(
             {"_id": thread_id},
             {
                 "$push": {"turns": turn_record},
-                "$set": {"updated_at": now},
+                "$set": set_fields,
                 "$unset": {"text": ""},
                 "$setOnInsert": {"created_at": now},
             },
@@ -115,25 +124,27 @@ def sync_turn_to_mongo(
     thread_id: str,
     turn_record: dict[str, Any],
     *,
-    background: bool = True,
+    full_logs: str | None = None,
+    background: bool = False,
 ) -> None:
     """Push a completed turn to MongoDB turns[] on the thread document.
 
-    When ``background`` is True (default), runs in a daemon thread so the graph
-    response is never blocked on MongoDB.
+    By default runs synchronously so the write completes before the graph returns.
+    Set ``THREAD_LOG_MONGO_BACKGROUND=true`` or ``background=True`` for async writes.
     """
     if not thread_id or not mongo_thread_log_enabled():
         return
 
-    if background:
+    if background or _env_flag("THREAD_LOG_MONGO_BACKGROUND"):
         threading.Thread(
             target=_sync_turn_to_mongo,
             args=(thread_id, turn_record),
+            kwargs={"full_logs": full_logs},
             name=f"thread-log-mongo-turn-{thread_id[:8]}",
             daemon=True,
         ).start()
     else:
-        _sync_turn_to_mongo(thread_id, turn_record)
+        _sync_turn_to_mongo(thread_id, turn_record, full_logs=full_logs)
 
 
 def read_thread_turns(thread_id: str) -> list[dict[str, Any]]:
@@ -161,7 +172,7 @@ def read_thread_turns(thread_id: str) -> list[dict[str, Any]]:
 
 
 def read_thread_log_text(thread_id: str) -> str:
-    """Read accumulated log text for a thread (concatenated turns[].log_text)."""
+    """Read accumulated log text for a thread (full_logs, then turns[], then legacy text)."""
     if not thread_id:
         return ""
 
@@ -172,11 +183,15 @@ def read_thread_log_text(thread_id: str) -> str:
     try:
         doc = col.find_one(
             {"_id": thread_id},
-            {"turns": 1, "text": 1},
+            {"turns": 1, "text": 1, "full_logs": 1},
             max_time_ms=_MONGO_OP_TIMEOUT_MS,
         )
         if not doc:
             return ""
+
+        full_logs = doc.get("full_logs")
+        if isinstance(full_logs, str) and full_logs.strip():
+            return full_logs
 
         turns = doc.get("turns")
         if isinstance(turns, list) and turns:

--- a/ai/ajrasakha/agents/thread_logging.py
+++ b/ai/ajrasakha/agents/thread_logging.py
@@ -308,7 +308,8 @@ def end_conversation_turn(
     _turn_num_ctx.set(None)
 
     if mongo_thread_log_enabled():
-        sync_turn_to_mongo(tid, turn_record)
+        full_logs = _read_local_thread_log_text(tid)
+        sync_turn_to_mongo(tid, turn_record, full_logs=full_logs)
 
 
 def _resolve_config_thread_id(config: RunnableConfig | dict[str, Any] | None) -> str | None:

--- a/ai/ajrasakha/agents/user_location.py
+++ b/ai/ajrasakha/agents/user_location.py
@@ -1,0 +1,125 @@
+"""Validation and persistence helpers for user-level location storage."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+from ajrasakha.agents.location_context import (
+    _PLACEHOLDER_LOCATION_VALUES,
+    normalize_state_name,
+)
+from ajrasakha.agents.user_location_mongo import get_user_location, save_user_location
+
+logger = logging.getLogger(__name__)
+
+EXPLICIT_LOCATION_SOURCES = frozenset({
+    "rephrased_query_text",
+    "plan.entities.state (llm)",
+    "plan.entities.district (llm)",
+    "default_all_when_state_only",
+})
+
+
+def normalize_district_name(district: str | None, *, allow_all: bool = False) -> str | None:
+    if not district:
+        return None
+    cleaned = " ".join(str(district).strip().split())
+    if not cleaned:
+        return None
+    if cleaned.lower() == "all":
+        return "all" if allow_all else None
+    if cleaned.lower() in _PLACEHOLDER_LOCATION_VALUES:
+        return None
+    return cleaned.title()
+
+
+def validate_location(
+    state: str | None,
+    district: str | None,
+    *,
+    allow_district_all: bool = False,
+) -> bool:
+    """Return True when state is valid and district is a real name (or ``all`` when allowed)."""
+    normalized_state = normalize_state_name(state)
+    if not normalized_state:
+        return False
+    normalized_district = normalize_district_name(district, allow_all=allow_district_all)
+    return bool(normalized_district)
+
+
+def sanitize_stored_location(
+    stored: dict[str, Any] | None,
+) -> dict[str, str] | None:
+    """Validate and normalize a stored location record for planner use."""
+    if not stored:
+        return None
+    state = normalize_state_name(stored.get("state"))
+    district = normalize_district_name(stored.get("district"), allow_all=True)
+    if not state or not district:
+        logger.warning(
+            "Ignoring invalid stored user location state=%r district=%r",
+            stored.get("state"),
+            stored.get("district"),
+        )
+        return None
+    return {"state": state, "district": district}
+
+
+def load_user_location(user_id: str | None) -> dict[str, str] | None:
+    if not user_id:
+        return None
+    stored = sanitize_stored_location(get_user_location(user_id))
+    if stored:
+        return stored
+    from ajrasakha.agents.user_location_mongo import get_farmer_profile_location
+
+    try:
+        profile = get_farmer_profile_location(user_id)
+    except Exception:
+        logger.exception("Failed to load farmerProfile location for user_id=%s", user_id)
+        profile = None
+    return sanitize_stored_location(profile)
+
+
+def is_explicit_location_source(state_source: str | None, district_source: str | None) -> bool:
+    return (
+        state_source in EXPLICIT_LOCATION_SOURCES
+        or district_source in EXPLICIT_LOCATION_SOURCES
+    )
+
+
+def maybe_persist_resolved_location(
+    user_id: str | None,
+    state: str | None,
+    district: str | None,
+    *,
+    state_source: str | None,
+    district_source: str | None,
+    background: bool = True,
+) -> None:
+    """Persist location when resolved explicitly from the current query (not stored/prev)."""
+    if not user_id:
+        return
+    if not is_explicit_location_source(state_source, district_source):
+        return
+    if not validate_location(state, district, allow_district_all=True):
+        return
+
+    normalized_state = normalize_state_name(state)
+    normalized_district = normalize_district_name(district, allow_all=True) or "all"
+    if not normalized_state:
+        return
+
+    def _save() -> None:
+        save_user_location(user_id, normalized_district, normalized_state)
+
+    if background:
+        threading.Thread(
+            target=_save,
+            name=f"user-location-save-{user_id[:12]}",
+            daemon=True,
+        ).start()
+    else:
+        _save()

--- a/ai/ajrasakha/agents/user_location_mongo.py
+++ b/ai/ajrasakha/agents/user_location_mongo.py
@@ -1,0 +1,269 @@
+"""MongoDB persistence for per-user district/state location."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pymongo.collection import Collection
+
+logger = logging.getLogger(__name__)
+
+_client = None
+_collection: Collection | None = None
+_init_lock = threading.Lock()
+_init_logged = False
+_index_ensured = False
+
+_MONGO_OP_TIMEOUT_MS = 5_000
+_HISTORY_CAP = 20
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("true", "1", "yes")
+
+
+def user_location_mongo_enabled() -> bool:
+    uri = os.getenv("GOLDEN_MONGODB_URI", "").strip()
+    if not uri:
+        return False
+    explicit = os.getenv("USER_DETAILS_MONGODB")
+    if explicit is not None:
+        return _env_flag("USER_DETAILS_MONGODB")
+    return True
+
+
+def _collection_name() -> str:
+    return (
+        os.getenv("USER_DETAILS_MONGODB_COLLECTION", "user_details").strip()
+        or "user_details"
+    )
+
+
+def _database_name() -> str:
+    return os.getenv("GOLDEN_MONGODB_DATABASE", "agriai").strip() or "agriai"
+
+
+def _ensure_index(col: Collection) -> None:
+    global _index_ensured
+    if _index_ensured:
+        return
+    try:
+        col.create_index("user_id", unique=True)
+        _index_ensured = True
+    except Exception:
+        logger.exception("Failed to ensure user_details index on user_id")
+
+
+def _get_collection() -> Collection | None:
+    global _client, _collection, _init_logged
+    if not user_location_mongo_enabled():
+        return None
+
+    with _init_lock:
+        if _collection is not None:
+            return _collection
+
+        from pymongo import MongoClient
+
+        uri = os.getenv("GOLDEN_MONGODB_URI", "").strip()
+        if not uri:
+            return None
+
+        try:
+            _client = MongoClient(
+                uri,
+                serverSelectionTimeoutMS=5_000,
+                connectTimeoutMS=5_000,
+                socketTimeoutMS=_MONGO_OP_TIMEOUT_MS,
+            )
+            _collection = _client[_database_name()][_collection_name()]
+            _ensure_index(_collection)
+        except Exception:
+            logger.exception("Failed to initialize user location MongoDB client")
+            return None
+
+        if not _init_logged:
+            _init_logged = True
+            logger.info(
+                "User location MongoDB enabled: %s.%s",
+                _database_name(),
+                _collection_name(),
+            )
+    return _collection
+
+
+def _normalize_user_id(user_id: str) -> str | None:
+    user_id = (user_id or "").strip()
+    return user_id or None
+
+
+def _locations_equal(
+    a: dict[str, Any] | None,
+    b: dict[str, Any] | None,
+) -> bool:
+    if not a or not b:
+        return False
+    return (
+        str(a.get("state", "")).strip().lower()
+        == str(b.get("state", "")).strip().lower()
+        and str(a.get("district", "")).strip().lower()
+        == str(b.get("district", "")).strip().lower()
+    )
+
+
+def get_user_location(user_id: str | None) -> dict[str, str] | None:
+    """Return ``{district, state}`` from ``current_location`` or None."""
+    normalized_id = _normalize_user_id(user_id or "")
+    if not normalized_id:
+        return None
+
+    col = _get_collection()
+    if col is None:
+        return None
+
+    try:
+        doc = col.find_one(
+            {"user_id": normalized_id},
+            {"current_location": 1},
+            max_time_ms=_MONGO_OP_TIMEOUT_MS,
+        )
+    except Exception:
+        logger.exception("Failed to read user location for user_id=%s", normalized_id)
+        return None
+
+    if not doc:
+        return None
+
+    current = doc.get("current_location") or {}
+    district = str(current.get("district") or "").strip()
+    state = str(current.get("state") or "").strip()
+    if not district or not state:
+        return None
+    return {"district": district, "state": state}
+
+
+def get_farmer_profile_location(user_id: str | None) -> dict[str, str] | None:
+    """Read state/district from ``users.farmerProfile`` when ``user_details`` is empty."""
+    normalized_id = _normalize_user_id(user_id or "")
+    if not normalized_id:
+        return None
+
+    col = _get_collection()
+    if col is None:
+        return None
+
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    try:
+        parsed_id: ObjectId | str = ObjectId(normalized_id)
+    except (InvalidId, TypeError):
+        parsed_id = normalized_id
+
+    try:
+        users_col = col.database["users"]
+        doc = users_col.find_one(
+            {"_id": parsed_id},
+            projection={"farmerProfile.state": 1, "farmerProfile.district": 1},
+            max_time_ms=_MONGO_OP_TIMEOUT_MS,
+        )
+    except Exception:
+        logger.exception("Failed to read farmerProfile location for user_id=%s", normalized_id)
+        return None
+
+    if not doc:
+        return None
+
+    profile = doc.get("farmerProfile") or {}
+    district = str(profile.get("district") or "").strip()
+    state = str(profile.get("state") or "").strip()
+    if not state:
+        return None
+    if not district:
+        district = "all"
+    return {"district": district, "state": state}
+
+
+def save_user_location(user_id: str, district: str, state: str) -> bool:
+    """Upsert current location; move prior current_location to history when changed."""
+    normalized_id = _normalize_user_id(user_id)
+    if not normalized_id:
+        return False
+
+    district = district.strip()
+    state = state.strip()
+    if not district or not state:
+        return False
+
+    col = _get_collection()
+    if col is None:
+        return False
+
+    now = datetime.now(timezone.utc)
+    new_current = {"district": district, "state": state}
+
+    try:
+        existing = col.find_one(
+            {"user_id": normalized_id},
+            {"current_location": 1, "location_history": 1},
+            max_time_ms=_MONGO_OP_TIMEOUT_MS,
+        )
+    except Exception:
+        logger.exception("Failed to read user location before save user_id=%s", normalized_id)
+        return False
+
+    update: dict[str, Any] = {
+        "$set": {
+            "current_location": new_current,
+            "updated_at": now,
+        },
+    }
+    set_on_insert: dict[str, Any] = {
+        "user_id": normalized_id,
+        "created_at": now,
+    }
+
+    old_current = (existing or {}).get("current_location")
+    if existing and old_current and not _locations_equal(old_current, new_current):
+        history_entry = {
+            "district": str(old_current.get("district", "")).strip(),
+            "state": str(old_current.get("state", "")).strip(),
+            "timestamp": now.isoformat().replace("+00:00", "Z"),
+        }
+        if history_entry["district"] and history_entry["state"]:
+            update["$push"] = {
+                "location_history": {
+                    "$each": [history_entry],
+                    "$slice": -_HISTORY_CAP,
+                }
+            }
+    else:
+        # MongoDB rejects $push and $setOnInsert on the same path in one update.
+        set_on_insert["location_history"] = []
+
+    update["$setOnInsert"] = set_on_insert
+
+    if existing and _locations_equal(old_current, new_current):
+        return False
+
+    try:
+        col.update_one({"user_id": normalized_id}, update, upsert=True)
+    except Exception:
+        logger.exception("Failed to save user location for user_id=%s", normalized_id)
+        return False
+
+    logger.info(
+        "Saved user location user_id=%s district=%s state=%s",
+        normalized_id,
+        district,
+        state,
+    )
+    return True


### PR DESCRIPTION
…ad logs.

Store district/state in MongoDB user_details with history rotation, use stored location as planner fallback, sync thread logs synchronously with full_logs, and fix location_history update conflicts on save.