### PR TITLE
feat: GDB Coverage Gap Detector (Project 6)

### DIFF
--- a/apis/acc_api/.env.example
+++ b/apis/acc_api/.env.example
@@ -7,3 +7,6 @@ EMBEDDING_MODEL_NAME=BAAI/bge-large-en-v1.5
 
 # Gemma LLM Endpoint for Agent Search and Sanitization
 GEMMA_LLM_ENDPOINT=http://100.100.108.44:8014/v1/chat/completions
+
+# Optional: collection for GDB Coverage Gap Detector reports (same DB_NAME as questions)
+GAP_REPORTS_COLLECTION=gdb_gap_reports

--- a/apis/acc_api/apiGuide.md
+++ b/apis/acc_api/apiGuide.md
@@ -173,6 +173,67 @@ curl -X GET http://127.0.0.1:8001/filters
 
 ---
 
+### 4. `GET /gdb/gap-report` (GDB Coverage Gap Detector)
+
+Returns the most recent pre-computed **weekly gap report**: farmer questions the GDB could not answer (the AI agent's 2-hour-disclaimer path), clustered by crop/state/domain and ranked by farmer demand, plus a crop x state x domain coverage heatmap and outreach recommendations. Read-only — never touches `questions`.
+
+The report itself is generated out-of-band by `gap_pipeline.py` (see below), not by this endpoint, so results reflect whenever the pipeline last ran.
+
+**Example request**
+```bash
+curl -X GET http://127.0.0.1:8001/gdb/gap-report
+```
+
+**Example response (trimmed)**
+```json
+{
+  "report_type": "weekly",
+  "period_days": 7,
+  "generated_at": "2026-07-14T10:00:00Z",
+  "total_disclaimers": 214,
+  "clusters_found": 18,
+  "top_gaps": [
+    {
+      "cluster_name": "Whitefly attack on cotton during flowering",
+      "size": 37,
+      "keywords": ["dosage", "flowering", "spray"],
+      "crop": "Cotton",
+      "states": ["Gujarat"],
+      "domains": ["Pest"],
+      "growth_rate": 0.6,
+      "priority_score": 59.2,
+      "priority_level": "CRITICAL",
+      "recommended_action": "Draft a GDB answer for Cotton / Pest in Gujarat."
+    }
+  ],
+  "coverage_stats": {
+    "heatmap": [
+      {"crop": "Cotton", "state": "Gujarat", "domain": "Pest", "gdb_count": 2, "disclaimer_count": 37, "coverage_score": 0.05, "status": "gap"}
+    ],
+    "covered": 120, "partial": 30, "gaps": 18
+  },
+  "outreach_recommendations": [
+    {"target_state": "Gujarat", "focus_domain": "Pest", "gap_questions": 37, "priority": "HIGH"}
+  ]
+}
+```
+
+Returns `404` until the pipeline has produced at least one report.
+
+**Running the pipeline manually**
+```bash
+python gap_pipeline.py
+```
+This connects using the same env vars as `main.py`, builds one report, and inserts it into `GAP_REPORTS_COLLECTION` (default `gdb_gap_reports`, same database as `questions`). Wire this into your existing cron/ops tooling for a weekly cadence — no scheduler is bundled here.
+
+**Running the tests**
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+---
+
 ## Docker Containerization
 
 This API is fully containerized and deployable via Docker.

--- a/apis/acc_api/gap_detector.py
+++ b/apis/acc_api/gap_detector.py
@@ -1,0 +1,507 @@
+"""GDB Coverage Gap Detector: read-only analytics over farmer questions.
+
+Finds clusters of farmer questions the GDB could not answer (the AI agent's
+"static_dynamic" disclaimer path — see ai/ajrasakha/agents/plan_executor.py
+should_expert_queue_reply / QuestionService.ts isDisclaimer tagging) and turns
+them into a weekly, demand-ranked gap report plus a crop x state x domain
+coverage heatmap.
+
+Design notes:
+- Read-only. Nothing here ever writes to the `questions` collection.
+- No invented collections: "gap" questions are `tag == "static_dynamic"` +
+  `source in (AJRASAKHA, WHATSAPP)` on the existing `questions` collection —
+  there is no separate disclaimer log in this codebase.
+- No new ML infra: clustering reuses whatever embedding function the caller
+  already has loaded (acc_api's SentenceTransformer), and duplicate/overlap
+  checking against the GDB reuses the existing golden-search API instead of
+  standing up a second hybrid-search + reranker + NLI pipeline.
+- This module has no import-time side effects (no Mongo/model construction),
+  so it can be unit tested with plain Python fixtures.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+import numpy as np
+
+# --- The real "gap" signal on the existing `questions` collection ----------
+# tag="static_dynamic" is set by the Node backend (QuestionService.ts) when
+# only dynamic/non-knowledge-base tools ran and the 2-hour disclaimer was
+# sent — i.e. the GDB had no answer. See ai/ajrasakha/agents/plan_executor.py
+# should_expert_queue_reply for the AI-side trigger.
+GAP_TAG = "static_dynamic"
+GAP_SOURCES = ("AJRASAKHA", "WHATSAPP")
+ANSWERED_STATUS = "closed"
+
+DEFAULT_SIMILARITY_THRESHOLD = 0.82
+DEFAULT_PERIOD_DAYS = 7
+DEFAULT_LOOKBACK_DAYS = 30
+DEFAULT_TOP_N_GAPS = 20
+
+_UNKNOWN = "Unknown"
+
+_STOPWORDS = frozenset({
+    "the", "a", "an", "is", "are", "was", "were", "in", "on", "at", "to",
+    "for", "of", "and", "or", "what", "why", "how", "when", "where", "which",
+    "my", "i", "do", "does", "can", "should", "it", "this", "that", "with",
+    "from", "not", "will", "get", "has", "have", "there", "any", "please",
+    "help", "know", "want", "need",
+})
+_WORD_RE = re.compile(r"[a-zA-Z']+")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _question_text(doc: dict) -> str:
+    return (doc.get("question") or doc.get("text") or "").strip()
+
+
+def _crop_of(details: dict) -> str:
+    return (details.get("normalised_crop") or details.get("crop") or _UNKNOWN).strip() or _UNKNOWN
+
+
+def _state_of(details: dict) -> str:
+    return (details.get("state") or _UNKNOWN).strip() or _UNKNOWN
+
+
+def _domains_of(details: dict) -> list[str]:
+    domains = details.get("domain")
+    if isinstance(domains, list) and domains:
+        cleaned = [str(d).strip() for d in domains if str(d).strip()]
+        return cleaned or [_UNKNOWN]
+    if isinstance(domains, str) and domains.strip():
+        return [domains.strip()]
+    return [_UNKNOWN]
+
+
+# ---------------------------------------------------------------------------
+# Mongo access (thin — logic below operates on plain dicts/arrays so it can
+# be unit tested without a live database).
+# ---------------------------------------------------------------------------
+
+
+def gap_question_filter(since: datetime | None = None) -> dict:
+    """Read-only Mongo filter for disclaimer-triggered farmer questions."""
+    query: dict = {"tag": GAP_TAG, "source": {"$in": list(GAP_SOURCES)}}
+    if since is not None:
+        query["createdAt"] = {"$gte": since}
+    return query
+
+
+def fetch_gap_questions(collection, *, since: datetime | None = None) -> list[dict]:
+    """Fetch unanswered disclaimer-triggered questions. Never writes."""
+    cursor = collection.find(
+        gap_question_filter(since),
+        {"question": 1, "text": 1, "details": 1, "createdAt": 1},
+    )
+    return list(cursor)
+
+
+def _crop_state_domain_group_id() -> dict:
+    return {
+        "crop": {"$ifNull": ["$details.normalised_crop", {"$ifNull": ["$details.crop", _UNKNOWN]}]},
+        "state": {"$ifNull": ["$details.state", _UNKNOWN]},
+        "domain": {"$ifNull": ["$details.domain", _UNKNOWN]},
+    }
+
+
+def _aggregate_counts_by_cell(collection, match: dict) -> dict[tuple[str, str, str], int]:
+    pipeline = [
+        {"$match": match},
+        {"$unwind": {"path": "$details.domain", "preserveNullAndEmptyArrays": True}},
+        {"$group": {"_id": _crop_state_domain_group_id(), "count": {"$sum": 1}}},
+    ]
+    counts: dict[tuple[str, str, str], int] = {}
+    for row in collection.aggregate(pipeline):
+        cell = row["_id"]
+        counts[(cell["crop"], cell["state"], cell["domain"])] = row["count"]
+    return counts
+
+
+def fetch_gdb_coverage_counts(collection) -> dict[tuple[str, str, str], int]:
+    """All-time answered-question counts per (crop, state, domain) — the GDB."""
+    return _aggregate_counts_by_cell(collection, {"status": ANSWERED_STATUS})
+
+
+def fetch_all_time_gap_counts(collection) -> dict[tuple[str, str, str], int]:
+    """All-time gap-question counts per cell, for the coverage heatmap."""
+    return _aggregate_counts_by_cell(collection, gap_question_filter())
+
+
+def fetch_gap_window_counts(
+    collection, *, window_start: datetime, window_end: datetime
+) -> dict[tuple[str, str, str], int]:
+    """Gap-question counts per cell within [window_start, window_end)."""
+    match = gap_question_filter(window_start)
+    match["createdAt"]["$lt"] = window_end
+    return _aggregate_counts_by_cell(collection, match)
+
+
+# ---------------------------------------------------------------------------
+# Coverage heatmap
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HeatmapCell:
+    crop: str
+    state: str
+    domain: str
+    gdb_count: int
+    gap_count: int
+    coverage_score: float
+    status: str  # "good" | "partial" | "gap"
+
+
+def _cell_status(coverage_score: float, gdb_count: int) -> str:
+    if gdb_count == 0:
+        return "gap"
+    if coverage_score >= 0.7:
+        return "good"
+    return "partial"
+
+
+def build_coverage_heatmap(
+    gdb_counts: dict[tuple[str, str, str], int],
+    gap_counts: dict[tuple[str, str, str], int],
+) -> list[HeatmapCell]:
+    """Combine GDB-answered vs gap counts into one crop x state x domain grid."""
+    cells: list[HeatmapCell] = []
+    for cell_key in set(gdb_counts) | set(gap_counts):
+        crop, state, domain = cell_key
+        gdb_count = gdb_counts.get(cell_key, 0)
+        gap_count = gap_counts.get(cell_key, 0)
+        total = gdb_count + gap_count
+        coverage_score = (gdb_count / total) if total else 0.0
+        cells.append(HeatmapCell(
+            crop=crop,
+            state=state,
+            domain=domain,
+            gdb_count=gdb_count,
+            gap_count=gap_count,
+            coverage_score=round(coverage_score, 4),
+            status=_cell_status(coverage_score, gdb_count),
+        ))
+    return cells
+
+
+# ---------------------------------------------------------------------------
+# Clustering — greedy cosine-similarity clustering.
+# ---------------------------------------------------------------------------
+
+
+def _cosine_sim_matrix(vectors: np.ndarray) -> np.ndarray:
+    norm = vectors / (np.linalg.norm(vectors, axis=1, keepdims=True) + 1e-9)
+    return norm @ norm.T
+
+
+def cluster_by_similarity(
+    embeddings: np.ndarray,
+    *,
+    threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+) -> list[list[int]]:
+    """Greedy single-pass clustering by cosine similarity to the cluster seed.
+
+    ponytail: O(n^2) similarity matrix — fine for a single (crop, state)
+    partition of a 30-day gap window (tens to low hundreds of rows), not for
+    the whole corpus. If a partition regularly exceeds a few thousand rows,
+    swap in scikit-learn DBSCAN over the same embeddings.
+    """
+    n = embeddings.shape[0]
+    if n == 0:
+        return []
+    sims = _cosine_sim_matrix(embeddings)
+    assigned = [-1] * n
+    clusters: list[list[int]] = []
+    for i in range(n):
+        if assigned[i] != -1:
+            continue
+        cluster = [i]
+        assigned[i] = len(clusters)
+        for j in range(i + 1, n):
+            if assigned[j] == -1 and sims[i, j] >= threshold:
+                cluster.append(j)
+                assigned[j] = len(clusters)
+        clusters.append(cluster)
+    return clusters
+
+
+def _most_common_domain(cluster_docs: list[dict]) -> str:
+    counter: Counter[str] = Counter()
+    for doc in cluster_docs:
+        counter.update(_domains_of(doc.get("details") or {}))
+    return counter.most_common(1)[0][0] if counter else _UNKNOWN
+
+
+def _tokenize(text: str) -> set[str]:
+    return {w.lower() for w in _WORD_RE.findall(text or "") if w.lower() not in _STOPWORDS and len(w) > 2}
+
+
+def extract_missing_keywords(cluster_texts: list[str], representative_text: str, top_n: int = 5) -> list[str]:
+    """Words common across the cluster's variations but absent from the
+    representative question — the specifics a GDB content writer should add.
+    """
+    rep_words = _tokenize(representative_text)
+    counter: Counter[str] = Counter()
+    for text in cluster_texts:
+        counter.update(_tokenize(text) - rep_words)
+    return [word for word, _ in counter.most_common(top_n)]
+
+
+def priority_score(cluster_size: int, growth_rate: float) -> float:
+    """Demand x Deficit ranking: farmer demand (cluster size) boosted by how
+    fast the gap is growing. A flat/shrinking gap still ranks by raw demand.
+    """
+    return round(cluster_size * (1.0 + max(growth_rate, 0.0)), 3)
+
+
+def priority_level(score: float) -> str:
+    if score >= 20:
+        return "CRITICAL"
+    if score >= 10:
+        return "HIGH"
+    if score >= 4:
+        return "MEDIUM"
+    return "LOW"
+
+
+def _growth_rate(current: int, previous: int) -> float:
+    if previous <= 0:
+        return 1.0 if current > 0 else 0.0
+    return (current - previous) / previous
+
+
+@dataclass
+class GapCluster:
+    cluster_id: str
+    representative_text: str
+    size: int
+    sample_questions: list[str]
+    crop: str
+    state: str
+    domain: str
+    keywords: list[str]
+    growth_rate: float
+    priority_score: float
+    priority_level: str
+
+
+def build_gap_clusters(
+    gap_docs: list[dict],
+    embeddings: np.ndarray,
+    *,
+    current_counts: dict[tuple[str, str, str], int],
+    previous_counts: dict[tuple[str, str, str], int],
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    max_samples: int = 5,
+) -> list[GapCluster]:
+    """Partition gap questions by (crop, state), cluster within each partition
+    by semantic similarity, and score every cluster by farmer demand x growth.
+    """
+    partitions: dict[tuple[str, str], list[int]] = {}
+    for idx, doc in enumerate(gap_docs):
+        details = doc.get("details") or {}
+        key = (_crop_of(details), _state_of(details))
+        partitions.setdefault(key, []).append(idx)
+
+    clusters: list[GapCluster] = []
+    for (crop, state), indices in partitions.items():
+        partition_docs = [gap_docs[i] for i in indices]
+        partition_embeddings = embeddings[indices]
+        for local_cluster in cluster_by_similarity(partition_embeddings, threshold=similarity_threshold):
+            cluster_docs = [partition_docs[i] for i in local_cluster]
+            texts = [_question_text(d) for d in cluster_docs]
+            representative = max(texts, key=len) if texts else ""
+            domain = _most_common_domain(cluster_docs)
+
+            cell_key = (crop, state, domain)
+            current = current_counts.get(cell_key, 0)
+            previous = previous_counts.get(cell_key, 0)
+            growth = _growth_rate(current, previous)
+            score = priority_score(len(cluster_docs), growth)
+
+            clusters.append(GapCluster(
+                cluster_id=f"{crop}|{state}|{domain}|{len(clusters)}",
+                representative_text=representative,
+                size=len(cluster_docs),
+                sample_questions=texts[:max_samples],
+                crop=crop,
+                state=state,
+                domain=domain,
+                keywords=extract_missing_keywords(texts, representative),
+                growth_rate=round(growth, 3),
+                priority_score=score,
+                priority_level=priority_level(score),
+            ))
+
+    clusters.sort(key=lambda c: c.priority_score, reverse=True)
+    return clusters
+
+
+# ---------------------------------------------------------------------------
+# Outreach recommendations — cheap derivation from the heatmap, no LLM call.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OutreachRecommendation:
+    target_state: str
+    focus_domain: str
+    gap_questions: int
+    recommendation: str
+    priority: str
+
+
+def build_outreach_recommendations(
+    heatmap: list[HeatmapCell], *, top_n: int = 10
+) -> list[OutreachRecommendation]:
+    gap_cells = sorted(
+        (c for c in heatmap if c.status in ("gap", "partial") and c.gap_count > 0),
+        key=lambda c: c.gap_count,
+        reverse=True,
+    )[:top_n]
+    return [
+        OutreachRecommendation(
+            target_state=c.state,
+            focus_domain=c.domain,
+            gap_questions=c.gap_count,
+            recommendation=(
+                f"{c.gap_count} unanswered {c.domain} questions for {c.crop} in {c.state} "
+                f"({'no GDB coverage' if c.status == 'gap' else 'weak GDB coverage'}) — "
+                "prioritize for content team / field visit."
+            ),
+            priority="HIGH" if c.status == "gap" else "MEDIUM",
+        )
+        for c in gap_cells
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Report orchestration
+# ---------------------------------------------------------------------------
+
+
+def build_gap_report(
+    *,
+    questions_collection,
+    embed_fn: Callable[[list[str]], np.ndarray],
+    period_days: int = DEFAULT_PERIOD_DAYS,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    top_n_gaps: int = DEFAULT_TOP_N_GAPS,
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+) -> dict[str, Any]:
+    """Build one weekly gap report. Read-only against `questions_collection`.
+
+    `embed_fn` takes a list of question texts and returns an (n, d) array of
+    embeddings — inject the caller's already-loaded SentenceTransformer so
+    this module never manages its own model.
+    """
+    now = _now()
+    current_start = now - timedelta(days=period_days)
+    previous_start = current_start - timedelta(days=period_days)
+    lookback_start = now - timedelta(days=lookback_days)
+
+    gap_docs = fetch_gap_questions(questions_collection, since=lookback_start)
+    gdb_counts = fetch_gdb_coverage_counts(questions_collection)
+    all_time_gap_counts = fetch_all_time_gap_counts(questions_collection)
+    heatmap = build_coverage_heatmap(gdb_counts, all_time_gap_counts)
+
+    current_counts = fetch_gap_window_counts(questions_collection, window_start=current_start, window_end=now)
+    previous_counts = fetch_gap_window_counts(
+        questions_collection, window_start=previous_start, window_end=current_start
+    )
+
+    if gap_docs:
+        texts = [_question_text(d) for d in gap_docs]
+        embeddings = np.asarray(embed_fn(texts))
+        clusters = build_gap_clusters(
+            gap_docs,
+            embeddings,
+            current_counts=current_counts,
+            previous_counts=previous_counts,
+            similarity_threshold=similarity_threshold,
+        )
+    else:
+        clusters = []
+
+    top_gaps = clusters[:top_n_gaps]
+    outreach = build_outreach_recommendations(heatmap)
+
+    domain_gap_totals: Counter[str] = Counter()
+    state_gap_totals: Counter[str] = Counter()
+    for cell in heatmap:
+        if cell.status in ("gap", "partial"):
+            domain_gap_totals[cell.domain] += cell.gap_count
+            state_gap_totals[cell.state] += cell.gap_count
+
+    return {
+        "report_type": "weekly",
+        "period_days": period_days,
+        "start_date": current_start,
+        "end_date": now,
+        "generated_at": now,
+        "total_disclaimers": len(gap_docs),
+        "unique_queries": len({_question_text(d) for d in gap_docs}),
+        "clusters_found": len(clusters),
+        "top_gaps": [
+            {
+                "cluster_id": c.cluster_id,
+                "cluster_name": c.representative_text,
+                "size": c.size,
+                "keywords": c.keywords,
+                "sample_queries": c.sample_questions,
+                "domains": [c.domain],
+                "states": [c.state],
+                "crop": c.crop,
+                "growth_rate": c.growth_rate,
+                "priority_score": c.priority_score,
+                "farmer_demand": c.size,
+                "recommended_action": f"Draft a GDB answer for {c.crop} / {c.domain} in {c.state}.",
+                "priority_level": c.priority_level,
+            }
+            for c in top_gaps
+        ],
+        "coverage_stats": {
+            "heatmap": [
+                {
+                    "crop": c.crop,
+                    "state": c.state,
+                    "domain": c.domain,
+                    "gdb_count": c.gdb_count,
+                    "disclaimer_count": c.gap_count,
+                    "coverage_score": c.coverage_score,
+                    "status": c.status,
+                }
+                for c in heatmap
+            ],
+            "total_combinations": len(heatmap),
+            "covered": sum(1 for c in heatmap if c.status == "good"),
+            "partial": sum(1 for c in heatmap if c.status == "partial"),
+            "gaps": sum(1 for c in heatmap if c.status == "gap"),
+        },
+        "outreach_recommendations": [
+            {
+                "target_state": o.target_state,
+                "focus_domain": o.focus_domain,
+                "gap_questions": o.gap_questions,
+                "recommendation": o.recommendation,
+                "priority": o.priority,
+            }
+            for o in outreach
+        ],
+        "domains_with_gaps": [
+            {"domain": domain, "gap_count": count}
+            for domain, count in domain_gap_totals.most_common()
+        ],
+        "states_with_gaps": [
+            {"state": state, "gap_count": count}
+            for state, count in state_gap_totals.most_common()
+        ],
+    }

--- a/apis/acc_api/gap_pipeline.py
+++ b/apis/acc_api/gap_pipeline.py
@@ -1,0 +1,46 @@
+"""Standalone runner for the GDB Coverage Gap Detector.
+
+Builds one weekly gap report and inserts it into `gap_reports_collection`.
+Intended to be cron'd (e.g. weekly) against the same Mongo/embedding config
+as main.py — it reuses main.py's already-configured connections rather than
+opening new ones.
+
+Usage:
+    python gap_pipeline.py
+
+ponytail: no scheduler here (no APScheduler/Celery dependency added) — wire
+this into whatever cron/orchestration the ops team already uses for the
+service. Building a scheduler was out of scope for a single-report pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from gap_detector import build_gap_report
+from main import gap_reports_collection, model, reviewer_collection
+
+log = logging.getLogger("gap_pipeline")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)-7s | %(message)s")
+
+
+def _embed_texts(texts: list[str]):
+    prefixed = [f"Represent this sentence for searching relevant passages: {t}" for t in texts]
+    return model.encode(prefixed, normalize_embeddings=True)
+
+
+def run() -> dict:
+    log.info("Building GDB coverage gap report...")
+    report = build_gap_report(questions_collection=reviewer_collection, embed_fn=_embed_texts)
+    gap_reports_collection.insert_one(report)
+    log.info(
+        "Gap report stored: %d disclaimer questions, %d clusters, %d heatmap cells.",
+        report["total_disclaimers"],
+        report["clusters_found"],
+        report["coverage_stats"]["total_combinations"],
+    )
+    return report
+
+
+if __name__ == "__main__":
+    run()

