### PR TITLE
revert(ai): undo accidental ai/ changes from 5feed71 (Copy/main stagi…

### DIFF
--- a/ai/ajrasakha/agents/config.py
+++ b/ai/ajrasakha/agents/config.py
@@ -1,5 +1,8 @@
 import os
+import re
 from typing import Any, Optional
+
+_WHATSAPP_THREAD_ID_RE = re.compile(r"^(\d+)-\d{4}-\d{2}-\d{2}$")
 
 CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
 
@@ -49,13 +52,38 @@ def resolve_thread_id(config: Optional[dict[str, Any]] = None) -> Optional[str]:
     return None
 
 
-def resolve_user_id(config: Optional[dict[str, Any]] = None) -> Optional[str]:
-    """User identifier from configurable (set by langgraph-openai-adapter via x-user-id)."""
-    configurable = (config or {}).get("configurable") or {}
-    for key in ("user_id", "user"):
-        val = configurable.get(key)
-        if val is not None and str(val).strip():
-            return str(val).strip()
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value is not None and str(value).strip():
+            cleaned = str(value).strip()
+            # LibreChat leaves unresolved placeholders when user context is missing.
+            if cleaned.startswith("{{") and cleaned.endswith("}}"):
+                continue
+            return cleaned
+    return None
+
+
+def resolve_user_id(config: Optional[dict[str, Any]] = None) -> str | None:
+    """Resolve user identity from run config (configurable, metadata, thread_id)."""
+    cfg = config or {}
+    configurable = cfg.get("configurable") or {}
+    metadata = cfg.get("metadata") or {}
+
+    user_id = _first_non_empty(
+        configurable.get("user_id"),
+        configurable.get("phone_number"),
+        metadata.get("user_id"),
+        metadata.get("userId"),
+        metadata.get("phoneNumber"),
+    )
+    if user_id:
+        return user_id
+
+    thread_id = resolve_thread_id(cfg)
+    if thread_id:
+        match = _WHATSAPP_THREAD_ID_RE.match(thread_id)
+        if match:
+            return match.group(1)
     return None
 
 

--- a/ai/ajrasakha/agents/language.py
+++ b/ai/ajrasakha/agents/language.py
@@ -11,6 +11,33 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# India's 22 scheduled languages + English (23 total)
+OFFICIAL_LANGUAGES = [
+    "Assamese",
+    "Bengali",
+    "Bodo",
+    "Dogri",
+    "English",
+    "Gujarati",
+    "Hindi",
+    "Kannada",
+    "Kashmiri",
+    "Konkani",
+    "Maithili",
+    "Malayalam",
+    "Marathi",
+    "Nepali",
+    "Odia",
+    "Punjabi",
+    "Sanskrit",
+    "Sindhi",
+    "Tamil",
+    "Telugu",
+    "Urdu",
+    "Manipuri (Meitei)",
+    "Santali",
+]
+
 # 12 native Indian script Unicode ranges
 _DEVANAGARI = re.compile(r"[\u0900-\u097F]")
 _BENGALI_ASSAMESE = re.compile(r"[\u0980-\u09FF]")
@@ -206,13 +233,33 @@ def _llm_detect_language(text: str) -> str:
         llm = ChatAnthropic(model=SANITIZER_MODEL)
         
         prompt = (
-            "Analyze the following text from an Indian farmer and identify the underlying spoken language. "
-            "Even if the text is written in English/Latin alphabets, identify the spoken language (e.g., if the text is "
-            "'Mera sawal gehu ke baare me hai', the underlying language is Hindi, not English).\n\n"
-            "Spoken languages include: English, Hindi, Punjabi, Bengali, Assamese, Gujarati, Odia, Tamil, Telugu, Kannada, Malayalam, Urdu, Kashmiri, Sindhi, Santali, Manipuri.\n\n"
-            "Return ONLY the language name as a single word (e.g., 'Hindi', 'English', 'Punjabi', 'Tamil'). Do not include any other text, reasoning, or punctuation.\n\n"
-            "Focus more on hepling verbs, prepositions, conjuctions, tenses, articles to decide the vocol language"
-            "**Strictly** Never take vocal language based on state name, distict name, crop name, mentioned in question."
+            "Analyze the following text from an Indian farmer and identify the underlying spoken language.\n\n"
+            "Examples:\n"
+            "- 'What weather-related risks should I watch for over the next 7 days?' → English\n"
+            "- 'Mera sawal gehu ke baare me hai' → Hindi\n\n"
+            "Hinglish/Hindi markers to look for (indicates Hindi, not English):\n"
+            "- Hindi postpositions: me, ke liye, se, ko, par\n"
+            "- Hindi verb forms: hai, hain, sakta hai, karna\n"
+            "- Hindi conjunctions: aur, ya, lekin, ki\n"
+            "- Hindi pronouns: mera, aap, hum, unka\n"
+            "- Hindi question words: kya, kahan, kab, kaise\n"
+            "- Hindi articles: ek\n\n"
+            "CRITICAL RULE:\n"
+            "- If the text uses standard English words, English prepositions (in, for, to, with, over, next), "
+            "English verb forms (is, are, can, should, will, watch), and English grammar → classify as ENGLISH\n"
+            "- If the text contains ANY of the Hindi markers above → classify as the underlying Indian language\n"
+            "- NEVER classify as Hindi just because the text mentions Indian place names (Villupuram, Tamil Nadu), "
+            "crop names (paddy, wheat), or state names — UNLESS the crop name itself is in Hindi (gehu, chawal, kanak)\n\n"
+            "CROP NAME RULE (apply ONLY if text is exactly a crop name, nothing else):\n"
+            "- English crop names: paddy, wheat, rice, maize, cotton, sugarcane, soybean, groundnut, potato, onion, tomato → English\n"
+            "- Hindi crop names: gehu, chawal, makka, ganne, aloo, pyaz, tamatar, kanak → Hindi\n"
+            "- For crop names in other Indian languages, use your judgment based on the word\n\n"
+            "LOCATION-ONLY RULE (apply ONLY if text is exactly a place name, nothing else):\n"
+            "- If text is only a state/district name in Latin script (Uttar Pradesh, Tamil Nadu, Villupuram, etc.) → English\n"
+            "- If text is only a state/district name in Devanagari script (उत्तर प्रदेश, महाराष्ट्र, etc.) → Hindi\n"
+            "- If text is only a state/district name in other native scripts → the corresponding language\n\n"
+            f"Return language from this EXACT list only:\n{', '.join(OFFICIAL_LANGUAGES)}.\n\n"
+            "Return ONLY the language name. Do not include any other text, reasoning, or punctuation.\n\n"
             f"Text: {t}\n"
             "Language:"
         )
@@ -220,21 +267,12 @@ def _llm_detect_language(text: str) -> str:
         response = llm.invoke(prompt)
         lang = str(response.content).strip()
         
-        known_languages = [
-            "Hindi", "English", "Punjabi", "Bengali", "Assamese", "Gujarati", 
-            "Odia", "Tamil", "Telugu", "Kannada", "Malayalam", "Urdu", 
-            "Kashmiri", "Sindhi", "Santali", "Manipuri"
-        ]
-        
-        # Check if any known language name is contained as a standalone word
-        for l in known_languages:
-            if re.search(rf"\b{l}\b", lang, re.IGNORECASE):
+        # Validate against OFFICIAL_LANGUAGES
+        for l in OFFICIAL_LANGUAGES:
+            if re.search(rf"\b{re.escape(l)}\b", lang, re.IGNORECASE):
                 return l
-                
-        # Clean up any non-alphabetic characters as a fallback
-        lang_title = lang.title()
-        cleaned = re.sub(r'[^a-zA-Z-]', '', lang_title)
-        return cleaned if cleaned else "English"
+        
+        return "English"
     except Exception as e:
         logger.warning("LLM language detection failed with exception: %s", e, exc_info=True)
         return "English"
@@ -251,11 +289,33 @@ async def _allm_detect_language(text: str) -> str:
         llm = ChatAnthropic(model=SANITIZER_MODEL)
         
         prompt = (
-            "Analyze the following text from an Indian farmer and identify the underlying spoken language. "
-            "Even if the text is written in English/Latin alphabets, identify the spoken language (e.g., if the text is "
-            "'Mera sawal gehu ke baare me hai', the underlying language is Hindi, not English).\n\n"
-            "Spoken languages include: English, Hindi, Punjabi, Bengali, Assamese, Gujarati, Odia, Tamil, Telugu, Kannada, Malayalam, Urdu, Kashmiri, Sindhi, Santali, Manipuri.\n\n"
-            "Return ONLY the language name as a single word (e.g., 'Hindi', 'English', 'Punjabi', 'Tamil'). Do not include any other text, reasoning, or punctuation.\n\n"
+            "Analyze the following text from an Indian farmer and identify the underlying spoken language.\n\n"
+            "Examples:\n"
+            "- 'What weather-related risks should I watch for over the next 7 days?' → English\n"
+            "- 'Mera sawal gehu ke baare me hai' → Hindi\n\n"
+            "Hinglish/Hindi markers to look for (indicates Hindi, not English):\n"
+            "- Hindi postpositions: me, ke liye, se, ko, par\n"
+            "- Hindi verb forms: hai, hain, sakta hai, karna\n"
+            "- Hindi conjunctions: aur, ya, lekin, ki\n"
+            "- Hindi pronouns: mera, aap, hum, unka\n"
+            "- Hindi question words: kya, kahan, kab, kaise\n"
+            "- Hindi articles: ek\n\n"
+            "CRITICAL RULE:\n"
+            "- If the text uses standard English words, English prepositions (in, for, to, with, over, next), "
+            "English verb forms (is, are, can, should, will, watch), and English grammar → classify as ENGLISH\n"
+            "- If the text contains ANY of the Hindi markers above → classify as the underlying Indian language\n"
+            "- NEVER classify as Hindi just because the text mentions Indian place names (Villupuram, Tamil Nadu), "
+            "crop names (paddy, wheat), or state names — UNLESS the crop name itself is in Hindi (gehu, chawal, kanak)\n\n"
+            "CROP NAME RULE (apply ONLY if text is exactly a crop name, nothing else):\n"
+            "- English crop names: paddy, wheat, rice, maize, cotton, sugarcane, soybean, groundnut, potato, onion, tomato → English\n"
+            "- Hindi crop names: gehu, chawal, makka, ganne, aloo, pyaz, tamatar, kanak → Hindi\n"
+            "- For crop names in other Indian languages, use your judgment based on the word\n\n"
+            "LOCATION-ONLY RULE (apply ONLY if text is exactly a place name, nothing else):\n"
+            "- If text is only a state/district name in Latin script (Uttar Pradesh, Tamil Nadu, Villupuram, etc.) → English\n"
+            "- If text is only a state/district name in Devanagari script (उत्तर प्रदेश, महाराष्ट्र, etc.) → Hindi\n"
+            "- If text is only a state/district name in other native scripts → the corresponding language\n\n"
+            f"Return language from this EXACT list only:\n{', '.join(OFFICIAL_LANGUAGES)}.\n\n"
+            "Return ONLY the language name. Do not include any other text, reasoning, or punctuation.\n\n"
             f"Text: {t}\n"
             "Language:"
         )
@@ -263,21 +323,12 @@ async def _allm_detect_language(text: str) -> str:
         response = await llm.ainvoke(prompt)
         lang = str(response.content).strip()
         
-        known_languages = [
-            "Hindi", "English", "Punjabi", "Bengali", "Assamese", "Gujarati", 
-            "Odia", "Tamil", "Telugu", "Kannada", "Malayalam", "Urdu", 
-            "Kashmiri", "Sindhi", "Santali", "Manipuri"
-        ]
-        
-        # Check if any known language name is contained as a standalone word
-        for l in known_languages:
-            if re.search(rf"\b{l}\b", lang, re.IGNORECASE):
+        # Validate against OFFICIAL_LANGUAGES
+        for l in OFFICIAL_LANGUAGES:
+            if re.search(rf"\b{re.escape(l)}\b", lang, re.IGNORECASE):
                 return l
-                
-        # Clean up any non-alphabetic characters as a fallback
-        lang_title = lang.title()
-        cleaned = re.sub(r'[^a-zA-Z-]', '', lang_title)
-        return cleaned if cleaned else "English"
+        
+        return "English"
     except Exception as e:
         logger.warning("Async LLM language detection failed with exception: %s", e, exc_info=True)
         return "English"

--- a/ai/ajrasakha/agents/memory.py
+++ b/ai/ajrasakha/agents/memory.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from langchain_core.runnables import RunnableConfig
 from langgraph.store.base import BaseStore
 
+from ajrasakha.agents.config import resolve_thread_id, resolve_user_id
+
 
 def _coerce_store_text(value: object) -> str:
     if value is None:
@@ -22,9 +24,8 @@ async def load_long_term_summary(store: BaseStore | None, config: RunnableConfig
     if store is None:
         return ""
 
-    configurable = config.get("configurable") or {}
-    thread_id = configurable.get("thread_id") or configurable.get("thread")
-    user_id = configurable.get("user_id") or configurable.get("phone_number")
+    thread_id = resolve_thread_id(config)
+    user_id = resolve_user_id(config)
 
     namespace = ("farmer_profiles", str(user_id or "unknown_user"))
     summary_parts: list[str] = []

--- a/ai/ajrasakha/agents/planner.py
+++ b/ai/ajrasakha/agents/planner.py
@@ -67,7 +67,11 @@ from ajrasakha.agents.planner_rules import (
 )
 from ajrasakha.agents.prompts import PLANNER_SYSTEM_PROMPT
 from ajrasakha.agents.state import AjraSakhaState, PlannerEntities, PlannerPlan
-from ajrasakha.agents.user_location import load_user_location, maybe_persist_resolved_location
+from ajrasakha.agents.user_location import (
+    load_user_location,
+    maybe_persist_rephrased_query,
+    maybe_persist_resolved_location,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -715,6 +719,15 @@ async def planner_node(
                 state_source=location_sources.get("state_source"),
                 district_source=location_sources.get("district_source"),
             )
+            # Save the rephrased query for future context-aware rewriting
+            rephrased = plan.get("rephrased_query")
+            if rephrased:
+                maybe_persist_rephrased_query(user_id, rephrased)
+                trace_event(
+                    "planner_rephrased_query_saved",
+                    user_id=user_id,
+                    rephrased_query=rephrased,
+                )
 
         trace_event(
             "planner_final_plan",

--- a/ai/ajrasakha/agents/planner_rules.py
+++ b/ai/ajrasakha/agents/planner_rules.py
@@ -316,7 +316,7 @@ def merge_entities_from_rephrased_query(
     stored_location: Optional[dict[str, str]] = None,
     sources_out: Optional[dict[str, str | None]] = None,
 ) -> PlannerEntities:
-    """Resolve state/crop/district from farmer text and planner LLM entities only (no GPS).
+    """Resolve state/crop/district from farmer text, LLM entities, stored profile, or clarify carry-over.
 
     State/district never come from device coordinates — only from rephrased query text,
     LLM entity fields, stored user location, or ``prev_entities`` during clarification.

--- a/ai/ajrasakha/agents/tests/test_planner_rules.py
+++ b/ai/ajrasakha/agents/tests/test_planner_rules.py
@@ -12,6 +12,7 @@ from ajrasakha.agents.planner_rules import (
     format_prev_plan_context,
     infer_domain_for_plan,
     is_schemes_intent,
+    merge_entities_from_rephrased_query,
 )
 
 
@@ -232,3 +233,39 @@ def test_crop_clarify_reply_still_extracts_cotton():
     assert plan["is_complete"] is True
     assert plan["entities"]["crop"] == "Cotton"
     assert plan.get("follow_up_question") is None
+
+
+def test_stored_location_makes_plan_complete_without_clarify():
+    messages = [HumanMessage(content="What is the weather today?")]
+    plan = apply_planner_completeness_rules(
+        {
+            "domain": "Weather",
+            "domains": ["Weather"],
+            "is_complete": False,
+            "missing_info": ["location"],
+            "entities": {},
+            "rephrased_query": "What is the weather today?",
+        },
+        messages,
+        None,
+        stored_location={"state": "Haryana", "district": "Sirsa"},
+    )
+    assert plan["is_complete"] is True
+    assert plan["entities"]["state"] == "Haryana"
+    assert plan["entities"]["district"] == "Sirsa"
+    assert plan.get("follow_up_question") is None
+
+
+def test_merge_entities_records_stored_location_source():
+    plan = {"rephrased_query": "Weather today", "entities": {}}
+    messages = [HumanMessage(content="Weather today")]
+    sources: dict[str, str | None] = {}
+    entities = merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        None,
+        stored_location={"state": "Haryana", "district": "Sirsa"},
+        sources_out=sources,
+    )
+    assert entities["state"] == "Haryana"
+    assert sources["state_source"] == "stored_user_location"

--- a/ai/ajrasakha/agents/tests/test_user_location_resolution.py
+++ b/ai/ajrasakha/agents/tests/test_user_location_resolution.py
@@ -1,0 +1,147 @@
+"""Tests for user location resolution and persistence helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from langchain_core.messages import HumanMessage
+
+from ajrasakha.agents.config import resolve_user_id
+from ajrasakha.agents.planner_rules import merge_entities_from_rephrased_query
+from ajrasakha.agents.user_location import (
+    is_explicit_location_source,
+    load_user_location,
+    maybe_persist_resolved_location,
+    sanitize_stored_location,
+    validate_location,
+)
+
+
+def test_resolve_user_id_from_configurable():
+    config = {"configurable": {"user_id": "507f1f77bcf86cd799439011"}}
+    assert resolve_user_id(config) == "507f1f77bcf86cd799439011"
+
+
+def test_resolve_user_id_from_metadata():
+    config = {"metadata": {"user_id": "919876543210", "channel": "whatsapp"}}
+    assert resolve_user_id(config) == "919876543210"
+
+
+def test_resolve_user_id_from_whatsapp_thread_id():
+    config = {"configurable": {"thread_id": "919876543210-2026-06-12"}}
+    assert resolve_user_id(config) == "919876543210"
+
+
+def test_validate_location_rejects_placeholders():
+    assert validate_location("Haryana", "all") is False
+    assert validate_location("Haryana", "all", allow_district_all=True) is True
+    assert validate_location("unknown", "Sirsa") is False
+    assert validate_location("Haryana", "Sirsa") is True
+
+
+def test_sanitize_stored_location_normalizes_names():
+    assert sanitize_stored_location({"state": "haryana", "district": "sirsa"}) == {
+        "state": "Haryana",
+        "district": "Sirsa",
+    }
+    assert sanitize_stored_location({"state": "all", "district": "Sirsa"}) is None
+
+
+def test_merge_uses_stored_location_when_query_has_no_state():
+    plan = {
+        "rephrased_query": "What is the weather today?",
+        "entities": {},
+    }
+    messages = [HumanMessage(content="What is the weather today?")]
+    stored = {"state": "Haryana", "district": "Sirsa"}
+    sources: dict[str, str | None] = {}
+    entities = merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        None,
+        stored_location=stored,
+        sources_out=sources,
+    )
+    assert entities["state"] == "Haryana"
+    assert entities["district"] == "Sirsa"
+    assert sources["state_source"] == "stored_user_location"
+
+
+def test_merge_query_overrides_stored_location():
+    plan = {
+        "rephrased_query": "Weather in Ambala, Haryana",
+        "entities": {"state": "Haryana", "district": "Ambala"},
+    }
+    messages = [HumanMessage(content="Weather in Ambala, Haryana")]
+    stored = {"state": "Haryana", "district": "Sirsa"}
+    sources: dict[str, str | None] = {}
+    entities = merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        None,
+        stored_location=stored,
+        sources_out=sources,
+    )
+    assert entities["district"] == "Ambala"
+    assert sources["state_source"] in ("plan.entities.state (llm)", "rephrased_query_text")
+
+
+def test_merge_prefers_stored_over_prev_entities():
+    plan = {"rephrased_query": "What is PM-KISAN?", "entities": {}}
+    messages = [HumanMessage(content="What is PM-KISAN?")]
+    prev = {"state": "Punjab", "district": "Ludhiana"}
+    stored = {"state": "Haryana", "district": "Sirsa"}
+    entities = merge_entities_from_rephrased_query(
+        plan,
+        messages,
+        None,
+        prev_entities=prev,
+        stored_location=stored,
+    )
+    assert entities["state"] == "Haryana"
+    assert entities["district"] == "Sirsa"
+
+
+def test_is_explicit_location_source():
+    assert is_explicit_location_source("rephrased_query_text", None) is True
+    assert is_explicit_location_source("stored_user_location", "stored_user_location") is False
+
+
+@patch("ajrasakha.agents.user_location.save_user_location")
+def test_maybe_persist_only_on_explicit_source(mock_save):
+    maybe_persist_resolved_location(
+        "919876543210",
+        "Haryana",
+        "Sirsa",
+        state_source="stored_user_location",
+        district_source="stored_user_location",
+        background=False,
+    )
+    mock_save.assert_not_called()
+
+    maybe_persist_resolved_location(
+        "919876543210",
+        "Haryana",
+        "Sirsa",
+        state_source="plan.entities.state (llm)",
+        district_source="plan.entities.district (llm)",
+        background=False,
+    )
+    mock_save.assert_called_once_with("919876543210", "Sirsa", "Haryana")
+
+    mock_save.reset_mock()
+    maybe_persist_resolved_location(
+        "919876543210",
+        "Uttar Pradesh",
+        "all",
+        state_source="rephrased_query_text",
+        district_source="default_all_when_state_only",
+        background=False,
+    )
+    mock_save.assert_called_once_with("919876543210", "all", "Uttar Pradesh")
+
+
+@patch("ajrasakha.agents.user_location.get_user_location")
+def test_load_user_location_sanitizes_invalid(mock_get):
+    mock_get.return_value = {"state": "all", "district": "Sirsa"}
+    assert load_user_location("919876543210") is None

--- a/ai/ajrasakha/tools/golden/golden_api.py
+++ b/ai/ajrasakha/tools/golden/golden_api.py
@@ -38,7 +38,8 @@ class GDBSearchRequest(BaseModel):
         description=(
             "Crop filter. Normalised to title case with underscores as spaces "
             "(e.g. bengal_gram → Bengal Gram). Matched on MongoDB details.normalised_crop. "
-            "Use all to skip crop filter."
+            "Use all to skip crop filter. If crop-filtered retrieval finds nothing, "
+            "search retries without the crop filter."
         ),
         examples=["Wheat", "round_gourd", "all"],
     )
@@ -155,7 +156,8 @@ async def health():
         "**Pipeline:**\n"
         "1. **Strict exact** on `rephrased_query` (+ crop/state filters) → if hit, return `exact_match` only.\n"
         "2. Else **vector RAG** on `rephrased_query`.\n"
-        "3. **Gemma** relevance + classify + select one answer using the same `rephrased_query`."
+        "3. If both return no hits and crop is not `all`, retry steps 1–2 with `crop=all`.\n"
+        "4. **Gemma** relevance + classify + select one answer using the same `rephrased_query`."
     ),
 )
 async def search_gdb(body: GDBSearchRequest):

--- a/ai/ajrasakha/tools/golden/golden_search.py
+++ b/ai/ajrasakha/tools/golden/golden_search.py
@@ -46,55 +46,44 @@ log = logging.getLogger(__name__)
 SELECTION_RULE = "relevance_filter_then_same_intent_then_covered_by_context"
 
 
-async def gdb_search(
-    rephrased_query: str,
-    crop: str,
-    state: str,
+def _apply_crop_fallback_metadata(
+    response: dict[str, Any],
     *,
-    season: Optional[str] = None,
-    domain: Optional[str] = None,
+    original_crop: str,
+    crop_fallback: bool,
+) -> None:
+    if not crop_fallback:
+        return
+    response["original_crop"] = original_crop
+    response["crop_fallback"] = True
+    audit = response.get("classification_audit") or {}
+    audit["crop_fallback"] = True
+    audit["original_crop"] = original_crop
+    response["classification_audit"] = audit
+
+
+def _exact_match_response(
+    query: str,
+    state: str,
+    crop: str,
+    pair: QuestionAnswerPair,
+    *,
+    original_crop: str,
+    crop_fallback: bool,
 ) -> dict[str, Any]:
-    crop, state = _normalize_crop_state(crop, state)
-    query = (rephrased_query or "").strip()
-    if not query:
-        raise ValueError("rephrased_query is required")
-
-    log.info(
-        "gdb_search start rephrased_query=%r crop=%s state=%s",
-        _truncate_text(query, 80),
-        crop,
-        state,
-    )
-
     response: dict[str, Any] = {
         "rephrased_query": query,
         "state": state,
         "crop": crop,
-        "exact_match": {},
-        "selected_match": None,
-        "classification_audit": {
-            "status": "empty",
-            "model": GEMMA_MODEL,
-            "relevance_filter_mode": "batch_all_candidates",
-            "evaluations": [],
-            "selected_question_id": None,
-            "selection_rule": SELECTION_RULE,
-        },
-    }
-
-    strict_results = await strict_exact_search(query=query, crop=crop, state=state)
-    log.info("gdb_search strict exact returned %d hit(s)", len(strict_results))
-
-    if strict_results:
-        pair = strict_results[0]
-        response["exact_match"] = match_entry(
+        "exact_match": match_entry(
             pair,
             RETRIEVAL_SOURCE_STRICT_EXACT,
             similarity_score=1.0,
             chosen_for_answer=True,
             answer_from_class="strict_exact",
-        )
-        response["classification_audit"] = {
+        ),
+        "selected_match": None,
+        "classification_audit": {
             "status": "exact_bypass",
             "model": GEMMA_MODEL,
             "evaluations": [],
@@ -103,22 +92,32 @@ async def gdb_search(
             "selection_method": "strict_exact",
             "chosen_for_answer": True,
             "answer_from_class": "strict_exact",
-        }
-        log.info("gdb_search done path=strict_exact question_id=%s", pair.question_id)
-        return response
-
-    rag_pairs = await vector_rag_search(
-        query,
-        crop,
-        state,
-        season=season,
-        domain=domain,
+        },
+    }
+    _apply_crop_fallback_metadata(
+        response,
+        original_crop=original_crop,
+        crop_fallback=crop_fallback,
     )
-    if not rag_pairs:
-        log.warning("gdb_search done path=empty (no vector hits)")
-        return response
+    return response
 
-    # Stage 1: one batch LLM call — all RAG candidates; may detect SAME for early bypass
+
+async def _run_gemma_pipeline(
+    query: str,
+    crop: str,
+    state: str,
+    rag_pairs: list[QuestionAnswerPair],
+    response: dict[str, Any],
+    *,
+    original_crop: str,
+    crop_fallback: bool,
+) -> dict[str, Any]:
+    _apply_crop_fallback_metadata(
+        response,
+        original_crop=original_crop,
+        crop_fallback=crop_fallback,
+    )
+
     filter_results = await filter_relevance_batch(
         query, rag_pairs, crop=crop, state=state
     )
@@ -223,7 +222,6 @@ async def gdb_search(
         )
         return response
 
-    # Stage 2: intent classification on kept pairs only
     classify_tasks = [
         classify_pair(
             original_query=query,
@@ -244,7 +242,6 @@ async def gdb_search(
         ev["llm_parse_ok"] = cls_result.get("llm_parse_ok", False)
         ev["action"] = "classified"
 
-    # Stage 3: select best (2+ same class → LLM tie-breaker; 1 → auto-pick)
     selection = await select_best_match(query, kept_pairs, classify_results)
     audit = response["classification_audit"]
     audit["evaluations"] = evaluations
@@ -308,3 +305,121 @@ async def gdb_search(
         rule,
     )
     return response
+
+
+async def gdb_search(
+    rephrased_query: str,
+    crop: str,
+    state: str,
+    *,
+    season: Optional[str] = None,
+    domain: Optional[str] = None,
+) -> dict[str, Any]:
+    crop, state = _normalize_crop_state(crop, state)
+    original_crop = crop
+    crop_fallback = False
+    query = (rephrased_query or "").strip()
+    if not query:
+        raise ValueError("rephrased_query is required")
+
+    log.info(
+        "gdb_search start rephrased_query=%r crop=%s state=%s",
+        _truncate_text(query, 80),
+        crop,
+        state,
+    )
+
+    response: dict[str, Any] = {
+        "rephrased_query": query,
+        "state": state,
+        "crop": crop,
+        "exact_match": {},
+        "selected_match": None,
+        "classification_audit": {
+            "status": "empty",
+            "model": GEMMA_MODEL,
+            "relevance_filter_mode": "batch_all_candidates",
+            "evaluations": [],
+            "selected_question_id": None,
+            "selection_rule": SELECTION_RULE,
+        },
+    }
+
+    strict_results = await strict_exact_search(query=query, crop=crop, state=state)
+    log.info("gdb_search strict exact returned %d hit(s)", len(strict_results))
+
+    if strict_results:
+        log.info(
+            "gdb_search done path=strict_exact question_id=%s",
+            strict_results[0].question_id,
+        )
+        return _exact_match_response(
+            query,
+            state,
+            crop,
+            strict_results[0],
+            original_crop=original_crop,
+            crop_fallback=False,
+        )
+
+    rag_pairs = await vector_rag_search(
+        query,
+        crop,
+        state,
+        season=season,
+        domain=domain,
+    )
+
+    if not rag_pairs and crop != "all":
+        log.info(
+            "gdb_search: no retrieval hits for crop=%s; retrying with crop=all",
+            crop,
+        )
+        crop_fallback = True
+        strict_results = await strict_exact_search(query=query, crop="all", state=state)
+        log.info(
+            "gdb_search strict exact (crop=all) returned %d hit(s)",
+            len(strict_results),
+        )
+        if strict_results:
+            log.info(
+                "gdb_search done path=strict_exact_crop_fallback question_id=%s",
+                strict_results[0].question_id,
+            )
+            return _exact_match_response(
+                query,
+                state,
+                "all",
+                strict_results[0],
+                original_crop=original_crop,
+                crop_fallback=True,
+            )
+
+        rag_pairs = await vector_rag_search(
+            query,
+            "all",
+            state,
+            season=season,
+            domain=domain,
+        )
+        crop = "all"
+        response["crop"] = "all"
+
+    if not rag_pairs:
+        _apply_crop_fallback_metadata(
+            response,
+            original_crop=original_crop,
+            crop_fallback=crop_fallback,
+        )
+        log.warning("gdb_search done path=empty (no vector hits)")
+        return response
+
+    return await _run_gemma_pipeline(
+        query,
+        crop,
+        state,
+        rag_pairs,
+        response,
+        original_crop=original_crop,
+        crop_fallback=crop_fallback,
+    )

--- a/ai/ajrasakha/tools/golden/tests/test_crop_fallback.py
+++ b/ai/ajrasakha/tools/golden/tests/test_crop_fallback.py
@@ -1,0 +1,156 @@
+"""Unit tests for crop=all retry when retrieval returns no hits."""
+
+import pytest
+
+from ajrasakha.tools.golden.golden_core import QuestionAnswerPair
+
+
+def _pair(qid: str, score: float = 0.8) -> QuestionAnswerPair:
+    return QuestionAnswerPair(
+        question_id=qid,
+        question_text=f"Q {qid}",
+        answer_text=f"A {qid}",
+        author=None,
+        sources=[],
+        similarity_score=score,
+    )
+
+
+@pytest.mark.asyncio
+async def test_crop_fallback_retries_rag_with_all(monkeypatch):
+    from ajrasakha.tools.golden import golden_search
+
+    rag_calls: list[str] = []
+
+    async def mock_strict(*_args, crop: str, **_kwargs):
+        return []
+
+    async def mock_rag(*args, **kwargs):
+        crop_arg = kwargs.get("crop", args[1] if len(args) > 1 else "")
+        rag_calls.append(crop_arg)
+        if crop_arg == "all":
+            return [_pair("fallback_hit")]
+        return []
+
+    async def mock_filter(*_args, **_kwargs):
+        return [
+            {
+                "relevance_decision": "KEEP",
+                "relevance_reason": "related",
+                "llm_parse_ok": True,
+            }
+        ]
+
+    async def mock_classify(*_args, **_kwargs):
+        return {"classification": "SAME_INTENT", "reason": "match", "llm_parse_ok": True}
+
+    async def mock_select(*_args, **_kwargs):
+        return {
+            "pair": _pair("fallback_hit"),
+            "cls_result": {"classification": "SAME_INTENT"},
+            "selection_rule": "single",
+            "winning_class": "SAME_INTENT",
+            "selection_method": "auto",
+        }
+
+    monkeypatch.setattr(golden_search, "strict_exact_search", mock_strict)
+    monkeypatch.setattr(golden_search, "vector_rag_search", mock_rag)
+    monkeypatch.setattr(golden_search, "filter_relevance_batch", mock_filter)
+    monkeypatch.setattr(golden_search, "classify_pair", mock_classify)
+    monkeypatch.setattr(golden_search, "select_best_match", mock_select)
+
+    result = await golden_search.gdb_search("farmer question", "Unknown Crop", "Punjab")
+
+    assert rag_calls == ["Unknown Crop", "all"]
+    assert result["crop"] == "all"
+    assert result["original_crop"] == "Unknown Crop"
+    assert result["crop_fallback"] is True
+    assert result["selected_match"]["question_id"] == "fallback_hit"
+    assert result["classification_audit"]["crop_fallback"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_first_rag_returns_hits(monkeypatch):
+    from ajrasakha.tools.golden import golden_search
+
+    rag_calls: list[str] = []
+
+    async def mock_strict(*_args, **_kwargs):
+        return []
+
+    async def mock_rag(*args, **kwargs):
+        crop_arg = kwargs.get("crop", args[1] if len(args) > 1 else "")
+        rag_calls.append(crop_arg)
+        return [_pair("first_hit")]
+
+    async def mock_filter(*_args, **_kwargs):
+        return [
+            {
+                "relevance_decision": "SAME",
+                "relevance_reason": "paraphrase",
+                "llm_parse_ok": True,
+            }
+        ]
+
+    monkeypatch.setattr(golden_search, "strict_exact_search", mock_strict)
+    monkeypatch.setattr(golden_search, "vector_rag_search", mock_rag)
+    monkeypatch.setattr(golden_search, "filter_relevance_batch", mock_filter)
+
+    result = await golden_search.gdb_search("farmer question", "Wheat", "Punjab")
+
+    assert rag_calls == ["Wheat"]
+    assert result.get("crop_fallback") is None
+    assert result["crop"] == "Wheat"
+    assert result["selected_match"]["question_id"] == "first_hit"
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_crop_is_all(monkeypatch):
+    from ajrasakha.tools.golden import golden_search
+
+    rag_calls: list[str] = []
+
+    async def mock_strict(*_args, **_kwargs):
+        return []
+
+    async def mock_rag(*args, **kwargs):
+        crop_arg = kwargs.get("crop", args[1] if len(args) > 1 else "")
+        rag_calls.append(crop_arg)
+        return []
+
+    monkeypatch.setattr(golden_search, "strict_exact_search", mock_strict)
+    monkeypatch.setattr(golden_search, "vector_rag_search", mock_rag)
+
+    result = await golden_search.gdb_search("farmer question", "all", "Punjab")
+
+    assert rag_calls == ["all"]
+    assert result.get("crop_fallback") is None
+    assert result["crop"] == "all"
+    assert result["selected_match"] is None
+
+
+@pytest.mark.asyncio
+async def test_crop_fallback_exact_match_on_retry(monkeypatch):
+    from ajrasakha.tools.golden import golden_search
+
+    strict_calls: list[str] = []
+
+    async def mock_strict(*args, **kwargs):
+        crop_arg = kwargs.get("crop", args[1] if len(args) > 1 else "")
+        strict_calls.append(crop_arg)
+        if crop_arg == "all":
+            return [_pair("exact_fallback")]
+        return []
+
+    async def mock_rag(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(golden_search, "strict_exact_search", mock_strict)
+    monkeypatch.setattr(golden_search, "vector_rag_search", mock_rag)
+
+    result = await golden_search.gdb_search("farmer question", "Unknown Crop", "Punjab")
+
+    assert strict_calls == ["Unknown Crop", "all"]
+    assert result["crop"] == "all"
+    assert result["crop_fallback"] is True
+    assert result["exact_match"]["question_id"] == "exact_fallback"


### PR DESCRIPTION
…ng #889)

Commit 5feed71 ('Copy/main staging #889') accidentally modified 16 files in ai/, removing ~936 lines of logic. This commit reverses those changes while preserving all 24 subsequent commits to the ai/ directory.

Files restored from pre-bad-commit state:
- agents/config.py: restored _first_non_empty helper and rich resolve_user_id
- agents/language.py: restored full language detection logic
- agents/memory.py: restored memory handling code
- agents/planner.py: restored user_location import, rephrased query persist
- agents/planner_rules.py: restored docstring
- agents/tests/test_planner_rules.py: restored test cases
- tools/golden/golden_api.py: restored API function
- tools/golden/golden_search.py: restored full search logic

Deleted files restored:
- agents/tests/test_user_location_resolution.py (147 lines)
- tools/golden/tests/test_crop_fallback.py (156 lines)

Files left at HEAD (already corrected by #924):
- agents/tests/test_thread_log_mongo.py
- agents/tests/test_thread_logging.py
- agents/tests/test_user_location_mongo.py
- agents/thread_log_mongo.py
- agents/thread_logging.py

Subsequent commits preserved: #895, #910, #914, #916, #922, #924, and others.