### PR TITLE
Improve thread log Mongo sync and persist user location with provenance.

### DIFF
--- a/ai/.env.example
+++ b/ai/.env.example
@@ -30,9 +30,13 @@ THREAD_LOG_DIR=logs
 THREAD_FILE_LOGGING=true
 # MongoDB thread logs (agriai.langgraph_log): one document per thread_id (_id).
 #   turns[]  — per farmer message: user_message, bot_message, outcome, log_text
+#   full_logs — full local .txt snapshot (updated async each turn)
 # (no top-level text field; all logs live in turns[n].log_text)
 THREAD_LOG_MONGODB=true
 THREAD_LOG_MONGODB_COLLECTION=langgraph_log
+# Async by default (non-blocking). Set THREAD_LOG_MONGO_SYNC=true only for debugging.
+# THREAD_LOG_MONGO_SYNC=false
+# THREAD_LOG_MONGO_WORKERS=4
 
 # Agricultural API Base URLs
 AGMARKNET_BASE_URL=https://api.agmarknet.gov.in/v1

--- a/ai/ajrasakha/agents/location_context.py
+++ b/ai/ajrasakha/agents/location_context.py
@@ -87,6 +87,22 @@ def extract_state_from_text(text: str) -> Optional[str]:
     return None
 
 
+def normalize_state_name(state: str | None) -> Optional[str]:
+    """Map a state string to the canonical Indian state name, if recognized."""
+    if not state:
+        return None
+    cleaned = " ".join(str(state).strip().split())
+    if not cleaned or cleaned.lower() in _PLACEHOLDER_LOCATION_VALUES:
+        return None
+    for name, _pattern in _STATE_PATTERNS:
+        if cleaned.lower() == name.lower():
+            return name
+    from_text = extract_state_from_text(cleaned)
+    if from_text:
+        return from_text
+    return cleaned.title()
+
+
 def _message_to_text(message: BaseMessage) -> str:
     content = message.content
     if content is None:

--- a/ai/ajrasakha/agents/planner.py
+++ b/ai/ajrasakha/agents/planner.py
@@ -21,7 +21,7 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from langchain_core.runnables import RunnableConfig, patch_config
 from pydantic import BaseModel, Field
 
