### PR TITLE
feat(golden): retry search with crop=all when retrieval returns no hits

### DIFF
--- a/ai/ajrasakha/tools/golden/golden_api.py
+++ b/ai/ajrasakha/tools/golden/golden_api.py
@@ -36,7 +36,8 @@ class GDBSearchRequest(BaseModel):
         description=(
             "Crop filter. Normalised to title case with underscores as spaces "
             "(e.g. bengal_gram → Bengal Gram). Matched on MongoDB details.normalised_crop. "
-            "Use all to skip crop filter."
+            "Use all to skip crop filter. If crop-filtered retrieval finds nothing, "
+            "search retries without the crop filter."
         ),
         examples=["Wheat", "round_gourd", "all"],
     )
@@ -83,7 +84,8 @@ async def health():
         "**Pipeline:**\n"
         "1. **Strict exact** on `rephrased_query` (+ crop/state filters) → if hit, return `exact_match` only.\n"
         "2. Else **vector RAG** on `rephrased_query`.\n"
-        "3. **Gemma** relevance + classify + select one answer using the same `rephrased_query`."
+        "3. If both return no hits and crop is not `all`, retry steps 1–2 with `crop=all`.\n"
+        "4. **Gemma** relevance + classify + select one answer using the same `rephrased_query`."
     ),
 )
 async def search_gdb(body: GDBSearchRequest):

--- a/ai/ajrasakha/tools/golden/golden_search.py
+++ b/ai/ajrasakha/tools/golden/golden_search.py
@@ -46,55 +46,44 @@ log = logging.getLogger(__name__)
 SELECTION_RULE = "relevance_filter_then_same_intent_then_covered_by_context"
 
 
