### PR TITLE
fix/blocking user to change the question status for re-routed questions.

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2125,17 +2125,14 @@ export class QuestionService extends BaseService implements IQuestionService {
           throw new BadRequestError(`Question with ID ${questionId} not found`);
         }
 
-        // Block changing status to 'open' or 'delayed' when the question has an active re-route
-        if (updates.status === 'open' || updates.status === 'delayed') {
-          const rerouteDoc = await this.reRouteRepository.findByQuestionId(questionId, session);
-          const hasActiveReroute = rerouteDoc?.reroutes?.some(r =>
-            r.status === 'pending' || r.status === 'expert_completed' || r.status === 'in-review',
+        // Block changing status to 'open' or 'delayed' when the question is re-routed
+        if (
+          (updates.status === 'open' || updates.status === 'delayed') &&
+          existingQuestion.status === 're-routed'
+        ) {
+          throw new BadRequestError(
+            `Cannot change the status, this question is currently re-routed.`,
           );
-          if (hasActiveReroute) {
-            throw new BadRequestError(
-              `Cannot change status to "${updates.status}": this question has an active re-route. Resolve the re-route first.`,
-            );
-          }
         }
 
         // if (existingQuestion.status == 'closed')

--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2125,6 +2125,19 @@ export class QuestionService extends BaseService implements IQuestionService {
           throw new BadRequestError(`Question with ID ${questionId} not found`);
         }
 
+        // Block changing status to 'open' or 'delayed' when the question has an active re-route
+        if (updates.status === 'open' || updates.status === 'delayed') {
+          const rerouteDoc = await this.reRouteRepository.findByQuestionId(questionId, session);
+          const hasActiveReroute = rerouteDoc?.reroutes?.some(r =>
+            r.status === 'pending' || r.status === 'expert_completed' || r.status === 'in-review',
+          );
+          if (hasActiveReroute) {
+            throw new BadRequestError(
+              `Cannot change status to "${updates.status}": this question has an active re-route. Resolve the re-route first.`,
+            );
+          }
+        }
+
         // if (existingQuestion.status == 'closed')
         //   throw new BadRequestError(
         //     'You cannot modify a question that has already been closed.',


### PR DESCRIPTION
Restricts users when they tries to change the status of any re-routed question to open or delayed.

<img width="1525" height="724" alt="image" src="https://github.com/user-attachments/assets/03651ed8-c732-42ad-b965-d7e0e36c2047" />
