### PR TITLE
feat/showing duplicate cancelled patch

### DIFF
--- a/frontend/src/features/question-table-page/QuestionRow.tsx
+++ b/frontend/src/features/question-table-page/QuestionRow.tsx
@@ -372,7 +372,9 @@ export const QuestionRow: React.FC<QuestionRowProps> = ({
                         q?.referenceQuestion&&
                         q?.referenceSource&&
                         (
-                          <span className='text-xs text-red-600 mr-1'>(DUPLICATE)</span>
+                          q?.isDuplicateCancelled
+                            ? <span className='text-xs text-amber-600 mr-1'>(DUPLICATE_CANCELED)</span>
+                            : <span className='text-xs text-red-600 mr-1'>(DUPLICATE)</span>
                         )
                         }
                         {truncate(q.question, 50)}

--- a/frontend/src/features/question_details/components/QuestionHeader.tsx
+++ b/frontend/src/features/question_details/components/QuestionHeader.tsx
@@ -343,7 +343,7 @@ export const QuestionHeader = ({ question, goBack, currentUser, isQuestionAlloca
             {isDuplicateCancelled && (
               <div className="flex items-center gap-1.5">
                 <Badge className="bg-amber-500/10 text-amber-700 border-amber-500/30">
-                  Duplicate Cancelled
+                  DUPLICATE_CANCELED
                 </Badge>
                 <span className="text-[11px] italic text-muted-foreground">
                   To view the cancel reason, check the audit trail.


### PR DESCRIPTION
Showing duplicate cancelled if question duplicate is cancelled by gate keeper instead of duplicate.

<img width="1529" height="680" alt="image" src="https://github.com/user-attachments/assets/b65b849b-ed77-4da9-8fe9-bf9464c299e2" />
