### PR TITLE
Send userId and messageId to reviewer for AJRASAKHA uploads.

### DIFF
--- a/ai/ajrasakha/agents/config.py
+++ b/ai/ajrasakha/agents/config.py
@@ -48,6 +48,26 @@ def resolve_thread_id(config: Optional[dict[str, Any]] = None) -> Optional[str]:
             return str(val).strip()
     return None
 
+
+def resolve_user_id(config: Optional[dict[str, Any]] = None) -> Optional[str]:
+    """User identifier from configurable (set by langgraph-openai-adapter via x-user-id)."""
+    configurable = (config or {}).get("configurable") or {}
+    for key in ("user_id", "user"):
+        val = configurable.get(key)
+        if val is not None and str(val).strip():
+            return str(val).strip()
+    return None
+
+
+def resolve_message_id(config: Optional[dict[str, Any]] = None) -> Optional[str]:
+    """Message identifier from configurable (set by langgraph-openai-adapter via x-message-id)."""
+    configurable = (config or {}).get("configurable") or {}
+    for key in ("message_id", "message"):
+        val = configurable.get(key)
+        if val is not None and str(val).strip():
+            return str(val).strip()
+    return None
+
 # gdb_agent reads this (not MCP_URLS["gdb"]). Set in ai/.env, e.g. http://100.100.108.41:8110
 GOLDEN_API_URL = f"http://{REMOTE_IP}:8110"
 

--- a/ai/ajrasakha/agents/plan_executor.py
+++ b/ai/ajrasakha/agents/plan_executor.py
@@ -17,7 +17,12 @@ from ajrasakha.agents.location_context import (
     merge_location_dict,
 )
 from ajrasakha.agents.language import text_matches_user_language
-from ajrasakha.agents.config import resolve_question_source, resolve_thread_id
+from ajrasakha.agents.config import (
+    resolve_message_id,
+    resolve_question_source,
+    resolve_thread_id,
+    resolve_user_id,
+)
 from ajrasakha.agents.resolution_trace import trace_resolution, trace_thread_location
 from ajrasakha.agents.thread_trace import trace_event
 from ajrasakha.agents.domains import reviewer_upload_domain
@@ -416,6 +421,37 @@ def _resolve_reviewer_location(
     )
 
 
+def _apply_reviewer_identity_args(
+    reviewer_args: dict[str, Any],
+    *,
+    question_source: str | None,
+    thread_id: str | None = None,
+    user_id: str | None = None,
+    message_id: str | None = None,
+) -> None:
+    if thread_id and str(thread_id).strip():
+        reviewer_args["thread_id"] = str(thread_id).strip()
+
+    src = (question_source or "").strip().upper()
+    if src != "AJRASAKHA":
+        return
+
+    missing: list[str] = []
+    if user_id and str(user_id).strip():
+        reviewer_args["user_id"] = str(user_id).strip()
+    else:
+        missing.append("user_id")
+    if message_id and str(message_id).strip():
+        reviewer_args["message_id"] = str(message_id).strip()
+    else:
+        missing.append("message_id")
+    if missing:
+        logger.warning(
+            "AJRASAKHA reviewer upload missing identity fields: %s",
+            ", ".join(missing),
+        )
+
+
 def build_reviewer_upload_calls(
     plan: PlannerPlan,
     user_query: str,
@@ -425,6 +461,8 @@ def build_reviewer_upload_calls(
     reviewer_tool_name: str,
     question_source: str | None = None,
     thread_id: str | None = None,
+    user_id: str | None = None,
+    message_id: str | None = None,
     resolved: ResolvedToolEntities | None = None,
 ) -> list[dict[str, Any]]:
     """Location resolve (if needed) + upload_question_to_reviewer_system only."""
@@ -466,8 +504,13 @@ def build_reviewer_upload_calls(
             },
             "source": str(question_source).strip(),
         }
-        if thread_id and str(thread_id).strip():
-            reviewer_args["thread_id"] = str(thread_id).strip()
+        _apply_reviewer_identity_args(
+            reviewer_args,
+            question_source=question_source,
+            thread_id=thread_id,
+            user_id=user_id,
+            message_id=message_id,
+        )
         trace_resolution(
             "reviewer_upload_args",
             state=state_name,
@@ -724,6 +767,8 @@ async def build_reviewer_upload_with_tools_used(
     *,
     question_source: str | None = None,
     thread_id: str | None = None,
+    user_id: str | None = None,
+    message_id: str | None = None,
     resolved: ResolvedToolEntities | None = None,
 ) -> list[dict[str, Any]]:
     """Build reviewer upload call with computed tools_used."""
@@ -759,9 +804,14 @@ async def build_reviewer_upload_with_tools_used(
         },
         "source": str(question_source).strip(),
     }
