### PR TITLE
Add market price alerts panel for farmers

### DIFF
--- a/frontend/src/components/play-ground.tsx
+++ b/frontend/src/components/play-ground.tsx
@@ -30,6 +30,7 @@ import { ManageCallAgents } from "./ManageCallAgents";
 import { env } from "@/config/env";
 import { DataProcessingDashboard } from "../features/faq-pop/DataProcessingDashboard";
 import { CallAgentDashboard } from "./CallAgentDashboard";
+import { PriceAlertPanel } from "../features/market-alerts/PriceAlertPanel";
 
 export const PlaygroundPage = () => {
   const { data: user } = useGetCurrentUser({});
@@ -499,7 +500,14 @@ export const PlaygroundPage = () => {
                   )}
                 >
                   <div className=" overflow-hidden bg-background p-4 ps-0">
-                    <div className=" mx-auto py-8 pt-0">
+                    <div className=" mx-auto py-8 pt-0 space-y-6">
+                      {/* Market Price Alerts Panel - Farmers Only */}
+                      {user.role === "farmer" && (
+                        <div>
+                          <PriceAlertPanel />
+                        </div>
+                      )}
+                      {/* Voice Recorder for asking questions */}
                       <VoiceRecorderCard />
                     </div>
                   </div>

--- a/frontend/src/features/market-alerts/PriceAlertPanel.tsx
+++ b/frontend/src/features/market-alerts/PriceAlertPanel.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Bell } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/atoms/card";
+import { Button } from "@/components/atoms/button";
+import { Skeleton } from "@/components/atoms/skeleton";
+import { usePriceAlerts } from "./usePriceAlerts";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+import { toast } from "sonner";
+
+/**
+ * PriceAlertPanel - Farmer-facing component for managing crop price alerts
+ *
+ * Features:
+ * - Display 6 common crops (Wheat, Rice, Cotton, Tomato, Onion, Potato)
+ * - Toggle alerts per crop with bell icon feedback
+ * - Save preferences button
+ * - Local storage persistence
+ * - Role-aware rendering (farmers only)
+ */
+export const PriceAlertPanel = () => {
+  const { alerts, toggleAlert, savePreferences, isLoaded } = usePriceAlerts();
+  const [isSaving, setIsSaving] = useState(false);
+
+  if (!isLoaded) {
+    return (
+      <Card className="w-full bg-gradient-to-br from-emerald-50 to-transparent border-emerald-200">
+        <CardHeader className="pb-3">
+          <div className="flex items-center gap-2">
+            <Bell className="h-5 w-5 text-emerald-600" />
+            <CardTitle className="text-lg font-semibold text-emerald-900">
+              Market Price Alerts
+            </CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const handleToggle = (crop: string) => {
+    toggleAlert(crop as any);
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      savePreferences();
+      const enabledCrops = alerts
+        .filter((a) => a.enabled)
+        .map((a) => a.crop)
+        .join(", ");
+
+      toast.success(
+        enabledCrops.length > 0
+          ? `Alerts set for: ${enabledCrops}`
+          : "Price alerts disabled"
+      );
+    } catch (error) {
+      toast.error("Failed to save preferences");
+      console.error(error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const enabledCount = alerts.filter((a) => a.enabled).length;
+
+  return (
+    <Card className="w-full bg-gradient-to-br from-emerald-50 to-transparent border-emerald-200 shadow-sm hover:shadow-md transition-shadow">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Bell className="h-5 w-5 text-emerald-600" />
+            <CardTitle className="text-lg font-semibold text-emerald-900">
+              Market Price Alerts
+            </CardTitle>
+          </div>
+          {enabledCount > 0 && (
+            <span className="inline-flex items-center rounded-full bg-emerald-600 px-2.5 py-0.5 text-xs font-medium text-white">
+              {enabledCount} active
+            </span>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* Crop Toggle Grid */}
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {alerts.map((alert) => (
+            <button
+              key={alert.crop}
+              onClick={() => handleToggle(alert.crop)}
+              className={cn(
+                "group relative inline-flex items-center justify-between gap-2 rounded-lg px-3 py-2.5 font-medium text-sm transition-all duration-200",
+                alert.enabled
+                  ? "bg-emerald-100 text-emerald-900 ring-2 ring-emerald-300"
+                  : "bg-white text-gray-700 border border-gray-200 hover:border-emerald-200"
+              )}
+            >
+              <span className="truncate">{alert.crop}</span>
+              <Bell
+                className={cn(
+                  "h-4 w-4 flex-shrink-0 transition-all",
+                  alert.enabled
+                    ? "fill-emerald-600 text-emerald-600"
+                    : "text-gray-400 group-hover:text-emerald-400"
+                )}
+              />
+            </button>
+          ))}
+        </div>
+
+        {/* Info Text */}
+        <p className="text-xs text-gray-600">
+          {enabledCount > 0
+            ? `You'll be notified when prices change for ${enabledCount} selected crop${enabledCount !== 1 ? "s" : ""}`
+            : "Select crops to receive price alerts"}
+        </p>
+
+        {/* Save Button */}
+        <Button
+          onClick={handleSave}
+          disabled={isSaving}
+          className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium transition-colors"
+        >
+          {isSaving ? (
+            <span className="flex items-center gap-2">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              Saving...
+            </span>
+          ) : (
+            "Save Preferences"
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/features/market-alerts/PriceAlertPanel.tsx
+++ b/frontend/src/features/market-alerts/PriceAlertPanel.tsx
@@ -43,8 +43,8 @@ export const PriceAlertPanel = () => {
     );
   }
 
-  const handleToggle = (crop: string) => {
-    toggleAlert(crop as any);
+  const handleToggle = (crop: Parameters<typeof toggleAlert>[0]) => {
+    toggleAlert(crop);
   };
 
   const handleSave = async () => {

--- a/frontend/src/features/market-alerts/usePriceAlerts.ts
+++ b/frontend/src/features/market-alerts/usePriceAlerts.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect } from "react";
+
+export type CropType = "Wheat" | "Rice" | "Cotton" | "Tomato" | "Onion" | "Potato";
+
+export interface PriceAlert {
+  crop: CropType;
+  enabled: boolean;
+}
+
+const DEFAULT_CROPS: CropType[] = ["Wheat", "Rice", "Cotton", "Tomato", "Onion", "Potato"];
+const STORAGE_KEY = "market_price_alerts";
+
+/**
+ * Hook to manage farmer price alerts preferences
+ * Stores state in localStorage for persistence across sessions
+ */
+export const usePriceAlerts = () => {
+  const [alerts, setAlerts] = useState<PriceAlert[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Initialize from localStorage on mount
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      try {
+        setAlerts(JSON.parse(saved));
+      } catch (e) {
+        console.error("Failed to parse saved alerts", e);
+        // Fall back to default
+        setAlerts(DEFAULT_CROPS.map((crop) => ({ crop, enabled: false })));
+      }
+    } else {
+      // Initialize with default crops, all disabled
+      setAlerts(DEFAULT_CROPS.map((crop) => ({ crop, enabled: false })));
+    }
+    setIsLoaded(true);
+  }, []);
+
+  // Persist to localStorage whenever alerts change
+  useEffect(() => {
+    if (isLoaded) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(alerts));
+    }
+  }, [alerts, isLoaded]);
+
+  const toggleAlert = (crop: CropType) => {
+    setAlerts((prev) =>
+      prev.map((alert) =>
+        alert.crop === crop ? { ...alert, enabled: !alert.enabled } : alert
+      )
+    );
+  };
+
+  const savePreferences = () => {
+    // Persist is handled automatically by the useEffect above
+    // This is exposed for explicit save button interaction
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(alerts));
+  };
+
+  return {
+    alerts,
+    toggleAlert,
+    savePreferences,
+    isLoaded,
+  };
+};


### PR DESCRIPTION
## Market Price Alerts for Farmers

### Overview
This PR introduces a lightweight, frontend-only **Market Price Alerts** panel for farmers. It enables users to manage price alert preferences for common crops directly from the farmer chat interface without changing the existing application architecture.

### What's Included
- Added a reusable `PriceAlertPanel` component.
- Integrated the panel into the farmer chat interface near the Voice Recorder / Quick Prompts.
- Added toggle controls for:
  - Wheat
  - Rice
  - Cotton
  - Tomato
  - Onion
  - Potato
- Added a **Save Preferences** button.
- Used local React state and `localStorage` for frontend persistence.

### Benefits
- Improves the farmer experience by making market alerts easy to access.
- Keeps the feature close to the primary chat workflow.
- Introduces the feature without requiring backend or database changes.

### Scope
This PR is intentionally limited to a frontend MVP. It does **not** include:
- Backend APIs
- Database changes
- Notification services
- New routes

### Testing
- Verified the panel renders for farmer users.
- Verified crop preferences can be toggled.
- Verified preferences persist using local state and `localStorage`.