-async def gdb_search(
-    rephrased_query: str,
-    crop: str,
-    state: str,
+def _apply_crop_fallback_metadata(
+    response: dict[str, Any],
     *,
-    season: Optional[str] = None,
-    domain: Optional[str] = None,
+    original_crop: str,
+    crop_fallback: bool,
+) -> None:
+    if not crop_fallback:
+        return
+    response["original_crop"] = original_crop
+    response["crop_fallback"] = True
+    audit = response.get("classification_audit") or {}
+    audit["crop_fallback"] = True
+    audit["original_crop"] = original_crop
+    response["classification_audit"] = audit
+
+
+def _exact_match_response(
+    query: str,
+    state: str,
+    crop: str,
+    pair: QuestionAnswerPair,
+    *,
+    original_crop: str,
+    crop_fallback: bool,
 ) -> dict[str, Any]:
-    crop, state = _normalize_crop_state(crop, state)
-    query = (rephrased_query or "").strip()
-    if not query:
-        raise ValueError("rephrased_query is required")
-
-    log.info(
-        "gdb_search start rephrased_query=%r crop=%s state=%s",
-        _truncate_text(query, 80),
-        crop,
-        state,
-    )
-
     response: dict[str, Any] = {
         "rephrased_query": query,
         "state": state,
         "crop": crop,
-        "exact_match": {},
-        "selected_match": None,
-        "classification_audit": {
-            "status": "empty",
-            "model": GEMMA_MODEL,
-            "relevance_filter_mode": "batch_all_candidates",
-            "evaluations": [],
-            "selected_question_id": None,
-            "selection_rule": SELECTION_RULE,
-        },
-    }
-
-    strict_results = await strict_exact_search(query=query, crop=crop, state=state)
-    log.info("gdb_search strict exact returned %d hit(s)", len(strict_results))
-
-    if strict_results:
-        pair = strict_results[0]
-        response["exact_match"] = match_entry(
+        "exact_match": match_entry(
             pair,
             RETRIEVAL_SOURCE_STRICT_EXACT,
             similarity_score=1.0,
             chosen_for_answer=True,
             answer_from_class="strict_exact",
-        )
-        response["classification_audit"] = {
+        ),
+        "selected_match": None,
+        "classification_audit": {
             "status": "exact_bypass",
             "model": GEMMA_MODEL,
             "evaluations": [],
@@ -103,22 +92,32 @@ async def gdb_search(
             "selection_method": "strict_exact",
             "chosen_for_answer": True,
             "answer_from_class": "strict_exact",
-        }
-        log.info("gdb_search done path=strict_exact question_id=%s", pair.question_id)
-        return response
-
-    rag_pairs = await vector_rag_search(
-        query,
-        crop,
-        state,
-        season=season,
-        domain=domain,
+        },
+    }
+    _apply_crop_fallback_metadata(
+        response,
+        original_crop=original_crop,
+        crop_fallback=crop_fallback,
     )
-    if not rag_pairs:
-        log.warning("gdb_search done path=empty (no vector hits)")
-        return response
+    return response
 
-    # Stage 1: one batch LLM call — all RAG candidates; may detect SAME for early bypass
+
+async def _run_gemma_pipeline(
+    query: str,
+    crop: str,
+    state: str,
+    rag_pairs: list[QuestionAnswerPair],
+    response: dict[str, Any],
+    *,
+    original_crop: str,
+    crop_fallback: bool,
+) -> dict[str, Any]:
+    _apply_crop_fallback_metadata(
+        response,
+        original_crop=original_crop,
+        crop_fallback=crop_fallback,
+    )
+
     filter_results = await filter_relevance_batch(
         query, rag_pairs, crop=crop, state=state
     )
@@ -223,7 +222,6 @@ async def gdb_search(
         )
         return response
 
-    # Stage 2: intent classification on kept pairs only
     classify_tasks = [
         classify_pair(
             original_query=query,
@@ -244,7 +242,6 @@ async def gdb_search(
         ev["llm_parse_ok"] = cls_result.get("llm_parse_ok", False)
         ev["action"] = "classified"
 
-    # Stage 3: select best (2+ same class → LLM tie-breaker; 1 → auto-pick)
     selection = await select_best_match(query, kept_pairs, classify_results)
     audit = response["classification_audit"]
     audit["evaluations"] = evaluations
@@ -308,3 +305,121 @@ async def gdb_search(
         rule,
     )
     return response
+
+
+async def gdb_search(
+    rephrased_query: str,
+    crop: str,
+    state: str,
+    *,
+    season: Optional[str] = None,
+    domain: Optional[str] = None,
+) -> dict[str, Any]:
+    crop, state = _normalize_crop_state(crop, state)
+    original_crop = crop
+    crop_fallback = False
+    query = (rephrased_query or "").strip()
+    if not query:
+        raise ValueError("rephrased_query is required")
+
+    log.info(
+        "gdb_search start rephrased_query=%r crop=%s state=%s",
+        _truncate_text(query, 80),
+        crop,
+        state,
+    )
+
+    response: dict[str, Any] = {
+        "rephrased_query": query,
+        "state": state,
+        "crop": crop,
+        "exact_match": {},
+        "selected_match": None,
+        "classification_audit": {
+            "status": "empty",
+            "model": GEMMA_MODEL,
+            "relevance_filter_mode": "batch_all_candidates",
+            "evaluations": [],
+            "selected_question_id": None,
+            "selection_rule": SELECTION_RULE,
+        },
+    }
+
+    strict_results = await strict_exact_search(query=query, crop=crop, state=state)
+    log.info("gdb_search strict exact returned %d hit(s)", len(strict_results))
+
+    if strict_results:
+        log.info(
+            "gdb_search done path=strict_exact question_id=%s",
+            strict_results[0].question_id,
+        )
+        return _exact_match_response(
+            query,
+            state,
+            crop,
+            strict_results[0],
+            original_crop=original_crop,
+            crop_fallback=False,
+        )
+
+    rag_pairs = await vector_rag_search(
+        query,
+        crop,
+        state,
+        season=season,
+        domain=domain,
+    )
+
+    if not rag_pairs and crop != "all":
+        log.info(
+            "gdb_search: no retrieval hits for crop=%s; retrying with crop=all",
+            crop,
+        )
+        crop_fallback = True
+        strict_results = await strict_exact_search(query=query, crop="all", state=state)
+        log.info(
+            "gdb_search strict exact (crop=all) returned %d hit(s)",
+            len(strict_results),
+        )
+        if strict_results:
+            log.info(
+                "gdb_search done path=strict_exact_crop_fallback question_id=%s",
+                strict_results[0].question_id,
+            )
+            return _exact_match_response(
+                query,
+                state,
+                "all",
+                strict_results[0],
+                original_crop=original_crop,
+                crop_fallback=True,
+            )
+
+        rag_pairs = await vector_rag_search(
+            query,
+            "all",
+            state,
+            season=season,
+            domain=domain,
+        )
+        crop = "all"
+        response["crop"] = "all"
+
+    if not rag_pairs:
+        _apply_crop_fallback_metadata(
+            response,
+            original_crop=original_crop,
+            crop_fallback=crop_fallback,
+        )
+        log.warning("gdb_search done path=empty (no vector hits)")
+        return response
+
+    return await _run_gemma_pipeline(
+        query,
+        crop,
+        state,
+        rag_pairs,
+        response,
+        original_crop=original_crop,
+        crop_fallback=crop_fallback,
+    )

--- a/ai/ajrasakha/tools/golden/tests/test_crop_fallback.py
+++ b/ai/ajrasakha/tools/golden/tests/test_crop_fallback.py
@@ -1,0 +1,156 @@
+"""Unit tests for crop=all retry when retrieval returns no hits."""
+
+import pytest
+
+from ajrasakha.tools.golden.golden_core import QuestionAnswerPair
+
+
+def _pair(qid: str, score: float = 0.8) -> QuestionAnswerPair:
+    return QuestionAnswerPair(
+        question_id=qid,
+        question_text=f"Q {qid}",
+        answer_text=f"A {qid}",
+        author=None,
+        sources=[],
+        similarity_score=score,
+    )
+
+
+@pytest.mark.asyncio
+async def test_crop_fallback_retries_rag_with_all(monkeypatch):
+    from ajrasakha.tools.golden import golden_search
+
+    rag_calls: list[str] = []
+
+    async def mock_strict(*_args, crop: str, **_kwargs):
+        return []
+
+    async def mock_rag(*args, **kwargs):
+        crop_arg = kwargs.get("crop", args[1] if len(args) > 1 else "")
+        rag_calls.append(crop_arg)
+        if crop_arg == "all":
+            return [_pair("fallback_hit")]
+        return []
+
+    async def mock_filter(*_args, **_kwargs):
+        return [
+            {
+                "relevance_decision": "KEEP",
+                "relevance_reason": "related",
+                "llm_parse_ok": True,
+            }
+        ]
+
+    async def mock_classify(*_args, **_kwargs):
+        return {"classification": "SAME_INTENT", "reason": "match", "llm_parse_ok": True}
+
+    async def mock_select(*_args, **_kwargs):
+        return {
+            "pair": _pair("fallback_hit"),
+            "cls_result": {"classification": "SAME_INTENT"},
+            "selection_rule": "single",
+            "winning_class": "SAME_INTENT",
+            "selection_method": "auto",
+        }
+
+    monkeypatch.setattr(golden_search, "strict_exact_search", mock_strict)
+    monkeypatch.setattr(golden_search, "vector_rag_search", mock_rag)
+    monkeypatch.setattr(golden_search, "filter_relevance_batch", mock_filter)
+    monkeypatch.setattr(golden_search, "classify_pair", mock_classify)
+    monkeypatch.setattr(golden_search, "select_best_match", mock_select)
+
+    result = await golden_search.gdb_search("farmer question", "Unknown Crop", "Punjab")
+
+    assert rag_calls == ["Unknown Crop", "all"]
+    assert result["crop"] == "all"
+    assert result["original_crop"] == "Unknown Crop"
+    assert result["crop_fallback"] is True
+    assert result["selected_match"]["question_id"] == "fallback_hit"
+    assert result["classification_audit"]["crop_fallback"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_first_rag_returns_hits(monkeypatch):
+    from ajrasakha.tools.golden import golden_search
+
+    rag_calls: list[str] = []
+
+    async def mock_strict(*_args, **_kwargs):
+        return []
+
+    async def mock_rag(*args, **kwargs):
+        crop_arg = kwargs.get("crop", args[1] if len(args) > 1 else "")
+        rag_calls.append(crop_arg)
+        return [_pair("first_hit")]
+
+    async def mock_filter(*_args, **_kwargs):
+        return [
+            {
+                "relevance_decision": "SAME",
+                "relevance_reason": "paraphrase",
+                "llm_parse_ok": True,
+            }
+        ]
+
+    monkeypatch.setattr(golden_search, "strict_exact_search", mock_strict)
+    monkeypatch.setattr(golden_search, "vector_rag_search", mock_rag)
+    monkeypatch.setattr(golden_search, "filter_relevance_batch", mock_filter)
+
+    result = await golden_search.gdb_search("farmer question", "Wheat", "Punjab")
+
+    assert rag_calls == ["Wheat"]
+    assert result.get("crop_fallback") is None
+    assert result["crop"] == "Wheat"
+    assert result["selected_match"]["question_id"] == "first_hit"
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_crop_is_all(monkeypatch):
+    from ajrasakha.tools.golden import golden_search
+
+    rag_calls: list[str] = []
+
+    async def mock_strict(*_args, **_kwargs):
+        return []
+
+    async def mock_rag(*args, **kwargs):
+        crop_arg = kwargs.get("crop", args[1] if len(args) > 1 else "")
+        rag_calls.append(crop_arg)
+        return []
+
+    monkeypatch.setattr(golden_search, "strict_exact_search", mock_strict)
+    monkeypatch.setattr(golden_search, "vector_rag_search", mock_rag)
+
+    result = await golden_search.gdb_search("farmer question", "all", "Punjab")
+
+    assert rag_calls == ["all"]
+    assert result.get("crop_fallback") is None
+    assert result["crop"] == "all"
+    assert result["selected_match"] is None
+
+
+@pytest.mark.asyncio
+async def test_crop_fallback_exact_match_on_retry(monkeypatch):
+    from ajrasakha.tools.golden import golden_search
+
+    strict_calls: list[str] = []
+
+    async def mock_strict(*args, **kwargs):
+        crop_arg = kwargs.get("crop", args[1] if len(args) > 1 else "")
+        strict_calls.append(crop_arg)
+        if crop_arg == "all":
+            return [_pair("exact_fallback")]
+        return []
+
+    async def mock_rag(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(golden_search, "strict_exact_search", mock_strict)
+    monkeypatch.setattr(golden_search, "vector_rag_search", mock_rag)
+
+    result = await golden_search.gdb_search("farmer question", "Unknown Crop", "Punjab")
+
+    assert strict_calls == ["Unknown Crop", "all"]
+    assert result["crop"] == "all"
+    assert result["crop_fallback"] is True
+    assert result["exact_match"]["question_id"] == "exact_fallback"


### PR DESCRIPTION
When strict exact and vector RAG both return zero hits for a specific crop, retry without the crop filter so unknown or uncovered crops can still match cross-crop Golden DB answers.