-    if thread_id and str(thread_id).strip():
-        reviewer_args["thread_id"] = str(thread_id).strip()
-    
+    _apply_reviewer_identity_args(
+        reviewer_args,
+        question_source=question_source,
+        thread_id=thread_id,
+        user_id=user_id,
+        message_id=message_id,
+    )
+
     trace_resolution(
         "reviewer_upload_with_tools_used",
         state=state_name,
@@ -918,6 +968,8 @@ async def upload_reviewer_only_node(
     reviewer_tool = await get_reviewer_tool()
     question_source = resolve_question_source(config)
     thread_id = resolve_thread_id(config)
+    user_id = resolve_user_id(config)
+    message_id = resolve_message_id(config)
     tool_calls = build_reviewer_upload_calls(
         plan,
         user_query,
@@ -926,6 +978,8 @@ async def upload_reviewer_only_node(
         reviewer_tool_name=reviewer_tool.name,
         question_source=question_source,
         thread_id=thread_id,
+        user_id=user_id,
+        message_id=message_id,
     )
     if not tool_calls:
         return {}
@@ -971,6 +1025,8 @@ async def execute_plan_node(
     reviewer_tool = await get_reviewer_tool()
     question_source = resolve_question_source(config)
     thread_id = resolve_thread_id(config)
+    user_id = resolve_user_id(config)
+    message_id = resolve_message_id(config)
     
     # Step 1: Build and execute SPECIALIST tools ONLY (no reviewer upload)
     # This allows us to compute actual tools_used after seeing responses
@@ -991,6 +1047,8 @@ async def execute_plan_node(
             tools_used=[],
             question_source=question_source,
             thread_id=thread_id,
+            user_id=user_id,
+            message_id=message_id,
             resolved=resolved,
         )
         if reviewer_calls:
@@ -1037,6 +1095,8 @@ async def execute_plan_node(
         tools_used=actual_tools_used,
         question_source=question_source,
         thread_id=thread_id,
+        user_id=user_id,
+        message_id=message_id,
         resolved=resolved,
     )
     

--- a/ai/ajrasakha/agents/tests/test_agriculture_gate.py
+++ b/ai/ajrasakha/agents/tests/test_agriculture_gate.py
@@ -9,7 +9,7 @@ import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from ajrasakha.agents.ajrasakha import graph, use_planner_graph
-from ajrasakha.agents.plan_executor import build_reviewer_upload_calls, build_tool_calls_from_plan
+from ajrasakha.agents.plan_executor import build_reviewer_upload_calls
 from ajrasakha.agents.planner import route_after_ensure_location
 from ajrasakha.agents.planner_rules import (
     apply_non_agriculture_gate,
@@ -76,12 +76,18 @@ async def test_build_reviewer_upload_calls_only_reviewer():
         location_tool_name="location_information_tool",
         reviewer_tool_name="upload_question_to_reviewer_system",
         question_source="AJRASAKHA",
+        thread_id="conv-abc-123",
+        user_id="user-456",
+        message_id="msg-789",
     )
     names = [c["name"] for c in calls]
     assert names == ["upload_question_to_reviewer_system"]
     reviewer = calls[0]
     assert reviewer["args"]["question"] == "How can I make money?"
     assert reviewer["args"]["state_name"] == "Punjab"
+    assert reviewer["args"]["thread_id"] == "conv-abc-123"
+    assert reviewer["args"]["user_id"] == "user-456"
+    assert reviewer["args"]["message_id"] == "msg-789"
 
 
 @pytest.mark.asyncio

--- a/ai/ajrasakha/agents/tests/test_planner.py
+++ b/ai/ajrasakha/agents/tests/test_planner.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from ajrasakha.agents.plan_executor import (
-    build_tool_calls_from_plan,
+    build_reviewer_upload_calls,
     extract_chemicals_from_text,
     reviewer_direct_answer,
 )
@@ -93,7 +93,7 @@ async def test_reviewer_upload_uses_rephrased_query_not_raw_user_text():
         "entities": {"crop": "wheat", "state": "Punjab", "district": "Ropar"},
     }
     raw_user = "ਪੰਜਾਬ ਵਿੱਚ ਕਣਕ ਤੇ ਪੀਲਾ ਜੰਗ ਨਿਵਾਰਣ?"
-    calls = await build_tool_calls_from_plan(
+    calls = build_reviewer_upload_calls(
         plan,
         raw_user,
         {"state": "Punjab", "city": "Ropar"},
@@ -118,7 +118,7 @@ async def test_reviewer_upload_falls_back_to_user_query_without_rephrased():
         "is_complete": True,
         "entities": {"crop": "wheat", "state": "Punjab", "district": "Ropar"},
     }
-    calls = await build_tool_calls_from_plan(
+    calls = build_reviewer_upload_calls(
         plan,
         user_text,
         {"state": "Punjab", "city": "Ropar"},
@@ -130,7 +130,7 @@ async def test_reviewer_upload_falls_back_to_user_query_without_rephrased():
 
 
 @pytest.mark.asyncio
-async def test_reviewer_upload_includes_thread_id_when_provided():
+async def test_reviewer_upload_includes_identity_fields_for_ajrasakha():
     plan = {
         "weather": False,
         "mandi": False,
@@ -141,7 +141,7 @@ async def test_reviewer_upload_includes_thread_id_when_provided():
         "is_complete": True,
         "entities": {"crop": "wheat", "state": "Punjab", "district": "Ropar"},
     }
-    calls = await build_tool_calls_from_plan(
+    calls = build_reviewer_upload_calls(
         plan,
         "Yellow rust on wheat",
         {"state": "Punjab", "city": "Ropar"},
@@ -149,9 +149,42 @@ async def test_reviewer_upload_includes_thread_id_when_provided():
         reviewer_tool_name="upload_question_to_reviewer_system",
         question_source="AJRASAKHA",
         thread_id="conv-abc-123",
+        user_id="user-456",
+        message_id="msg-789",
     )
     reviewer = next(c for c in calls if c["name"] == "upload_question_to_reviewer_system")
     assert reviewer["args"]["thread_id"] == "conv-abc-123"
+    assert reviewer["args"]["user_id"] == "user-456"
+    assert reviewer["args"]["message_id"] == "msg-789"
+
+
+@pytest.mark.asyncio
+async def test_reviewer_upload_omits_identity_fields_for_non_ajrasakha():
+    plan = {
+        "weather": False,
+        "mandi": False,
+        "soil": False,
+        "schemes": False,
+        "chemical_checker": False,
+        "knowledge_base": True,
+        "is_complete": True,
+        "entities": {"crop": "wheat", "state": "Punjab", "district": "Ropar"},
+    }
+    calls = build_reviewer_upload_calls(
+        plan,
+        "Yellow rust on wheat",
+        {"state": "Punjab", "city": "Ropar"},
+        location_tool_name="location_information_tool",
+        reviewer_tool_name="upload_question_to_reviewer_system",
+        question_source="WHATSAPP",
+        thread_id="conv-abc-123",
+        user_id="user-456",
+        message_id="msg-789",
+    )
+    reviewer = next(c for c in calls if c["name"] == "upload_question_to_reviewer_system")
+    assert reviewer["args"]["thread_id"] == "conv-abc-123"
+    assert "user_id" not in reviewer["args"]
+    assert "message_id" not in reviewer["args"]
 
 
 @pytest.mark.asyncio
@@ -166,7 +199,7 @@ async def test_reviewer_upload_omits_thread_id_when_not_provided():
         "is_complete": True,
         "entities": {"crop": "wheat", "state": "Punjab", "district": "Ropar"},
     }
-    calls = await build_tool_calls_from_plan(
+    calls = build_reviewer_upload_calls(
         plan,
         "Yellow rust on wheat",
         {"state": "Punjab", "city": "Ropar"},

--- a/ai/ajrasakha/tools/reviewer/reviewer_system_tool.py
+++ b/ai/ajrasakha/tools/reviewer/reviewer_system_tool.py
@@ -53,6 +53,8 @@ def upload_question_to_reviewer_system(
     source: str,
     thread_id: str,
     tools_used: Optional[list[str]] = None,
+    user_id: Optional[str] = None,
+    message_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Pushes a farmer's question to the reviewer system for the Agri team to review.
@@ -66,6 +68,8 @@ def upload_question_to_reviewer_system(
     - source (str): Question channel identifier (e.g. AJRASAKHA, WHATSAPP, AJRASAKHA_WEBAPP).
     - thread_id (str): LangGraph conversation id (from x-conversation-id). Injected by the agent, not inferred by the LLM.
     - tools_used (list[str], optional): List of tools used to generate the answer (e.g. ["knowledge_base", "weather", "mandi"]). Empty list for non-agriculture queries.
+    - user_id (str, optional): LibreChat user id (from x-user-id). Injected by the agent for AJRASAKHA uploads.
+    - message_id (str, optional): LibreChat message id (from x-message-id). Injected by the agent for AJRASAKHA uploads.
     """
 
     if not isinstance(question, str) or not question.strip():
@@ -114,6 +118,10 @@ def upload_question_to_reviewer_system(
         "tools_used": tools_used if tools_used is not None else [],
         "threadId": thread_id.strip(),
     }
+    if user_id and str(user_id).strip():
+        payload["userId"] = str(user_id).strip()
+    if message_id and str(message_id).strip():
+        payload["messageId"] = str(message_id).strip()
 
     headers = {
         "x-internal-api-key": INTERNAL_API_KEY,

--- a/apis/langgraph-openai-adapter/langgraph_bridge.py
+++ b/apis/langgraph-openai-adapter/langgraph_bridge.py
@@ -276,6 +276,11 @@ def build_run_config(
         if user_id and str(user_id).strip():
             configurable["user_id"] = str(user_id).strip()
             break
+    for key in ("x-message-id", "X-Message-ID"):
+        message_id = request_headers.get(key)
+        if message_id and str(message_id).strip():
+            configurable["message_id"] = str(message_id).strip()
+            break
     return {"configurable": configurable}
 
 


### PR DESCRIPTION
Propagate x-user-id and x-message-id from the LangGraph adapter into configurable, attach them to reviewer tool args for AJRASAKHA, and include userId/messageId in the reviewer MCP POST payload.