### PR TITLE
refactor: sla-breach-calculation-logic

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -12420,6 +12420,27 @@ export class ChatbotRepository implements IChatbotRepository {
                   '$closedAt',
                 ],
               },
+              _effectiveCreatedAt: {
+                $let: {
+                  vars: {
+                    istHour: { $hour: { date: "$createdAt", timezone: "Asia/Kolkata" } },
+                    istDateTrunc: { $dateTrunc: { date: "$createdAt", unit: "day", timezone: "Asia/Kolkata" } }
+                  },
+                  in: {
+                    $cond: {
+                      if: { $gte: ["$$istHour", 22] },
+                      then: { $dateAdd: { startDate: "$$istDateTrunc", unit: "hour", amount: 30 } },
+                      else: {
+                        $cond: {
+                          if: { $lt: ["$$istHour", 6] },
+                          then: { $dateAdd: { startDate: "$$istDateTrunc", unit: "hour", amount: 6 } },
+                          else: "$createdAt"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             },
           },
           {
@@ -12431,7 +12452,12 @@ export class ChatbotRepository implements IChatbotRepository {
                   {$gte: ['$_operationalCompletionAt', '$createdAt']},
                   {
                     $lte: [
-                      {$subtract: ['$_operationalCompletionAt', '$createdAt']},
+                      {
+                        $max: [
+                          0,
+                          {$subtract: ['$_operationalCompletionAt', '$_effectiveCreatedAt']}
+                        ]
+                      },
                       2 * 60 * 60 * 1000,
                     ],
                   },
@@ -14247,7 +14273,10 @@ export class ChatbotRepository implements IChatbotRepository {
         ? {
             $gt: [
               {
-                $subtract: ['$_operationalCompletionAt', '$createdAt'],
+                $max: [
+                  0,
+                  {$subtract: ['$_operationalCompletionAt', '$_effectiveCreatedAt']}
+                ]
               },
               2 * 60 * 60 * 1000,
             ],
@@ -14255,7 +14284,10 @@ export class ChatbotRepository implements IChatbotRepository {
         : {
             $lte: [
               {
-                $subtract: ['$_operationalCompletionAt', '$createdAt'],
+                $max: [
+                  0,
+                  {$subtract: ['$_operationalCompletionAt', '$_effectiveCreatedAt']}
+                ]
               },
               2 * 60 * 60 * 1000,
             ],
@@ -14275,6 +14307,27 @@ export class ChatbotRepository implements IChatbotRepository {
               '$closedAt',
             ],
           },
+          _effectiveCreatedAt: {
+            $let: {
+              vars: {
+                istHour: { $hour: { date: "$createdAt", timezone: "Asia/Kolkata" } },
+                istDateTrunc: { $dateTrunc: { date: "$createdAt", unit: "day", timezone: "Asia/Kolkata" } }
+              },
+              in: {
+                $cond: {
+                  if: { $gte: ["$$istHour", 22] },
+                  then: { $dateAdd: { startDate: "$$istDateTrunc", unit: "hour", amount: 30 } },
+                  else: {
+                    $cond: {
+                      if: { $lt: ["$$istHour", 6] },
+                      then: { $dateAdd: { startDate: "$$istDateTrunc", unit: "hour", amount: 6 } },
+                      else: "$createdAt"
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
       },
       {

--- a/frontend/src/features/chatbotDashboard/ClosedInLastTwoHoursCard.tsx
+++ b/frontend/src/features/chatbotDashboard/ClosedInLastTwoHoursCard.tsx
@@ -318,7 +318,7 @@ export function ClosedInLastTwoHoursCard({
                   suffix=""
                   decimals={0}
                   accent="red"
-                  tooltip="Question resolution took more than 2 hours"
+                  tooltip="Questions exceeding 2 hours based on expert working hours. Questions received between 10:00 PM and 6:00 AM start counting from 6:00 AM"
                   onClick={() => {
                     setIsPassed(true);
                     setClosedWithInTowhours(true);


### PR DESCRIPTION
## This PR includes:

Updated the SLA calculation in `getClosedInLastTwoHours` and `getQuestionsClosedWithinTwoHours`.

### Changes

* Added business-hour based SLA calculation using an effective creation time.
* Questions created between 10:00 PM and 6:00 AM now use 6:00 AM as the SLA start time.
* Prevented negative SLA durations by treating them as 0.
