### PR TITLE
Refactor/list timebound first

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -1506,12 +1506,51 @@ export class QuestionRepository implements IQuestionRepository {
           priorityOrder: {
             $switch: {
               branches: [
-                {case: {$eq: ['$priority', 'critical']}, then: 1},
-                {case: {$eq: ['$priority', 'high']}, then: 2},
-                {case: {$eq: ['$priority', 'medium']}, then: 3},
-                {case: {$eq: ['$priority', 'low']}, then: 4},
+                // AJRASAKHA / WHATSAPP
+                {
+                  case: {
+                    $and: [
+                      { $eq: ['$priority', 'critical'] },
+                      { $in: ['$source', ['AJRASAKHA', 'WHATSAPP']] },
+                    ],
+                  },
+                  then: 1,
+                },
+                {
+                  case: {
+                    $and: [
+                      { $eq: ['$priority', 'high'] },
+                      { $in: ['$source', ['AJRASAKHA', 'WHATSAPP']] },
+                    ],
+                  },
+                  then: 2,
+                },
+                {
+                  case: {
+                    $and: [
+                      { $eq: ['$priority', 'medium'] },
+                      { $in: ['$source', ['AJRASAKHA', 'WHATSAPP']] },
+                    ],
+                  },
+                  then: 3,
+                },
+                {
+                  case: {
+                    $and: [
+                      { $eq: ['$priority', 'low'] },
+                      { $in: ['$source', ['AJRASAKHA', 'WHATSAPP']] },
+                    ],
+                  },
+                  then: 4,
+                },
+
+                // Other sources
+                { case: { $eq: ['$priority', 'critical'] }, then: 5 },
+                { case: { $eq: ['$priority', 'high'] }, then: 6 },
+                { case: { $eq: ['$priority', 'medium'] }, then: 7 },
+                { case: { $eq: ['$priority', 'low'] }, then: 8 },
               ],
-              default: 5,
+              default: 9,
             },
           },
         },

--- a/frontend/src/features/qa-interface-page/QA-interface.tsx
+++ b/frontend/src/features/qa-interface-page/QA-interface.tsx
@@ -263,6 +263,7 @@ export const QAInterface = ({
     } else {
       setNewAnswer("");
       setSources([]);
+      setRemarks("")
     }
     // Reset translation state when question changes
     setTranslatedText("");


### PR DESCRIPTION
**Description**

This pr change the sorting of allocated fetching by adding the source along with the priority in the case check and updated the priority cases to ensure the timebound questions are listed first. 
This pr also fixes the remark not reseting issue.