### PR TITLE
feat/ create accounts automatically in both dbs when selected coordinator

### DIFF
--- a/frontend/src/features/chatbotDashboard/components/AddFarmerModal.tsx
+++ b/frontend/src/features/chatbotDashboard/components/AddFarmerModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/atoms/dialog";
 import { Button } from "@/components/atoms/button";
 import { Input } from "@/components/atoms/input";
-import { Eye, EyeOff, RefreshCw } from "lucide-react";
+import { Eye, EyeOff, RefreshCw, Info } from "lucide-react";
 import { RadioGroup, RadioGroupItem } from "@/components/atoms/radio-group";
 import { Tabs, TabsList, TabsTrigger } from "@/components/atoms/tabs";
 
@@ -255,7 +255,7 @@ export function AddFarmerModal({
                   transition={{ duration: 0.2, ease: "easeOut" }}
                   className="min-h-0 flex-1 space-y-3 overflow-y-auto px-5 py-2"
                 >
-                  <motion.div
+                  {/* <motion.div
                     custom={0}
                     variants={formFieldVariants}
                     initial="hidden"
@@ -267,7 +267,7 @@ export function AddFarmerModal({
                         handleModeChange(value as ModalMode)
                       }
                     >
-                      <TabsList className="grid h-9 w-full grid-cols-2">
+                      <TabsList className="grid h-9 w-full grid-cols-1">
                         <TabsTrigger value="web_app">
                           Web Application
                         </TabsTrigger>
@@ -276,7 +276,7 @@ export function AddFarmerModal({
                         </TabsTrigger>
                       </TabsList>
                     </Tabs>
-                  </motion.div>
+                  </motion.div> */}
 
                   <motion.div
                     custom={1}
@@ -586,6 +586,25 @@ export function AddFarmerModal({
                     </AnimatePresence>
                   </motion.div>
                 </motion.div>
+              </AnimatePresence>
+
+              <AnimatePresence>
+                {["district_coordinator", "block_coordinator"].includes(role) && mode === "web_app" && (
+                  <motion.div
+                    initial={{ opacity: 0, y: -8, height: 0 }}
+                    animate={{ opacity: 1, y: 0, height: "auto" }}
+                    exit={{ opacity: 0, y: -8, height: 0 }}
+                    transition={{ duration: 0.25, ease: "easeOut" }}
+                    className="overflow-hidden px-5 pb-1"
+                  >
+                    <div className="flex items-start gap-2.5 rounded-xl border border-blue-200 bg-blue-50 px-3.5 py-3 text-[13px] leading-relaxed text-blue-800 dark:border-blue-500/20 dark:bg-blue-950/40 dark:text-blue-300">
+                      <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-500 dark:text-blue-400" />
+                      <span>
+                        District Coordinator and Block Coordinator accounts will be automatically created in both the Review System and Web Application.
+                      </span>
+                    </div>
+                  </motion.div>
+                )}
               </AnimatePresence>
 
               <motion.div

--- a/frontend/src/features/chatbotDashboard/hooks/useAddUser.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useAddUser.ts
@@ -26,8 +26,14 @@ export function useAddUser() {
         target?: 'web_app' | 'review_system';
       };
     }) => {
-      if (data.target === 'review_system') {
-        const result = await apiFetch<any>(
+      let reviewResult;
+
+      if (
+        data.target === 'review_system' ||
+        data.userRole === 'district_coordinator' ||
+        data.userRole === 'block_coordinator'
+      ) {
+        reviewResult = await apiFetch<any>(
           `${env.apiBaseUrl()}/auth/admin/review-users`,
           {
             method: 'POST',
@@ -35,12 +41,14 @@ export function useAddUser() {
               email: data.email,
               name: data.name,
               password: data.password,
-              role: data.role,
+              role: data.role || data.userRole,
               isVerified: data.isVerified,
             }),
           },
         );
-        return result;
+        if (data.target === 'review_system') {
+          return reviewResult;
+        }
       }
 
       const result = await apiFetch<any>(
@@ -50,7 +58,7 @@ export function useAddUser() {
           body: JSON.stringify(data),
         },
       );
-      return result;
+      return { ...result, reviewResult };
     },
     onSuccess: (_data, variables,context) => {
       if(context?.toastId)toast.dismiss(context.toastId)
@@ -58,6 +66,14 @@ export function useAddUser() {
       if (variables.data.target === 'review_system') {
         queryClient.invalidateQueries({ queryKey: ['admin'] });
         toast.success('Review system user added successfully');
+        return;
+      }
+      if (
+        variables.data.userRole === 'district_coordinator' ||
+        variables.data.userRole === 'block_coordinator'
+      ) {
+        queryClient.invalidateQueries({ queryKey: ['admin'] });
+        toast.success('User added to both systems successfully');
         return;
       }
       toast.success('Farmer added successfully');


### PR DESCRIPTION
### This PR includes:

* When a user is created through the **Web Application** form with the role **District Coordinator** or **Block Coordinator**, the system automatically creates the user in both the **Review System** and **Web Application** databases. To achieve this, it calls both the **Review System API** (`/auth/admin/review-users`) and the **Web App API** (`/analytics/users?source=${source}`), ensuring the user is synchronized across both systems.

* Hid the **Review System** tab from the user creation interface.

* Added an informational banner that appears when **District Coordinator** or **Block Coordinator** is selected in the **Web Application** form. The banner is displayed above the action buttons with a smooth animation and informs users that:

  > **District Coordinator and Block Coordinator accounts will be automatically created in both the Review System and Web Application.**