-from ajrasakha.agents.config import PLANNER_MODEL
+from ajrasakha.agents.config import PLANNER_MODEL, resolve_thread_id, resolve_user_id
 from ajrasakha.agents.thread_logging import (
     begin_conversation_turn,
     end_conversation_turn,
@@ -67,6 +67,7 @@ from ajrasakha.agents.planner_rules import (
 )
 from ajrasakha.agents.prompts import PLANNER_SYSTEM_PROMPT
 from ajrasakha.agents.state import AjraSakhaState, PlannerEntities, PlannerPlan
+from ajrasakha.agents.user_location import load_user_location, maybe_persist_resolved_location
 
 logger = logging.getLogger(__name__)
 
@@ -639,10 +640,13 @@ async def planner_node(
             plan["original_query_en"] = user_text
 
         configurable = config.get("configurable") or {}
-        user_id = configurable.get("user_id") or configurable.get("phone_number")
+        user_id = resolve_user_id(config) or configurable.get("phone_number")
+        stored_location = load_user_location(user_id) if user_id else None
+        location_sources: dict[str, str | None] = {}
         trace_event(
             "planner_user_location_lookup",
             user_id=user_id,
+            stored_location=stored_location,
             configurable_user_id=(config.get("configurable") or {}).get("user_id"),
         )
         entities = merge_entities_from_rephrased_query(
@@ -650,6 +654,8 @@ async def planner_node(
             messages,
             location,
             prev_entities,
+            stored_location=stored_location,
+            sources_out=location_sources,
         )
         plan["entities"] = entities
         trace_event("planner_entities_merged", entities=entities)
@@ -695,7 +701,20 @@ async def planner_node(
             messages,
             location,
             prev_entities,
+            stored_location=stored_location,
+            sources_out=location_sources,
         )
+
+        if plan.get("is_complete"):
+            final_entities = plan.get("entities") or {}
+            maybe_persist_resolved_location(
+                user_id,
+                final_entities.get("state"),
+                final_entities.get("district"),
+                thread_id=resolve_thread_id(config),
+                state_source=location_sources.get("state_source"),
+                district_source=location_sources.get("district_source"),
+            )
 
         trace_event(
             "planner_final_plan",

--- a/ai/ajrasakha/agents/planner_rules.py
+++ b/ai/ajrasakha/agents/planner_rules.py
@@ -312,11 +312,14 @@ def merge_entities_from_rephrased_query(
     messages: list[BaseMessage],
     location: Optional[Location],
     prev_entities: Optional[PlannerEntities] = None,
+    *,
+    stored_location: Optional[dict[str, str]] = None,
+    sources_out: Optional[dict[str, str | None]] = None,
 ) -> PlannerEntities:
     """Resolve state/crop/district from farmer text and planner LLM entities only (no GPS).
 
     State/district never come from device coordinates — only from rephrased query text,
-    LLM entity fields, or ``prev_entities`` during an incomplete clarification turn.
+    LLM entity fields, stored user location, or ``prev_entities`` during clarification.
     """
     # Start with previous entities, override with new plan entities
     merged: PlannerEntities = {**(prev_entities or {}), **dict(plan.get("entities") or {})}
@@ -389,6 +392,11 @@ def merge_entities_from_rephrased_query(
         merged["district"] = "all"
         state_source = "rephrased_query_text" if state_from_text else "plan.entities.state (llm)"
         district_source = "default_all_when_state_only"
+    elif stored_location and stored_location.get("state"):
+        merged["state"] = stored_location["state"]
+        merged["district"] = stored_location.get("district") or "all"
+        state_source = "stored_user_location"
+        district_source = "stored_user_location"
     elif prev_entities and prev_entities.get("state"):
         merged["state"] = prev_entities.get("state")
         state_source = "prev_entities (incomplete_clarify_carryover)"
@@ -420,6 +428,10 @@ def merge_entities_from_rephrased_query(
         crop_source=crop_source,
         entity_text=text[:200] if text else None,
     )
+
+    if sources_out is not None:
+        sources_out["state_source"] = state_source
+        sources_out["district_source"] = district_source
 
     return merged
 
@@ -501,8 +513,18 @@ def _merge_entities(
     messages: list[BaseMessage],
     location: Optional[Location],
     prev_entities: Optional[PlannerEntities] = None,
+    *,
+    stored_location: Optional[dict[str, str]] = None,
+    sources_out: Optional[dict[str, str | None]] = None,
 ) -> PlannerEntities:
-    return merge_entities_from_rephrased_query(plan, messages, location, prev_entities)
+    return merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        location,
+        prev_entities,
+        stored_location=stored_location,
+        sources_out=sources_out,
+    )
 
 
 def _location_status(
@@ -568,6 +590,9 @@ def apply_planner_completeness_rules(
     messages: list[BaseMessage],
     location: Optional[Location],
     prev_entities: Optional[PlannerEntities] = None,
+    *,
+    stored_location: Optional[dict[str, str]] = None,
+    sources_out: Optional[dict[str, str | None]] = None,
 ) -> PlannerPlan:
     """Post-process planner output: merge entities, enforce scheme overrides.
 
@@ -582,7 +607,14 @@ def apply_planner_completeness_rules(
     """
     out: PlannerPlan = dict(plan)
     latest = latest_human_text(messages)
-    entities = _merge_entities(out, messages, location, prev_entities)
+    entities = _merge_entities(
+        out,
+        messages,
+        location,
+        prev_entities,
+        stored_location=stored_location,
+        sources_out=sources_out,
+    )
     domains_for_crop = list(out.get("domains") or [normalize_domain(out.get("domain") or "General")])
     entities = apply_crop_one_shot_fallback(messages, entities, domains_for_crop)
     out["entities"] = entities

--- a/ai/ajrasakha/agents/tests/test_thread_log_mongo.py
+++ b/ai/ajrasakha/agents/tests/test_thread_log_mongo.py
@@ -61,11 +61,39 @@ def test_sync_turn_to_mongo_pushes_turn_without_text(tmp_path: Path, monkeypatch
     assert mock_col.update_one.call_args[1]["upsert"] is True
 
 
+def test_sync_missing_turns_only_pushes_absent(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("GOLDEN_MONGODB_URI", "mongodb://localhost:27017")
+    mock_col = MagicMock()
+    monkeypatch.setattr(tlm, "_collection", mock_col)
+    monkeypatch.setattr(
+        tlm,
+        "read_thread_turns",
+        lambda thread_id: [{"turn": 2, "user_message": "punjab"}],
+    )
+
+    records = [
+        {"turn": 1, "user_message": "disease", "log_text": "turn1"},
+        {"turn": 2, "user_message": "punjab", "log_text": "turn2"},
+    ]
+    tlm.sync_completed_turns_to_mongo(
+        "thread-abc",
+        records,
+        full_logs="full file text",
+        background=False,
+    )
+
+    mock_col.update_one.assert_called_once()
+    _, update_doc = mock_col.update_one.call_args[0]
+    assert update_doc["$push"]["turns"]["turn"] == 1
+    assert update_doc["$set"]["full_logs"] == "full file text"
+
+
 def test_sync_turn_to_mongo_swallows_errors(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("GOLDEN_MONGODB_URI", "mongodb://localhost:27017")
     mock_col = MagicMock()
     mock_col.update_one.side_effect = RuntimeError("db down")
     monkeypatch.setattr(tlm, "_collection", mock_col)
+    monkeypatch.setattr(tlm, "read_thread_turns", lambda thread_id: [])
 
     log_file = tmp_path / "thread-abc.txt"
     log_file.write_text("hello\n", encoding="utf-8")
@@ -159,9 +187,23 @@ def test_read_thread_log_text_from_turns(monkeypatch):
     assert tlm.read_thread_log_text("thread-abc") == "trace 1\ntrace 2\n"
     mock_col.find_one.assert_called_once_with(
         {"_id": "thread-abc"},
-        {"turns": 1, "text": 1},
+        {"turns": 1, "text": 1, "full_logs": 1},
         max_time_ms=tlm._MONGO_OP_TIMEOUT_MS,
     )
+
+
+def test_read_max_turn_number(monkeypatch):
+    monkeypatch.setenv("GOLDEN_MONGODB_URI", "mongodb://localhost:27017")
+    mock_col = MagicMock()
+    mock_col.find_one.return_value = {
+        "turns": [
+            {"turn": 1, "log_text": "a"},
+            {"turn": 2, "log_text": "b"},
+        ]
+    }
+    monkeypatch.setattr(tlm, "_collection", mock_col)
+
+    assert tlm.read_max_turn_number("thread-abc") == 2
 
 
 def test_read_thread_log_text(monkeypatch):

--- a/ai/ajrasakha/agents/tests/test_thread_logging.py
+++ b/ai/ajrasakha/agents/tests/test_thread_logging.py
@@ -93,14 +93,14 @@ def test_thread_file_handler_routes_by_context(tmp_path: Path):
 
 
 def test_end_conversation_turn_syncs_turn_to_mongo(tmp_path: Path, monkeypatch):
-    sync_calls: list[tuple[str, dict]] = []
+    sync_calls: list[tuple[str, list]] = []
 
-    def _capture_sync(thread_id: str, turn_record: dict, *, background=True):
-        sync_calls.append((thread_id, turn_record))
+    def _capture_sync(thread_id: str, turn_records, *, full_logs=None, background=True):
+        sync_calls.append((thread_id, turn_records))
 
     monkeypatch.setattr(tl, "thread_log_dir", lambda: tmp_path)
     monkeypatch.setattr(tl, "mongo_thread_log_enabled", lambda: True)
-    monkeypatch.setattr(tl, "sync_turn_to_mongo", _capture_sync)
+    monkeypatch.setattr(tl, "sync_completed_turns_to_mongo", _capture_sync)
 
     tl.set_thread_log_context("thread-mongo")
     tl.begin_conversation_turn("Hi")
@@ -108,8 +108,10 @@ def test_end_conversation_turn_syncs_turn_to_mongo(tmp_path: Path, monkeypatch):
     tl.clear_thread_log_context()
 
     assert len(sync_calls) == 1
-    thread_id, turn_record = sync_calls[0]
+    thread_id, turn_records = sync_calls[0]
     assert thread_id == "thread-mongo"
+    assert len(turn_records) == 1
+    turn_record = turn_records[0]
     assert turn_record["turn"] == 1
     assert turn_record["user_message"] == "Hi"
     assert turn_record["bot_message"] == "Hello!"
@@ -120,16 +122,47 @@ def test_end_conversation_turn_syncs_turn_to_mongo(tmp_path: Path, monkeypatch):
     assert (tmp_path / "thread-mongo.txt").is_file()
 
 
-def test_turn_state_survives_node_context_reset(tmp_path: Path, monkeypatch):
-    """Simulate LangGraph: planner sets turn, later node clears ContextVar but ends turn."""
-    sync_calls: list[dict] = []
+def test_end_conversation_turn_backfills_missing_turn_one(tmp_path: Path, monkeypatch):
+    """Turn 2 end should send both turn 1 (clarify) and turn 2 records to Mongo sync."""
+    sync_calls: list[list] = []
 
-    def _capture_sync(thread_id: str, turn_record: dict, *, background=True):
-        sync_calls.append(turn_record)
+    def _capture_sync(thread_id: str, turn_records, *, full_logs=None, background=True):
+        sync_calls.append(turn_records)
 
     monkeypatch.setattr(tl, "thread_log_dir", lambda: tmp_path)
     monkeypatch.setattr(tl, "mongo_thread_log_enabled", lambda: True)
-    monkeypatch.setattr(tl, "sync_turn_to_mongo", _capture_sync)
+    monkeypatch.setattr(tl, "sync_completed_turns_to_mongo", _capture_sync)
+
+    tl.set_thread_log_context("thread-backfill")
+    tl.begin_conversation_turn("my potatoes have leaf blight disease")
+    tl.end_conversation_turn("Please share your state.", outcome="clarify")
+    tl.clear_thread_log_context()
+
+    tl.set_thread_log_context("thread-backfill")
+    tl.begin_conversation_turn("punjab")
+    tl.end_conversation_turn("Here is advice.", outcome="answer")
+    tl.clear_thread_log_context()
+
+    assert len(sync_calls) == 2
+    second_batch = sync_calls[1]
+    assert len(second_batch) == 2
+    assert second_batch[0]["turn"] == 1
+    assert second_batch[0]["outcome"] == "clarify"
+    assert "leaf blight" in second_batch[0]["user_message"]
+    assert second_batch[1]["turn"] == 2
+    assert second_batch[1]["user_message"] == "punjab"
+
+
+def test_turn_state_survives_node_context_reset(tmp_path: Path, monkeypatch):
+    """Simulate LangGraph: planner sets turn, later node clears ContextVar but ends turn."""
+    sync_calls: list[list] = []
+
+    def _capture_sync(thread_id: str, turn_records, *, full_logs=None, background=True):
+        sync_calls.append(turn_records)
+
+    monkeypatch.setattr(tl, "thread_log_dir", lambda: tmp_path)
+    monkeypatch.setattr(tl, "mongo_thread_log_enabled", lambda: True)
+    monkeypatch.setattr(tl, "sync_completed_turns_to_mongo", _capture_sync)
 
     tl.set_thread_log_context("thread-nodes")
     tl.begin_conversation_turn("hii")
@@ -140,21 +173,21 @@ def test_turn_state_survives_node_context_reset(tmp_path: Path, monkeypatch):
     tl.clear_thread_log_context()
 
     assert len(sync_calls) == 1
-    assert sync_calls[0]["user_message"] == "hii"
-    assert "hii" in sync_calls[0]["log_text"]
-    assert "Hi there!" in sync_calls[0]["log_text"]
-    assert "END TURN 1" in sync_calls[0]["log_text"]
+    assert sync_calls[0][0]["user_message"] == "hii"
+    assert "hii" in sync_calls[0][0]["log_text"]
+    assert "Hi there!" in sync_calls[0][0]["log_text"]
+    assert "END TURN 1" in sync_calls[0][0]["log_text"]
 
 
 def test_turn_buffer_captures_handler_logs(tmp_path: Path, monkeypatch):
-    sync_calls: list[dict] = []
+    sync_calls: list[list] = []
 
-    def _capture_sync(thread_id: str, turn_record: dict, *, background=True):
-        sync_calls.append(turn_record)
+    def _capture_sync(thread_id: str, turn_records, *, full_logs=None, background=True):
+        sync_calls.append(turn_records)
 
     monkeypatch.setattr(tl, "thread_log_dir", lambda: tmp_path)
     monkeypatch.setattr(tl, "mongo_thread_log_enabled", lambda: True)
-    monkeypatch.setattr(tl, "sync_turn_to_mongo", _capture_sync)
+    monkeypatch.setattr(tl, "sync_completed_turns_to_mongo", _capture_sync)
 
     handler = tl.ThreadFileLogHandler(tmp_path)
     handler.addFilter(tl.ThreadLogFilter())
@@ -170,8 +203,8 @@ def test_turn_buffer_captures_handler_logs(tmp_path: Path, monkeypatch):
     logger.removeHandler(handler)
 
     assert len(sync_calls) == 1
-    assert "planner resolved state=Punjab" in sync_calls[0]["log_text"]
-    assert "Weather?" in sync_calls[0]["log_text"]
+    assert "planner resolved state=Punjab" in sync_calls[0][0]["log_text"]
+    assert "Weather?" in sync_calls[0][0]["log_text"]
 
 
 def test_handler_emit_writes_file_only_not_mongo_per_line(tmp_path: Path, monkeypatch):
@@ -181,7 +214,7 @@ def test_handler_emit_writes_file_only_not_mongo_per_line(tmp_path: Path, monkey
         sync_calls.append(thread_id)
 
     monkeypatch.setattr(tl, "mongo_thread_log_enabled", lambda: True)
-    monkeypatch.setattr(tl, "sync_turn_to_mongo", _capture_sync)
+    monkeypatch.setattr(tl, "sync_completed_turns_to_mongo", _capture_sync)
 
     handler = tl.ThreadFileLogHandler(tmp_path)
     handler.addFilter(tl.ThreadLogFilter())

--- a/ai/ajrasakha/agents/tests/test_user_location_mongo.py
+++ b/ai/ajrasakha/agents/tests/test_user_location_mongo.py
@@ -1,0 +1,118 @@
+"""Tests for user_details MongoDB persistence."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ajrasakha.agents import user_location_mongo as mongo
+
+
+def _mock_collection():
+    col = MagicMock()
+    store: dict[str, dict] = {}
+
+    def find_one(query, projection=None, max_time_ms=None):
+        return store.get(query.get("user_id"))
+
+    def update_one(query, update, upsert=False):
+        user_id = query["user_id"]
+        doc = store.get(user_id, {"user_id": user_id, "location_history": []})
+        if "$setOnInsert" in update:
+            for key, value in update["$setOnInsert"].items():
+                doc.setdefault(key, value)
+        if "$set" in update:
+            doc.update(update["$set"])
+        if "$push" in update:
+            push_spec = update["$push"]["location_history"]
+            history = doc.setdefault("location_history", [])
+            history.extend(push_spec["$each"])
+            slice_val = push_spec["$slice"]
+            doc["location_history"] = history[slice_val:] if slice_val < 0 else history[:slice_val]
+        store[user_id] = doc
+        return MagicMock(matched_count=1)
+
+    col.find_one.side_effect = find_one
+    col.update_one.side_effect = update_one
+    col._store = store
+    return col
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_save_includes_thread_id_metadata(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+
+    assert mongo.save_user_location(
+        "919876543210",
+        "all",
+        "Punjab",
+        thread_id="080ebed7-bd96-4a89-9a49-57a4b05d360f",
+        state_source="rephrased_query_text",
+        district_source="default_all_when_state_only",
+    ) is True
+
+    doc = col._store["919876543210"]
+    assert doc["current_location"] == {"district": "all", "state": "Punjab"}
+    source = doc["current_location_source"]
+    assert source["thread_id"] == "080ebed7-bd96-4a89-9a49-57a4b05d360f"
+    assert source["state_source"] == "rephrased_query_text"
+    assert source["district_source"] == "default_all_when_state_only"
+    assert source["picked_at"].endswith("Z")
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_same_location_refreshes_source_metadata(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+
+    mongo.save_user_location(
+        "919876543210",
+        "all",
+        "Punjab",
+        thread_id="thread-a",
+        state_source="rephrased_query_text",
+        district_source="default_all_when_state_only",
+    )
+    assert mongo.save_user_location(
+        "919876543210",
+        "all",
+        "Punjab",
+        thread_id="thread-b",
+        state_source="rephrased_query_text",
+        district_source="default_all_when_state_only",
+    ) is True
+
+    doc = col._store["919876543210"]
+    assert doc["current_location_source"]["thread_id"] == "thread-b"
+    assert doc["location_history"] == []
+
+
+@patch.dict("os.environ", {"GOLDEN_MONGODB_URI": "mongodb://test", "GOLDEN_MONGODB_DATABASE": "agriai"})
+@patch.object(mongo, "_get_collection")
+def test_location_change_preserves_old_source_in_history(mock_get_collection):
+    col = _mock_collection()
+    mock_get_collection.return_value = col
+
+    mongo.save_user_location(
+        "919876543210",
+        "Sirsa",
+        "Haryana",
+        thread_id="thread-a",
+        state_source="rephrased_query_text",
+        district_source="plan.entities.district (llm)",
+    )
+    mongo.save_user_location(
+        "919876543210",
+        "Ambala",
+        "Haryana",
+        thread_id="thread-b",
+        state_source="rephrased_query_text",
+        district_source="plan.entities.district (llm)",
+    )
+
+    doc = col._store["919876543210"]
+    assert doc["current_location"] == {"district": "Ambala", "state": "Haryana"}
+    assert len(doc["location_history"]) == 1
+    assert doc["location_history"][0]["source"]["thread_id"] == "thread-a"

--- a/ai/ajrasakha/agents/thread_log_mongo.py
+++ b/ai/ajrasakha/agents/thread_log_mongo.py
@@ -3,13 +3,19 @@
 During a request, logs are written only to the local file (THREAD_LOG_DIR).
 When a turn completes, the turn record is pushed to ``turns[]`` on the thread
 document (one document per thread_id, no top-level ``text`` field).
+
+Writes are queued on a background thread pool (non-blocking for the graph) with
+retries so fast clarify turns are not lost when the worker returns early.
 """
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -23,8 +29,12 @@ _client = None
 _collection: Collection | None = None
 _init_lock = threading.Lock()
 _init_logged = False
+_executor: ThreadPoolExecutor | None = None
+_executor_lock = threading.Lock()
 
 _MONGO_OP_TIMEOUT_MS = 5_000
+_MONGO_SYNC_RETRIES = 3
+_MONGO_SYNC_RETRY_BASE_S = 0.2
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -82,58 +92,174 @@ def _get_collection() -> Collection | None:
         if not _init_logged:
             _init_logged = True
             logger.info(
-                "Thread log MongoDB enabled: %s.%s (end-of-turn turns[] sync)",
+                "Thread log MongoDB enabled: %s.%s (async turns[] sync with retries)",
                 _database_name(),
                 _collection_name(),
             )
     return _collection
 
 
-def _sync_turn_to_mongo(thread_id: str, turn_record: dict[str, Any]) -> None:
-    """Push one turn to turns[] on the thread document."""
+def _get_executor() -> ThreadPoolExecutor:
+    """Shared pool for background Mongo writes (non-daemon workers survive request return)."""
+    global _executor
+    with _executor_lock:
+        if _executor is None:
+            workers = max(1, int(os.getenv("THREAD_LOG_MONGO_WORKERS", "4")))
+            _executor = ThreadPoolExecutor(
+                max_workers=workers,
+                thread_name_prefix="thread-log-mongo",
+            )
+            atexit.register(_shutdown_executor)
+        return _executor
+
+
+def _shutdown_executor() -> None:
+    global _executor
+    with _executor_lock:
+        if _executor is not None:
+            _executor.shutdown(wait=True, cancel_futures=False)
+            _executor = None
+
+
+def _sync_turn_to_mongo(
+    thread_id: str,
+    turn_record: dict[str, Any],
+    *,
+    full_logs: str | None = None,
+) -> None:
+    """Push one turn to turns[] on the thread document (with retries)."""
     col = _get_collection()
     if col is None:
         return
 
     now = datetime.now(timezone.utc)
-    try:
-        col.update_one(
-            {"_id": thread_id},
-            {
-                "$push": {"turns": turn_record},
-                "$set": {"updated_at": now},
-                "$unset": {"text": ""},
-                "$setOnInsert": {"created_at": now},
-            },
-            upsert=True,
-        )
-    except Exception:
-        logger.exception("Failed to sync turn log to MongoDB for %s", thread_id)
+    set_fields: dict[str, Any] = {"updated_at": now}
+    if full_logs is not None:
+        set_fields["full_logs"] = full_logs
+
+    update_doc: dict[str, Any] = {
+        "$push": {"turns": turn_record},
+        "$set": set_fields,
+        "$unset": {"text": ""},
+        "$setOnInsert": {"created_at": now},
+    }
+
+    last_exc: Exception | None = None
+    for attempt in range(_MONGO_SYNC_RETRIES):
+        try:
+            col.update_one(
+                {"_id": thread_id},
+                update_doc,
+                upsert=True,
+            )
+            return
+        except Exception as exc:
+            last_exc = exc
+            if attempt < _MONGO_SYNC_RETRIES - 1:
+                time.sleep(_MONGO_SYNC_RETRY_BASE_S * (attempt + 1))
+
+    logger.exception(
+        "Failed to sync turn log to MongoDB for %s after %d attempts: %s",
+        thread_id,
+        _MONGO_SYNC_RETRIES,
+        last_exc,
+    )
 
 
 def sync_turn_to_mongo(
     thread_id: str,
     turn_record: dict[str, Any],
     *,
+    full_logs: str | None = None,
     background: bool = True,
 ) -> None:
     """Push a completed turn to MongoDB turns[] on the thread document.
 
-    When ``background`` is True (default), runs in a daemon thread so the graph
-    response is never blocked on MongoDB.
+    Prefer :func:`sync_completed_turns_to_mongo` when multiple turns may be missing.
     """
-    if not thread_id or not mongo_thread_log_enabled():
+    sync_completed_turns_to_mongo(
+        thread_id,
+        [turn_record],
+        full_logs=full_logs,
+        background=background,
+    )
+
+
+def _sync_missing_turns_impl(
+    thread_id: str,
+    turn_records: list[dict[str, Any]],
+    *,
+    full_logs: str | None = None,
+) -> None:
+    """Push any turn records not yet present in Mongo (by turn number)."""
+    if not turn_records:
         return
 
-    if background:
-        threading.Thread(
-            target=_sync_turn_to_mongo,
-            args=(thread_id, turn_record),
-            name=f"thread-log-mongo-turn-{thread_id[:8]}",
-            daemon=True,
-        ).start()
-    else:
-        _sync_turn_to_mongo(thread_id, turn_record)
+    existing_nums: set[int] = set()
+    for item in read_thread_turns(thread_id):
+        if isinstance(item, dict):
+            turn = item.get("turn")
+            if isinstance(turn, int) and turn > 0:
+                existing_nums.add(turn)
+
+    missing = sorted(
+        (r for r in turn_records if isinstance(r.get("turn"), int) and r["turn"] not in existing_nums),
+        key=lambda r: r["turn"],
+    )
+    if not missing:
+        return
+
+    for idx, record in enumerate(missing):
+        is_last = idx == len(missing) - 1
+        _sync_turn_to_mongo(
+            thread_id,
+            record,
+            full_logs=full_logs if is_last else None,
+        )
+
+    logger.info(
+        "Synced %d missing turn(s) to Mongo for thread %s (turns=%s)",
+        len(missing),
+        thread_id,
+        [r["turn"] for r in missing],
+    )
+
+
+def sync_completed_turns_to_mongo(
+    thread_id: str,
+    turn_records: list[dict[str, Any]],
+    *,
+    full_logs: str | None = None,
+    background: bool = True,
+) -> None:
+    """Push all completed turns that are not yet stored in Mongo (non-blocking by default)."""
+    if not thread_id or not mongo_thread_log_enabled() or not turn_records:
+        return
+
+    sync_blocking = not background or _env_flag("THREAD_LOG_MONGO_SYNC")
+    if sync_blocking:
+        _sync_missing_turns_impl(thread_id, turn_records, full_logs=full_logs)
+        return
+
+    _get_executor().submit(
+        _sync_missing_turns_impl,
+        thread_id,
+        turn_records,
+        full_logs=full_logs,
+    )
+
+
+def read_max_turn_number(thread_id: str) -> int:
+    """Highest completed turn number stored in Mongo for this thread."""
+    turns = read_thread_turns(thread_id)
+    nums: list[int] = []
+    for item in turns:
+        if not isinstance(item, dict):
+            continue
+        turn = item.get("turn")
+        if isinstance(turn, int) and turn > 0:
+            nums.append(turn)
+    return max(nums) if nums else 0
 
 
 def read_thread_turns(thread_id: str) -> list[dict[str, Any]]:
@@ -161,7 +287,7 @@ def read_thread_turns(thread_id: str) -> list[dict[str, Any]]:
 
 
 def read_thread_log_text(thread_id: str) -> str:
-    """Read accumulated log text for a thread (concatenated turns[].log_text)."""
+    """Read accumulated log text for a thread (full_logs, then turns[], then legacy text)."""
     if not thread_id:
         return ""
 
@@ -172,11 +298,15 @@ def read_thread_log_text(thread_id: str) -> str:
     try:
         doc = col.find_one(
             {"_id": thread_id},
-            {"turns": 1, "text": 1},
+            {"turns": 1, "text": 1, "full_logs": 1},
             max_time_ms=_MONGO_OP_TIMEOUT_MS,
         )
         if not doc:
             return ""
+
+        full_logs = doc.get("full_logs")
+        if isinstance(full_logs, str) and full_logs.strip():
+            return full_logs
 
         turns = doc.get("turns")
         if isinstance(turns, list) and turns:
@@ -239,12 +369,7 @@ def sync_thread_log_file_to_mongo(
         return
 
     path = Path(file_path)
-    if background:
-        threading.Thread(
-            target=_sync_file_to_mongo,
-            args=(thread_id, path),
-            name=f"thread-log-mongo-sync-{thread_id[:8]}",
-            daemon=True,
-        ).start()
+    if background and not _env_flag("THREAD_LOG_MONGO_SYNC"):
+        _get_executor().submit(_sync_file_to_mongo, thread_id, path)
     else:
         _sync_file_to_mongo(thread_id, path)

--- a/ai/ajrasakha/agents/thread_logging.py
+++ b/ai/ajrasakha/agents/thread_logging.py
@@ -27,8 +27,9 @@ from langchain_core.runnables import RunnableConfig
 from ajrasakha.agents.config import resolve_thread_id
 from ajrasakha.agents.thread_log_mongo import (
     mongo_thread_log_enabled,
+    read_max_turn_number,
     read_thread_log_text,
-    sync_turn_to_mongo,
+    sync_completed_turns_to_mongo,
 )
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -51,6 +52,12 @@ _FARMER_MESSAGE_RE = re.compile(
     r"┏━ FARMER MESSAGE ━+\n(.*?)\n┗━",
     re.DOTALL,
 )
+_BOT_MESSAGE_RE = re.compile(
+    r"┏━ BOT MESSAGE ━+\n(.*?)\n┗━",
+    re.DOTALL,
+)
+_OUTCOME_RE = re.compile(r"── bot reply \(turn \d+\) \| outcome=(\w+)")
+_STARTED_AT_RE = re.compile(r"#  started: (.+)")
 _BOX_WIDTH = 76
 
 # Thread log files: application logs only (skip httpx / MCP transport noise).
@@ -128,12 +135,21 @@ def _read_thread_log_text(thread_id: str) -> str:
 
 
 def _max_turn_from_log(thread_id: str) -> int:
-    """Read highest completed turn from the local thread log file."""
+    """Read highest completed turn from local file, then Mongo (for multi-replica / restart)."""
     text = _read_local_thread_log_text(thread_id)
-    if not text:
-        return 0
-    turns = [int(m) for m in _END_TURN_RE.findall(text)]
-    return max(turns) if turns else 0
+    local_max = 0
+    if text:
+        turns = [int(m) for m in _END_TURN_RE.findall(text)]
+        local_max = max(turns) if turns else 0
+
+    mongo_max = 0
+    if mongo_thread_log_enabled():
+        try:
+            mongo_max = read_max_turn_number(thread_id)
+        except Exception:
+            pass
+
+    return max(local_max, mongo_max)
 
 
 def _get_active_turn(thread_id: str | None) -> dict[str, Any] | None:
@@ -175,6 +191,56 @@ def _extract_user_message_from_log(log_text: str) -> str:
         for line in raw.splitlines()
     ]
     return "\n".join(lines).strip()
+
+
+def _extract_bot_message_from_log(log_text: str) -> str:
+    match = _BOT_MESSAGE_RE.search(log_text)
+    if not match:
+        return ""
+    raw = match.group(1)
+    lines = [
+        line[2:] if line.startswith("┃ ") else line.lstrip("┃")
+        for line in raw.splitlines()
+    ]
+    return "\n".join(lines).strip()
+
+
+def _completed_turn_numbers_in_file(thread_id: str) -> list[int]:
+    text = _read_local_thread_log_text(thread_id)
+    if not text:
+        return []
+    return sorted({int(m) for m in _END_TURN_RE.findall(text)})
+
+
+def _turn_record_from_log_text(turn: int, log_text: str) -> dict[str, Any]:
+    outcome_match = _OUTCOME_RE.search(log_text)
+    started_match = _STARTED_AT_RE.search(log_text)
+    ended_at = ""
+    for line in log_text.splitlines():
+        if "── bot reply" in line and "IST" in line:
+            parts = line.rsplit("IST", 1)
+            if parts:
+                ended_at = parts[0].strip().split("─")[-1].strip() + " IST"
+            break
+    return {
+        "turn": turn,
+        "user_message": _extract_user_message_from_log(log_text),
+        "bot_message": _extract_bot_message_from_log(log_text),
+        "outcome": outcome_match.group(1) if outcome_match else "unknown",
+        "started_at": started_match.group(1).strip() if started_match else "",
+        "ended_at": ended_at,
+        "log_text": log_text,
+    }
+
+
+def build_turn_records_from_local_file(thread_id: str) -> list[dict[str, Any]]:
+    """Build structured turn records for every completed turn in the local log file."""
+    records: list[dict[str, Any]] = []
+    for turn in _completed_turn_numbers_in_file(thread_id):
+        log_text = _extract_turn_text_from_file(thread_id, turn)
+        if log_text.strip():
+            records.append(_turn_record_from_log_text(turn, log_text))
+    return records
 
 
 def _append_to_turn_buffer(text: str, *, thread_id: str | None = None) -> None:
@@ -308,7 +374,20 @@ def end_conversation_turn(
     _turn_num_ctx.set(None)
 
     if mongo_thread_log_enabled():
-        sync_turn_to_mongo(tid, turn_record)
+        full_logs = _read_local_thread_log_text(tid) or None
+        records = build_turn_records_from_local_file(tid)
+        if not records:
+            records = [turn_record]
+        else:
+            updated = False
+            for idx, record in enumerate(records):
+                if record.get("turn") == turn:
+                    records[idx] = turn_record
+                    updated = True
+                    break
+            if not updated:
+                records.append(turn_record)
+        sync_completed_turns_to_mongo(tid, records, full_logs=full_logs)
 
 
 def _resolve_config_thread_id(config: RunnableConfig | dict[str, Any] | None) -> str | None:

--- a/ai/ajrasakha/agents/user_location.py
+++ b/ai/ajrasakha/agents/user_location.py
@@ -99,6 +99,7 @@ def maybe_persist_resolved_location(
     state: str | None,
     district: str | None,
     *,
+    thread_id: str | None = None,
     state_source: str | None,
     district_source: str | None,
     background: bool = True,
@@ -117,13 +118,20 @@ def maybe_persist_resolved_location(
         return
 
     def _save() -> None:
-        save_user_location(user_id, normalized_district, normalized_state)
+        save_user_location(
+            user_id,
+            normalized_district,
+            normalized_state,
+            thread_id=thread_id,
+            state_source=state_source,
+            district_source=district_source,
+        )
 
     if background:
         threading.Thread(
             target=_save,
             name=f"user-location-save-{user_id[:12]}",
-            daemon=True,
+            daemon=False,
         ).start()
     else:
         _save()
@@ -149,7 +157,7 @@ def maybe_persist_rephrased_query(
         threading.Thread(
             target=_save,
             name=f"rephrased-query-save-{user_id[:12]}",
-            daemon=True,
+            daemon=False,
         ).start()
     else:
         _save()

--- a/ai/ajrasakha/agents/user_location_mongo.py
+++ b/ai/ajrasakha/agents/user_location_mongo.py
@@ -192,7 +192,35 @@ def get_farmer_profile_location(user_id: str | None) -> dict[str, str] | None:
     return {"district": district, "state": state}
 
 
-def save_user_location(user_id: str, district: str, state: str) -> bool:
+def _format_location_source(
+    *,
+    thread_id: str | None = None,
+    state_source: str | None = None,
+    district_source: str | None = None,
+    picked_at: datetime,
+) -> dict[str, str]:
+    """Provenance metadata for how/where the location was resolved."""
+    source: dict[str, str] = {
+        "picked_at": picked_at.isoformat().replace("+00:00", "Z"),
+    }
+    if thread_id and thread_id.strip():
+        source["thread_id"] = thread_id.strip()
+    if state_source and str(state_source).strip():
+        source["state_source"] = str(state_source).strip()
+    if district_source and str(district_source).strip():
+        source["district_source"] = str(district_source).strip()
+    return source
+
+
+def save_user_location(
+    user_id: str,
+    district: str,
+    state: str,
+    *,
+    thread_id: str | None = None,
+    state_source: str | None = None,
+    district_source: str | None = None,
+) -> bool:
     """Upsert current location; move prior current_location to history when changed."""
     normalized_id = _normalize_user_id(user_id)
     if not normalized_id:
@@ -209,20 +237,52 @@ def save_user_location(user_id: str, district: str, state: str) -> bool:
 
     now = datetime.now(timezone.utc)
     new_current = {"district": district, "state": state}
+    new_source = _format_location_source(
+        thread_id=thread_id,
+        state_source=state_source,
+        district_source=district_source,
+        picked_at=now,
+    )
 
     try:
         existing = col.find_one(
             {"user_id": normalized_id},
-            {"current_location": 1, "location_history": 1},
+            {"current_location": 1, "current_location_source": 1, "location_history": 1},
             max_time_ms=_MONGO_OP_TIMEOUT_MS,
         )
     except Exception:
         logger.exception("Failed to read user location before save user_id=%s", normalized_id)
         return False
 
+    old_current = (existing or {}).get("current_location")
+    if existing and _locations_equal(old_current, new_current):
+        try:
+            col.update_one(
+                {"user_id": normalized_id},
+                {
+                    "$set": {
+                        "current_location_source": new_source,
+                        "updated_at": now,
+                    }
+                },
+            )
+        except Exception:
+            logger.exception(
+                "Failed to refresh user location source for user_id=%s",
+                normalized_id,
+            )
+            return False
+        logger.info(
+            "Refreshed user location source user_id=%s thread_id=%s",
+            normalized_id,
+            new_source.get("thread_id"),
+        )
+        return True
+
     update: dict[str, Any] = {
         "$set": {
             "current_location": new_current,
+            "current_location_source": new_source,
             "updated_at": now,
         },
     }
@@ -231,13 +291,15 @@ def save_user_location(user_id: str, district: str, state: str) -> bool:
         "created_at": now,
     }
 
-    old_current = (existing or {}).get("current_location")
+    old_source = (existing or {}).get("current_location_source")
     if existing and old_current and not _locations_equal(old_current, new_current):
-        history_entry = {
+        history_entry: dict[str, Any] = {
             "district": str(old_current.get("district", "")).strip(),
             "state": str(old_current.get("state", "")).strip(),
             "timestamp": now.isoformat().replace("+00:00", "Z"),
         }
+        if isinstance(old_source, dict) and old_source:
+            history_entry["source"] = old_source
         if history_entry["district"] and history_entry["state"]:
             update["$push"] = {
                 "location_history": {
@@ -251,9 +313,6 @@ def save_user_location(user_id: str, district: str, state: str) -> bool:
 
     update["$setOnInsert"] = set_on_insert
 
-    if existing and _locations_equal(old_current, new_current):
-        return False
-
     try:
         col.update_one({"user_id": normalized_id}, update, upsert=True)
     except Exception:
@@ -261,10 +320,11 @@ def save_user_location(user_id: str, district: str, state: str) -> bool:
         return False
 
     logger.info(
-        "Saved user location user_id=%s district=%s state=%s",
+        "Saved user location user_id=%s district=%s state=%s thread_id=%s",
         normalized_id,
         district,
         state,
+        new_source.get("thread_id"),
     )
     return True
 


### PR DESCRIPTION
Backfill missing turns from local logs on each turn end, use a retrying background thread pool so fast clarify turns are not lost, and wire planner to save explicit farmer location to user_details with thread_id metadata.