### PR TITLE
Feat/acc agent mandi schemes

### DIFF
--- a/ai/ajrasakha/agents/acc_agent/README.md
+++ b/ai/ajrasakha/agents/acc_agent/README.md
@@ -4,7 +4,7 @@ A LangGraph-based agent for handling agricultural queries from farmers via call 
 
 ## Overview
 
-The ACC Agent processes farmer transcripts, extracts key information, routes queries to appropriate sub-agents (GDB, Weather, Market), and generates structured JSON responses for call center agents.
+The ACC Agent processes farmer transcripts, extracts key information, routes queries to appropriate sub-agents (GDB, Weather, Market, Schemes), and generates structured JSON responses for call center agents.
 
 ## Architecture
 
@@ -71,12 +71,13 @@ class AccAgentState(TypedDict):
     verified_by_human: bool            # HITL approval flag
     
     # Tool execution - multi-tool routing
-    selected_tools: list[str]          # Tools to call (gdb, weather, market)
+    selected_tools: list[str]          # Tools to call (gdb, weather, market, schemes)
     
     # Individual tool responses
     gdb_response: Optional[str]        # Raw GDB response
     weather_response: Optional[str]    # Raw Weather response
     market_response: Optional[str]     # Raw Market response
+    schemes_response: Optional[str]    # Raw Schemes response
     
     # Final output
     final_answer: Optional[str]        # JSON output with all sections
@@ -105,6 +106,7 @@ class AccAgentState(TypedDict):
   - `gdb`: Farming practices, diseases, pests, fertilizers
   - `weather`: Weather forecasts, rainfall
   - `market`: Market prices, MSP
+  - `schemes`: Government schemes, subsidies, yojanas, farmer benefits
 - Returns `selected_tools` array (can be multiple)
 
 ### 4. Tool Execution Node

--- a/ai/ajrasakha/agents/acc_agent/graph.py
+++ b/ai/ajrasakha/agents/acc_agent/graph.py
@@ -1,5 +1,4 @@
 from langgraph.graph import StateGraph, START, END
-from langgraph.checkpoint.memory import MemorySaver
 
 from ajrasakha.agents.acc_agent.state import AccAgentState
 from ajrasakha.agents.acc_agent.nodes import extract_node, planner_node, tool_execution_node, assembler_node
@@ -20,9 +19,7 @@ def build_graph():
     builder.add_edge("tool_execution", "assembler")
     builder.add_edge("assembler", END)
     
-    checkpointer = MemorySaver()
     graph = builder.compile(
-        checkpointer=checkpointer,
         interrupt_after=["extract"]
     )
     

--- a/ai/ajrasakha/agents/acc_agent/nodes.py
+++ b/ai/ajrasakha/agents/acc_agent/nodes.py
@@ -10,6 +10,7 @@ from ajrasakha.agents.acc_agent.prompts import ACC_EXTRACT_PROMPT, ACC_PLANNER_P
 from ajrasakha.agents.gdb_agent import gdb
 from ajrasakha.agents.weather_agent import weather
 from ajrasakha.agents.market_agent import market
+from ajrasakha.agents.schemes_agent import schemes
 
 async def extract_node(state: AccAgentState):
     """Extract query, state, district, crop, and standardized_domains from transcript."""
@@ -81,7 +82,7 @@ async def planner_node(state: AccAgentState):
                 normalized = []
                 for tool in parsed:
                     tool_lower = str(tool).lower().strip()
-                    if tool_lower in ["gdb", "weather", "market"]:
+                    if tool_lower in ["gdb", "weather", "market", "schemes"]:
                         normalized.append(tool_lower)
                 if normalized:
                     selected_tools = normalized
@@ -150,6 +151,24 @@ async def tool_execution_node(state: AccAgentState):
             })
         except Exception as e:
             return f"Error: {str(e)}"
+
+    async def call_schemes() -> str:
+        try:
+            return await schemes.ainvoke({
+                "query": query,
+                "state": loc_state,
+                "gender": None,
+                "age": None,
+                "caste": None,
+                "residence": None,
+                "occupation": "Farmer",
+                "benefit_type": None,
+                "is_bpl": False,
+                "is_minority": False,
+                "is_differently_abled": False,
+            })
+        except Exception as e:
+            return f"Error: {str(e)}"
     
     # Build task mapping
     tasks = {}
@@ -159,6 +178,8 @@ async def tool_execution_node(state: AccAgentState):
         tasks["weather"] = call_weather()
     if "market" in selected_tools:
         tasks["market"] = call_market()