--- a/apis/acc_api/main.py
+++ b/apis/acc_api/main.py
@@ -51,6 +51,10 @@ reviewer_collection = reviewer_client[DB_NAME][COLLECTION_NAME]
 answers_collection = reviewer_client[DB_NAME]["answers"]
 users_collection = reviewer_client[DB_NAME]["users"]
 
+# --- GDB Coverage Gap Detector (read-only report over `reviewer_collection`) ---
+GAP_REPORTS_COLLECTION = os.getenv("GAP_REPORTS_COLLECTION", "gdb_gap_reports")
+gap_reports_collection = reviewer_client[DB_NAME][GAP_REPORTS_COLLECTION]
+
 golden_client = MongoClient(GOLDEN_MONGO_URI)
 golden_qa_collection = golden_client[GOLDEN_DB_NAME][GOLDEN_QA_COLLECTION]
 golden_pop_collection = golden_client[GOLDEN_DB_NAME][GOLDEN_POP_COLLECTION]
@@ -836,6 +840,21 @@ def get_filters():
         "states": _VALID_STATES_CACHE,
         "crops": _VALID_CROPS_CACHE
     }
+
+
+@app.get("/gdb/gap-report")
+def get_gap_report():
+    """Latest pre-computed GDB Coverage Gap report (read-only).
+
+    Generated out-of-band by gap_pipeline.py — this endpoint only reads the
+    most recent document from `gap_reports_collection`, sorted by
+    `generated_at`. Returns 404 until the pipeline has run at least once.
+    """
+    doc = gap_reports_collection.find_one(sort=[("generated_at", -1)])
+    if not doc:
+        raise HTTPException(status_code=404, detail="No gap report available yet. Run gap_pipeline.py first.")
+    doc["_id"] = str(doc["_id"])
+    return doc
 
 
 @app.get("/health")

