### PR TITLE
Fix/showing exact crop name format as in the db

### DIFF
--- a/frontend/src/features/question-table-page/CropManagementModal.tsx
+++ b/frontend/src/features/question-table-page/CropManagementModal.tsx
@@ -382,7 +382,7 @@ const AliasManagerModal = ({
               );
             })()}
             <div className="min-w-0">
-              <h2 className="text-sm font-bold text-gray-900 dark:text-white capitalize leading-tight">
+              <h2 className="text-sm font-bold text-gray-900 dark:text-white leading-tight">
                 {crop.name}
               </h2>
               <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
@@ -437,7 +437,7 @@ const AliasManagerModal = ({
                         key={cropName}
                         className="inline-flex items-center gap-1 pl-2.5 pr-1 py-1 rounded-lg text-xs font-medium border bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700"
                       >
-                        <span className="capitalize">{cropName}</span>
+                        <span>{cropName}</span>
                         <button
                           type="button"
                           onClick={() =>
@@ -796,7 +796,7 @@ export const CropManagementModal = ({
             </div>
             {/* Crop Name */}
             <div className="px-3 py-2.5 min-w-0">
-              <span className="text-sm font-semibold text-gray-900 dark:text-white capitalize truncate block">
+              <span className="text-sm font-semibold text-gray-900 dark:text-white truncate block">
                 {item.name}
               </span>
             </div>
@@ -854,7 +854,7 @@ export const CropManagementModal = ({
             </div>
             {/* Chemical Name */}
             <div className="px-3 py-2.5 min-w-0">
-              <span className="text-sm font-semibold text-gray-900 dark:text-white capitalize truncate block">
+              <span className="text-sm font-semibold text-gray-900 dark:text-white truncate block">
                 {item.name}
               </span>
             </div>
@@ -928,7 +928,7 @@ export const CropManagementModal = ({
             </div>
             {/* Name */}
             <div className="px-3 py-2.5 min-w-0">
-              <span className="text-sm font-semibold text-gray-900 dark:text-white capitalize truncate block">
+              <span className="text-sm font-semibold text-gray-900 dark:text-white truncate block">
                 {item.name}
               </span>
             </div>

--- a/frontend/src/features/question-table-page/QuestionRow.tsx
+++ b/frontend/src/features/question-table-page/QuestionRow.tsx
@@ -408,8 +408,8 @@ export const QuestionRow: React.FC<QuestionRowProps> = ({
           {visibleColumns.crop && (
             <TableCell className="align-middle">
             {truncate(
-              (q.details.normalised_crop || q.details.crop || "")
-                .replace(/\b\w/g, char => char.toUpperCase()),
+              (q.details.normalised_crop || q.details.crop || ""),
+                // .replace(/\b\w/g, char => char.toUpperCase()),
               10
             )}
           </TableCell>


### PR DESCRIPTION
Showing the crop names in the same way as it is in the database.

<img width="681" height="646" alt="image" src="https://github.com/user-attachments/assets/98b074f5-ca9a-4285-9851-c44360e1b474" />
<img width="1497" height="709" alt="image" src="https://github.com/user-attachments/assets/db413769-352f-4f21-b855-49174e2cef11" />