+    if "schemes" in selected_tools:
+        tasks["schemes"] = call_schemes()
     
     # Execute all selected tools in parallel
     if tasks:
@@ -171,18 +192,25 @@ async def tool_execution_node(state: AccAgentState):
         
         return responses
     
-    return {"gdb_response": "No tools selected", "weather_response": None, "market_response": None}
+    return {
+        "gdb_response": "No tools selected",
+        "weather_response": None,
+        "market_response": None,
+        "schemes_response": None,
+    }
 
 async def assembler_node(state: AccAgentState):
-    """Build JSON output with 4 sections: gdb, weather, market, final_answer."""
+    """Build JSON output with tool data and the synthesized final answer."""
     # Parse each response into JSON (or keep as string if parsing fails)
     gdb_data = None
     weather_data = None
     market_data = None
+    schemes_data = None
     
     gdb_response = state.get("gdb_response")
     weather_response = state.get("weather_response")
     market_response = state.get("market_response")
+    schemes_response = state.get("schemes_response")
     
     # Try to parse GDB response
     if gdb_response:
@@ -204,6 +232,13 @@ async def assembler_node(state: AccAgentState):
             market_data = json.loads(market_response)
         except (json.JSONDecodeError, TypeError):
             market_data = market_response
+
+    # Try to parse Schemes response
+    if schemes_response:
+        try:
+            schemes_data = json.loads(schemes_response)
+        except (json.JSONDecodeError, TypeError):
+            schemes_data = schemes_response
     
     # Generate final_answer using LLM
     llm = ChatAnthropic(model=CLAUDE_MODEL)
@@ -211,7 +246,8 @@ async def assembler_node(state: AccAgentState):
         f"Original Query: {state.get('extracted_query')}\n\n"
         f"GDB Data:\n{json.dumps(gdb_data, indent=2, ensure_ascii=False) if gdb_data else 'Not requested'}\n\n"
         f"Weather Data:\n{json.dumps(weather_data, indent=2, ensure_ascii=False) if weather_data else 'Not requested'}\n\n"
-        f"Market Data:\n{json.dumps(market_data, indent=2, ensure_ascii=False) if market_data else 'Not requested'}"
+        f"Market Data:\n{json.dumps(market_data, indent=2, ensure_ascii=False) if market_data else 'Not requested'}\n\n"
+        f"Schemes Data:\n{json.dumps(schemes_data, indent=2, ensure_ascii=False) if schemes_data else 'Not requested'}"
     )
     
     messages = [
@@ -226,6 +262,7 @@ async def assembler_node(state: AccAgentState):
         "gdb": gdb_data,
         "weather": weather_data,
         "market": market_data,
+        "schemes": schemes_data,
         "final_answer": final_answer_text
     }
     

--- a/ai/ajrasakha/agents/acc_agent/prompts.py
+++ b/ai/ajrasakha/agents/acc_agent/prompts.py
@@ -51,6 +51,7 @@ You have access to specific sub-agent tools that can fetch agricultural data.
 Your job is to look at the user's verified query and decide WHICH tool(s) to use.
 If the query is about weather, include "weather" in your output.
 If the query is about market prices or mandi rates, include "market" in your output.
+If the query is about government schemes, subsidies, yojanas, or farmer benefits, include "schemes" in your output.
 If the query is about farming practices, diseases, pests, fertilizers, or general agricultural advice, include "gdb" in your output.
 
 IMPORTANT: A query may require multiple tools. If so, include ALL relevant tools.

--- a/ai/ajrasakha/agents/acc_agent/state.py
+++ b/ai/ajrasakha/agents/acc_agent/state.py
@@ -25,6 +25,7 @@ class AccAgentState(TypedDict):
     gdb_response: Optional[str]
     weather_response: Optional[str]
     market_response: Optional[str]
+    schemes_response: Optional[str]
     
     # Final output
     final_answer: Optional[str]


### PR DESCRIPTION
## Summary

- Integrated the existing government schemes tool into `acc_agent`.
- Preserved the existing mandi flow through the shared `market` tool.
- Removed the ACC graph's custom `MemorySaver` so it loads correctly through LangGraph API and Studio persistence.

## Validation

- Tested schemes and mandi paths in local LangGraph Studio.
- Tested the HITL curl/API flow for both paths.
- Schemes selects `schemes` and returns `schemes_response` plus a final answer.
- Mandi selects `market` and returns `market_response` plus a final answer.