--- a/apis/acc_api/pytest.ini
+++ b/apis/acc_api/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/apis/acc_api/requirements-dev.txt
+++ b/apis/acc_api/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=7.4.0

--- a/apis/acc_api/requirements.txt
+++ b/apis/acc_api/requirements.txt
@@ -4,3 +4,4 @@ pymongo>=4.7.0
 sentence-transformers>=3.0.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0
+numpy>=1.24.0

--- a/apis/acc_api/tests/test_gap_detector.py
+++ b/apis/acc_api/tests/test_gap_detector.py
@@ -1,0 +1,240 @@
+"""Unit tests for the GDB Coverage Gap Detector pipeline (gap_detector.py).
+
+No live MongoDB or embedding model needed: FakeCollection below is a minimal
+in-memory stand-in for the two aggregation shapes gap_detector actually issues
+(match -> optional unwind on details.domain -> group by crop/state/domain),
+and embed_fn is a deterministic bag-of-words vectorizer so cosine similarity
+behaves predictably for these fixtures.
+"""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+
+import gap_detector as gd
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory Mongo stand-in
+# ---------------------------------------------------------------------------
+
+
+def _get_path(doc, path):
+    cur = doc
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def _set_path(doc, path, value):
+    parts = path.split(".")
+    cur = doc
+    for part in parts[:-1]:
+        cur = cur.setdefault(part, {})
+    cur[parts[-1]] = value
+
+
+def _matches(doc, match: dict) -> bool:
+    for key, cond in match.items():
+        val = _get_path(doc, key)
+        if isinstance(cond, dict):
+            if "$in" in cond and val not in cond["$in"]:
+                return False
+            if "$gte" in cond and not (val is not None and val >= cond["$gte"]):
+                return False
+            if "$lt" in cond and not (val is not None and val < cond["$lt"]):
+                return False
+        elif val != cond:
+            return False
+    return True
+
+
+class FakeCollection:
+    """Just enough of pymongo's Collection API to exercise gap_detector's
+    find()/aggregate() calls against fixture data. Not a general emulator.
+    """
+
+    def __init__(self, docs: list[dict]):
+        self._docs = docs
+
+    def find(self, query, _projection=None):
+        return [d for d in self._docs if _matches(d, query)]
+
+    def aggregate(self, pipeline):
+        docs = list(self._docs)
+        for stage in pipeline:
+            if "$match" in stage:
+                docs = [d for d in docs if _matches(d, stage["$match"])]
+            elif "$unwind" in stage:
+                spec = stage["$unwind"]
+                path = spec["path"].lstrip("$")
+                preserve = spec.get("preserveNullAndEmptyArrays", False)
+                expanded = []
+                for d in docs:
+                    values = _get_path(d, path)
+                    if isinstance(values, list) and values:
+                        for v in values:
+                            clone = copy.deepcopy(d)
+                            _set_path(clone, path, v)
+                            expanded.append(clone)
+                    elif preserve:
+                        expanded.append(d)
+                docs = expanded
+            elif "$group" in stage:
+                buckets: dict[tuple, int] = {}
+                for d in docs:
+                    crop = _get_path(d, "details.normalised_crop") or _get_path(d, "details.crop") or "Unknown"
+                    state = _get_path(d, "details.state") or "Unknown"
+                    domain = _get_path(d, "details.domain") or "Unknown"
+                    key = (crop, state, domain)
+                    buckets[key] = buckets.get(key, 0) + 1
+                docs = [
+                    {"_id": {"crop": k[0], "state": k[1], "domain": k[2]}, "count": v}
+                    for k, v in buckets.items()
+                ]
+        return docs
+
+
+def _bag_of_words_embed(texts: list[str]) -> np.ndarray:
+    """Deterministic fake embedder: one-hot-ish bag of words, no ML needed."""
+    vocab: dict[str, int] = {}
+    rows = []
+    for text in texts:
+        words = gd._tokenize(text)
+        for w in words:
+            vocab.setdefault(w, len(vocab))
+        rows.append(words)
+    vectors = np.zeros((len(texts), max(len(vocab), 1)))
+    for i, words in enumerate(rows):
+        for w in words:
+            vectors[i, vocab[w]] = 1.0
+    return vectors
+
+
+# ---------------------------------------------------------------------------
+# Pure logic
+# ---------------------------------------------------------------------------
+
+
+def test_gap_question_filter_scopes_to_disclaimer_tag_and_farmer_sources():
+    query = gd.gap_question_filter()
+    assert query["tag"] == "static_dynamic"
+    assert set(query["source"]["$in"]) == {"AJRASAKHA", "WHATSAPP"}
+    assert "createdAt" not in query
+
+
+def test_gap_question_filter_applies_since():
+    since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    query = gd.gap_question_filter(since)
+    assert query["createdAt"]["$gte"] == since
+
+
+def test_cluster_by_similarity_groups_near_duplicates_apart_from_unrelated():
+    texts = [
+        "whitefly attack on cotton leaves",
+        "whitefly infestation cotton leaf",
+        "wheat rust disease treatment",
+    ]
+    embeddings = _bag_of_words_embed(texts)
+    clusters = gd.cluster_by_similarity(embeddings, threshold=0.45)
+    sizes = sorted(len(c) for c in clusters)
+    assert sizes == [1, 2]
+
+
+def test_extract_missing_keywords_excludes_representative_words():
+    texts = [
+        "whitefly attack on cotton during flowering stage",
+        "whitefly problem cotton flowering stage pesticide dosage",
+    ]
+    representative = "whitefly attack on cotton"
+    keywords = gd.extract_missing_keywords(texts, representative)
+    assert "flowering" in keywords
+    assert "whitefly" not in keywords
+    assert "cotton" not in keywords
+
+
+def test_priority_score_rewards_growth_and_ranks_above_flat_demand():
+    flat = gd.priority_score(cluster_size=10, growth_rate=0.0)
+    growing = gd.priority_score(cluster_size=10, growth_rate=1.0)
+    assert growing > flat
+    assert flat == 10.0
+
+
+def test_priority_level_buckets():
+    assert gd.priority_level(25) == "CRITICAL"
+    assert gd.priority_level(12) == "HIGH"
+    assert gd.priority_level(5) == "MEDIUM"
+    assert gd.priority_level(1) == "LOW"
+
+
+def test_build_coverage_heatmap_classifies_gap_partial_good():
+    gdb_counts = {("Wheat", "Punjab", "Pest"): 10, ("Cotton", "Gujarat", "Pest"): 2}
+    gap_counts = {("Cotton", "Gujarat", "Pest"): 8, ("Rice", "Bihar", "Disease"): 5}
+    cells = {(c.crop, c.state, c.domain): c for c in gd.build_coverage_heatmap(gdb_counts, gap_counts)}
+
+    assert cells[("Wheat", "Punjab", "Pest")].status == "good"
+    assert cells[("Cotton", "Gujarat", "Pest")].status == "partial"
+    assert cells[("Rice", "Bihar", "Disease")].status == "gap"
+    assert cells[("Rice", "Bihar", "Disease")].gdb_count == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end report build against the FakeCollection
+# ---------------------------------------------------------------------------
+
+
+def _gap_doc(question: str, *, crop: str, state: str, domain: str, days_ago: int) -> dict:
+    return {
+        "question": question,
+        "tag": "static_dynamic",
+        "source": "WHATSAPP",
+        "status": "open",
+        "details": {"normalised_crop": crop, "state": state, "domain": [domain]},
+        "createdAt": datetime.now(timezone.utc) - timedelta(days=days_ago),
+    }
+
+
+def test_build_gap_report_end_to_end():
+    docs = [
+        _gap_doc("whitefly attack on cotton leaves", crop="Cotton", state="Gujarat", domain="Pest", days_ago=1),
+        _gap_doc("whitefly infestation cotton leaf turning yellow", crop="Cotton", state="Gujarat", domain="Pest", days_ago=2),
+        _gap_doc("wheat rust disease treatment", crop="Wheat", state="Punjab", domain="Disease", days_ago=3),
+        # Already-answered question — must not be treated as a gap.
+        {
+            "question": "how to irrigate wheat",
+            "tag": "dynamic",
+            "source": "WHATSAPP",
+            "status": "closed",
+            "details": {"normalised_crop": "Wheat", "state": "Punjab", "domain": ["Irrigation"]},
+            "createdAt": datetime.now(timezone.utc),
+        },
+    ]
+    collection = FakeCollection(docs)
+
+    report = gd.build_gap_report(
+        questions_collection=collection,
+        embed_fn=_bag_of_words_embed,
+        period_days=7,
+        lookback_days=30,
+        similarity_threshold=0.4,
+    )
+
+    assert report["total_disclaimers"] == 3
+    assert report["clusters_found"] == 2  # cotton cluster + wheat rust cluster
+    cotton_gap = next(g for g in report["top_gaps"] if g["crop"] == "Cotton")
+    assert cotton_gap["farmer_demand"] == 2
+    # The representative is the longest/most detailed question in the cluster
+    # ("...turning yellow"); missing keywords surface words unique to the
+    # *other* variation ("leaves"/"attack") that the representative lacks.
+    assert "leaves" in cotton_gap["keywords"] or "attack" in cotton_gap["keywords"]
+
+    heatmap = report["coverage_stats"]["heatmap"]
+    wheat_disease_cell = next(
+        c for c in heatmap if c["crop"] == "Wheat" and c["domain"] == "Disease"
+    )
+    assert wheat_disease_cell["status"] == "gap"
+    assert report["coverage_stats"]["total_combinations"] == len(heatmap)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -15,6 +15,9 @@ VITE_API_BASE_URL=http://localhost:3141/api
 # Frontend development mode flag
 VITE_IS_DEVELOPMENT=true
 
+# GDB Coverage Gap Detector — separate acc_api FastAPI service (see apis/acc_api)
+VITE_GDB_GAP_API_URL=http://localhost:8001
+
 # ===================
 # Firebase (Client-side)
 # ===================

--- a/frontend/src/components/play-ground.tsx
+++ b/frontend/src/components/play-ground.tsx
@@ -29,6 +29,7 @@ import { CallHistory } from "./CallHistory";
 import { ManageCallAgents } from "./ManageCallAgents";
 import { env } from "@/config/env";
 import { DataProcessingDashboard } from "../features/faq-pop/DataProcessingDashboard";
+import { GDBGapReportDashboard } from "../features/gdb-gap-report/GDBGapReportDashboard";
 import { CallAgentDashboard } from "./CallAgentDashboard";
 import { UserService } from "@/hooks/services/userService";
 
@@ -344,6 +345,14 @@ export const PlaygroundPage = () => {
                     <span>Data Processing</span>
                   </TabsTrigger>
                 )}
+                {user && user.role === "admin" && (
+                  <TabsTrigger
+                    value="gdb_gap_report"
+                    className="px-2 md:px-3 py-1.5 rounded-lg font-medium text-sm md:text-base transition-all duration-150 flex-shrink-0"
+                  >
+                    <span>GDB Coverage</span>
+                  </TabsTrigger>
+                )}
                 {/*
                 {user && (
                   <TabsTrigger
@@ -592,6 +601,22 @@ export const PlaygroundPage = () => {
                   )}
                 >
                   <DataProcessingDashboard />
+                </TabsContent>
+              )}
+
+              {user && user.role === "admin" && (
+                <TabsContent
+                  value="gdb_gap_report"
+                  className={cn(
+                    "mt-0 border-0 outline-none",
+                    "data-[state=active]:animate-in",
+                    "data-[state=active]:fade-in-0",
+                    "data-[state=active]:zoom-in-[0.98]",
+                    "data-[state=active]:slide-in-from-bottom-3",
+                    "duration-500 ease-out",
+                  )}
+                >
+                  <GDBGapReportDashboard />
                 </TabsContent>
               )}
 

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -38,7 +38,10 @@ type EnvKey =
   | `VITE_PLIVO_${string}_PASSWORD`
   // FAQ / POP processing servers
   | "VITE_FAQ_API_URL"
-  | "VITE_POP_API_URL";
+  | "VITE_POP_API_URL"
+
+  // GDB Coverage Gap Detector (acc_api)
+  | "VITE_GDB_GAP_API_URL";
 
 /**
  * Internal getter (single source of truth)
@@ -95,4 +98,5 @@ export const env = {
   internalApiKey: () => getEnv("VITE_INTERNAL_API_KEY", true, "dummy-internal-api-key"),
   faqApiUrl: () => getEnv("VITE_FAQ_API_URL", false, "/api/faq"),
   popApiUrl: () => getEnv("VITE_POP_API_URL", false, "/api/pop"),
+  gdbGapApiUrl: () => getEnv("VITE_GDB_GAP_API_URL", false, "http://localhost:8001"),
 };

--- a/frontend/src/features/gdb-gap-report/GDBGapReportDashboard.tsx
+++ b/frontend/src/features/gdb-gap-report/GDBGapReportDashboard.tsx
@@ -1,0 +1,288 @@
+import { Fragment, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ResponsiveHeatMap } from "@nivo/heatmap";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/atoms/card";
+import { Badge } from "@/components/atoms/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/atoms/select";
+import { getGapReport, GapReportNotFoundError } from "./api";
+import type { GapItem } from "./types";
+
+const PRIORITY_BADGE_VARIANT: Record<
+  GapItem["priority_level"],
+  "destructive" | "default" | "secondary" | "outline"
+> = {
+  CRITICAL: "destructive",
+  HIGH: "default",
+  MEDIUM: "secondary",
+  LOW: "outline",
+};
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>{label}</CardDescription>
+        <CardTitle className="text-2xl">{value}</CardTitle>
+      </CardHeader>
+    </Card>
+  );
+}
+
+export function GDBGapReportDashboard() {
+  const [selectedState, setSelectedState] = useState<string>("All States");
+  const [expandedClusterId, setExpandedClusterId] = useState<string | null>(null);
+
+  const { data: report, isLoading, error } = useQuery({
+    queryKey: ["gdb-gap-report"],
+    queryFn: getGapReport,
+    retry: false,
+  });
+
+  const states = useMemo(() => {
+    if (!report) return ["All States"];
+    return ["All States", ...new Set(report.coverage_stats.heatmap.map((c) => c.state))];
+  }, [report]);
+
+  const heatmapData = useMemo(() => {
+    if (!report) return [];
+    const cells = report.coverage_stats.heatmap.filter(
+      (c) => selectedState === "All States" || c.state === selectedState,
+    );
+
+    const crops = [...new Set(cells.map((c) => c.crop))];
+    const domains = [...new Set(cells.map((c) => c.domain))];
+
+    return crops.map((crop) => ({
+      id: crop,
+      data: domains.map((domain) => {
+        const matching = cells.filter((c) => c.crop === crop && c.domain === domain);
+        const gdb = matching.reduce((sum, c) => sum + c.gdb_count, 0);
+        const gap = matching.reduce((sum, c) => sum + c.disclaimer_count, 0);
+        const total = gdb + gap;
+        return {
+          x: domain,
+          y: total ? Math.round((gdb / total) * 100) : 0,
+        };
+      }),
+    }));
+  }, [report, selectedState]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[300px]">
+        <div className="flex flex-col items-center gap-3">
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary" />
+          <p className="text-sm text-muted-foreground">Loading GDB coverage gap report...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error instanceof GapReportNotFoundError) {
+    return (
+      <div className="flex items-center justify-center min-h-[300px] text-center px-4">
+        <p className="text-sm text-muted-foreground max-w-md">
+          No gap report has been generated yet. Run{" "}
+          <code className="px-1 py-0.5 rounded bg-muted">python gap_pipeline.py</code> in{" "}
+          <code className="px-1 py-0.5 rounded bg-muted">apis/acc_api</code> to produce the first
+          one.
+        </p>
+      </div>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <div className="flex items-center justify-center min-h-[300px]">
+        <p className="text-sm text-destructive">
+          {error instanceof Error ? error.message : "Failed to load gap report."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h2 className="text-lg font-semibold">GDB Coverage Gap Report</h2>
+          <p className="text-xs text-muted-foreground">
+            Weekly report generated {new Date(report.generated_at).toLocaleString()} · period{" "}
+            {report.period_days} days
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard label="Disclaimer-triggered questions" value={report.total_disclaimers} />
+        <StatCard label="Unique queries" value={report.unique_queries} />
+        <StatCard label="Gap clusters found" value={report.clusters_found} />
+        <StatCard label="Coverage gaps (cells)" value={report.coverage_stats.gaps} />
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-4">
+          <div>
+            <CardTitle>Coverage heatmap</CardTitle>
+            <CardDescription>
+              % of questions answered by the GDB, per crop x domain cell (green = well covered,
+              red = gap)
+            </CardDescription>
+          </div>
+          <Select value={selectedState} onValueChange={setSelectedState}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {states.map((state) => (
+                <SelectItem key={state} value={state}>
+                  {state}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </CardHeader>
+        <CardContent>
+          {heatmapData.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No heatmap data for this filter.</p>
+          ) : (
+            <div className="h-[400px] min-w-[600px]">
+              <ResponsiveHeatMap
+                data={heatmapData}
+                margin={{ top: 40, right: 60, bottom: 40, left: 120 }}
+                colors={{ type: "diverging", scheme: "red_yellow_green", divergeAt: 0.5, minValue: 0, maxValue: 100 }}
+                emptyColor="#f5f5f5"
+                enableLabels={true}
+                labelTextColor="#000"
+                label={(d) => `${d.data.y}%`}
+                axisTop={{ tickSize: 5, tickPadding: 5, tickRotation: -30, legend: "Domain", legendPosition: "middle", legendOffset: -36 }}
+                axisLeft={{ tickSize: 5, tickPadding: 5, legend: "Crop", legendPosition: "middle", legendOffset: -100 }}
+                animate={false}
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Top {report.top_gaps.length} gaps, ranked by farmer demand</CardTitle>
+          <CardDescription>
+            Priority = demand (cluster size) x growth rate. Click a row for sample questions and
+            missing keywords.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="min-w-full text-sm border-collapse">
+            <thead>
+              <tr className="text-left text-muted-foreground border-b">
+                <th className="py-2 pr-3">#</th>
+                <th className="py-2 pr-3">Question</th>
+                <th className="py-2 pr-3">Crop</th>
+                <th className="py-2 pr-3">State</th>
+                <th className="py-2 pr-3">Domain</th>
+                <th className="py-2 pr-3">Demand</th>
+                <th className="py-2 pr-3">Growth</th>
+                <th className="py-2 pr-3">Priority</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.top_gaps.map((gap, idx) => {
+                const isExpanded = expandedClusterId === gap.cluster_id;
+                return (
+                  <Fragment key={gap.cluster_id}>
+                    <tr
+                      className="border-b cursor-pointer hover:bg-accent/50"
+                      onClick={() => setExpandedClusterId(isExpanded ? null : gap.cluster_id)}
+                    >
+                      <td className="py-2 pr-3">{idx + 1}</td>
+                      <td className="py-2 pr-3 max-w-[320px] truncate">{gap.cluster_name}</td>
+                      <td className="py-2 pr-3">{gap.crop}</td>
+                      <td className="py-2 pr-3">{gap.states.join(", ")}</td>
+                      <td className="py-2 pr-3">{gap.domains.join(", ")}</td>
+                      <td className="py-2 pr-3">{gap.farmer_demand}</td>
+                      <td className="py-2 pr-3">
+                        {gap.growth_rate > 0 ? "+" : ""}
+                        {Math.round(gap.growth_rate * 100)}%
+                      </td>
+                      <td className="py-2 pr-3">
+                        <Badge variant={PRIORITY_BADGE_VARIANT[gap.priority_level]}>
+                          {gap.priority_level}
+                        </Badge>
+                      </td>
+                    </tr>
+                    {isExpanded && (
+                      <tr className="bg-muted/30 border-b">
+                        <td colSpan={8} className="py-3 px-3">
+                          <div className="flex flex-col gap-2">
+                            <div>
+                              <span className="font-medium">Recommended action: </span>
+                              {gap.recommended_action}
+                            </div>
+                            {gap.keywords.length > 0 && (
+                              <div>
+                                <span className="font-medium">Missing keywords: </span>
+                                {gap.keywords.map((kw) => (
+                                  <Badge key={kw} variant="outline" className="mr-1">
+                                    {kw}
+                                  </Badge>
+                                ))}
+                              </div>
+                            )}
+                            {gap.sample_queries.length > 0 && (
+                              <div>
+                                <span className="font-medium">Sample variations:</span>
+                                <ul className="list-disc list-inside text-muted-foreground">
+                                  {gap.sample_queries.map((q, i) => (
+                                    <li key={i}>{q}</li>
+                                  ))}
+                                </ul>
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Outreach recommendations</CardTitle>
+          <CardDescription>Where the content/field team should focus next</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2">
+          {report.outreach_recommendations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No outreach recommendations yet.</p>
+          ) : (
+            report.outreach_recommendations.map((rec, i) => (
+              <div key={i} className="flex items-start justify-between gap-3 py-2 border-b last:border-0">
+                <p className="text-sm">{rec.recommendation}</p>
+                <Badge variant={rec.priority === "HIGH" ? "destructive" : "secondary"}>
+                  {rec.priority}
+                </Badge>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/features/gdb-gap-report/api.ts
+++ b/frontend/src/features/gdb-gap-report/api.ts
@@ -1,0 +1,32 @@
+import { env } from "@/config/env";
+import type { GapReport } from "./types";
+
+// acc_api is a separate FastAPI service (no Firebase auth, same as the
+// existing FAQ/PoP servers in features/faq-pop/api.ts) — called directly,
+// not proxied through the main Node backend.
+const GAP_API = (env.gdbGapApiUrl() || "").replace(/\/$/, "");
+
+export class GapReportNotFoundError extends Error {}
+
+export async function getGapReport(): Promise<GapReport> {
+  const res = await fetch(`${GAP_API}/gdb/gap-report`);
+
+  if (res.status === 404) {
+    throw new GapReportNotFoundError(
+      "No gap report available yet. Run gap_pipeline.py to generate one.",
+    );
+  }
+
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body?.detail) detail = body.detail;
+    } catch {
+      // ignore parse error
+    }
+    throw new Error(detail);
+  }
+
+  return res.json();
+}

--- a/frontend/src/features/gdb-gap-report/types.ts
+++ b/frontend/src/features/gdb-gap-report/types.ts
@@ -1,0 +1,73 @@
+// Mirrors the report dict built by apis/acc_api/gap_detector.py::build_gap_report.
+// Field names are snake_case because the FastAPI endpoint returns the pipeline's
+// plain dict as-is (see GET /gdb/gap-report in apis/acc_api/main.py).
+
+export interface GapItem {
+  cluster_id: string;
+  cluster_name: string;
+  size: number;
+  keywords: string[];
+  sample_queries: string[];
+  domains: string[];
+  states: string[];
+  crop: string;
+  growth_rate: number;
+  priority_score: number;
+  farmer_demand: number;
+  recommended_action: string;
+  priority_level: "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
+}
+
+export type CoverageStatus = "good" | "partial" | "gap";
+
+export interface HeatmapCell {
+  crop: string;
+  state: string;
+  domain: string;
+  gdb_count: number;
+  disclaimer_count: number;
+  coverage_score: number;
+  status: CoverageStatus;
+}
+
+export interface CoverageStats {
+  heatmap: HeatmapCell[];
+  total_combinations: number;
+  covered: number;
+  partial: number;
+  gaps: number;
+}
+
+export interface OutreachRecommendation {
+  target_state: string;
+  focus_domain: string;
+  gap_questions: number;
+  recommendation: string;
+  priority: "HIGH" | "MEDIUM";
+}
+
+export interface DomainGapTotal {
+  domain: string;
+  gap_count: number;
+}
+
+export interface StateGapTotal {
+  state: string;
+  gap_count: number;
+}
+
+export interface GapReport {
+  report_type: string;
+  period_days: number;
+  start_date: string;
+  end_date: string;
+  generated_at: string;
+  total_disclaimers: number;
+  unique_queries: number;
+  clusters_found: number;
+  top_gaps: GapItem[];
+  coverage_stats: CoverageStats;
+  outreach_recommendations: OutreachRecommendation[];
+  domains_with_gaps: DomainGapTotal[];
+  states_with_gaps: StateGapTotal[];
+}


### PR DESCRIPTION
## Summary
- Adds a read-only analytics pipeline that clusters farmer questions the GDB could not answer (the disclaimer path: `tag=static_dynamic`, `source in [AJRASAKHA, WHATSAPP]` on the existing `questions` collection) into a weekly, demand-ranked gap report.
- Adds a crop x state x domain coverage heatmap and outreach recommendations for the content/reviewer team, ranked by a Demand x Deficit priority score.
- Reuses existing infra rather than reinventing it: no new `disclaimer_logs` collection (the real signal is already on `questions`), and overlap/duplicate checking against the GDB already exists via `gdb_search_v2` in `ai/ajrasakha/tools/golden` — this PR only adds the coverage-gap analytics layer on top.

## What's new
- `apis/acc_api/gap_detector.py` — pure, unit-tested pipeline (similarity clustering, missing-keyword extraction, priority scoring, coverage heatmap). No import-time side effects, so it's testable without a live DB.
- `apis/acc_api/gap_pipeline.py` — standalone CLI runner (`python gap_pipeline.py`), reuses `main.py`'s existing Mongo/embedding connections. No scheduler dependency added; wire into existing ops cron.
- `GET /gdb/gap-report` on the existing `acc_api` FastAPI service.
- `apis/acc_api/tests/test_gap_detector.py` — 8 tests against an in-memory Mongo stand-in, no live database needed.
- `frontend/src/features/gdb-gap-report/` — dashboard (heatmap, ranked gap table, outreach panel), wired as a new admin-only "GDB Coverage" tab in the main app.

## Test plan
- [x] `pytest` in `apis/acc_api` — 8/8 passing (clustering, keyword extraction, priority scoring, heatmap classification, end-to-end report build against fixture data)
- [x] `tsc --noEmit` on frontend — new files compile clean against the existing codebase baseline
- [ ] Manual: run `python gap_pipeline.py` against a real Mongo instance, then load the "GDB Coverage" tab as an admin user
- [ ] Manual: confirm `tag=static_dynamic` / `source` values match production data shape (no live DB access during development — pipeline logic was validated against fixtures matching the documented schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)