### PR TITLE
fix(ai): align daily_price agent with new mandi MCP actions

### DIFF
--- a/ai/ajrasakha/agents/daily_price_agent.py
+++ b/ai/ajrasakha/agents/daily_price_agent.py
@@ -27,7 +27,52 @@ load_dotenv()
 DAILY_PRICE_GEMMA_BASE_URL = os.getenv("WEATHER_GEMMA_BASE_URL", "http://100.100.108.44:8014/v1")
 DAILY_PRICE_GEMMA_MODEL = "google/gemma-4-E4B-it"
 
-_FARMER_ACTIONS = frozenset({"get_prices", "search_markets", "lookup_commodity"})
+_FARMER_ACTIONS = frozenset({
+    "get_today_price",
+    "get_price_history",
+    "get_price_summary",
+    "get_highest_price",
+    "get_today_arrival",
+    "get_arrival_history",
+    "get_extreme_arrival",
+    "search_markets",
+})
+
+_COMMODITY_ACTIONS = frozenset({
+    "get_today_price",
+    "get_price_history",
+    "get_price_summary",
+    "get_highest_price",
+    "get_today_arrival",
+    "get_arrival_history",
+    "get_extreme_arrival",
+})
+
+_GEO_ACTIONS = frozenset({
+    "get_today_price",
+    "get_price_history",
+    "get_price_summary",
+    "get_highest_price",
+    "get_today_arrival",
+    "get_arrival_history",
+    "get_extreme_arrival",
+    "search_markets",
+})
+
+_HISTORY_ACTIONS = frozenset({
+    "get_price_history",
+    "get_price_summary",
+    "get_highest_price",
+    "get_arrival_history",
+    "get_extreme_arrival",
+})
+
+# Old tool actions → new MCP actions (PR #1017 renamed the surface).
+_LEGACY_ACTION_MAP = {
+    "get_prices": "get_today_price",
+    "lookup_commodity": "get_today_price",
+    "get_unresolved_markets": "search_markets",
+}
 
 _daily_price_mcp: MultiServerMCPClient | None = None
 _mandi_price_tool = None
@@ -61,48 +106,55 @@ async def _get_mandi_price_tool():
     return _mandi_price_tool
 
 
-def _heuristic_intent(query: str) -> dict[str, Any]:
-    """Fallback intent when Gemma is unavailable."""
-    q = (query or "").lower()
-    if "which market" in q or "nearest market" in q or "mandi near" in q or "find market" in q:
-        return {
-            "action": "search_markets",
-            "nearest_market": True,
-            "radius_km": 50,
-            "lookback_days": None,
-            "from_date": None,
-            "to_date": None,
-            "market_name": None,
-            "state": None,
-        }
-    if "alias" in q or "also known" in q or "canonical" in q or "what is the crop name" in q:
-        return {
-            "action": "lookup_commodity",
-            "nearest_market": False,
-            "radius_km": None,
-            "lookback_days": None,
-            "from_date": None,
-            "to_date": None,
-            "market_name": None,
-            "state": None,
-        }
-    lookback = 7
-    if "month" in q or "30 day" in q:
-        lookback = 30
-    elif "week" in q or "7 day" in q:
-        lookback = 7
-    elif "today" in q or "current" in q or "latest" in q or "now" in q:
-        lookback = 3
+def _empty_intent_fields() -> dict[str, Any]:
     return {
-        "action": "get_prices",
         "nearest_market": True,
         "radius_km": None,
-        "lookback_days": lookback,
+        "lookback_days": None,
         "from_date": None,
         "to_date": None,
         "market_name": None,
         "state": None,
+        "sort_order": None,
     }
+
+
+def _heuristic_intent(query: str) -> dict[str, Any]:
+    """Fallback intent when Gemma is unavailable."""
+    q = (query or "").lower()
+    base = _empty_intent_fields()
+
+    if "which market" in q or "nearest market" in q or "mandi near" in q or "find market" in q or "find mandi" in q:
+        return {**base, "action": "search_markets", "nearest_market": True, "radius_km": 50}
+
+    if "arrival" in q:
+        if "lowest" in q or "least" in q:
+            return {**base, "action": "get_extreme_arrival", "sort_order": "lowest", "lookback_days": 7}
+        if "highest" in q or "maximum" in q or "most" in q:
+            return {**base, "action": "get_extreme_arrival", "sort_order": "highest", "lookback_days": 7}
+        if any(k in q for k in ("history", "week", "month", "days", "last ", "past ")):
+            lookback = 30 if "month" in q else 7
+            return {**base, "action": "get_arrival_history", "lookback_days": lookback}
+        return {**base, "action": "get_today_arrival"}
+
+    if any(k in q for k in ("average", "avg", "summary", "min max", "statistics", "stats")):
+        lookback = 30 if "month" in q else 7
+        return {**base, "action": "get_price_summary", "lookback_days": lookback}
+
+    if any(k in q for k in ("highest price", "maximum price", "max price", "best price", "highest rate")):
+        lookback = 30 if "month" in q else 7
+        return {**base, "action": "get_highest_price", "lookback_days": lookback}
+
+    if any(k in q for k in ("history", "week", "month", "days", "last ", "past ", "from ", "between")):
+        if "month" in q or "30 day" in q:
+            lookback = 30
+        elif "week" in q or "7 day" in q:
+            lookback = 7
+        else:
+            lookback = 7
+        return {**base, "action": "get_price_history", "lookback_days": lookback}
+
+    return {**base, "action": "get_today_price"}
 
 
 def _extract_json_object(text: str) -> dict[str, Any] | None:
@@ -121,13 +173,26 @@ def _extract_json_object(text: str) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def _map_action(action: str) -> str:
+    key = (action or "").strip().lower()
+    key = _LEGACY_ACTION_MAP.get(key, key)
+    if key not in _FARMER_ACTIONS:
+        return "get_today_price"
+    return key
+
+
 def _normalize_intent(raw: dict[str, Any] | None, query: str) -> dict[str, Any]:
     base = _heuristic_intent(query)
     if not raw:
         return base
-    action = str(raw.get("action") or base["action"]).strip().lower()
-    if action not in _FARMER_ACTIONS:
-        action = "get_prices"
+    action = _map_action(str(raw.get("action") or base["action"]))
+    # Legacy get_prices with an explicit lookback/range should become history.
+    raw_action = str(raw.get("action") or "").strip().lower()
+    if raw_action in {"get_prices", "lookup_commodity"} and (
+        raw.get("lookback_days") or raw.get("from_date") or raw.get("to_date")
+    ):
+        action = "get_price_history"
+
     out = {
         "action": action,
         "nearest_market": bool(raw.get("nearest_market", base.get("nearest_market", True))),
@@ -137,6 +202,7 @@ def _normalize_intent(raw: dict[str, Any] | None, query: str) -> dict[str, Any]:
         "to_date": raw.get("to_date", base.get("to_date")),
         "market_name": raw.get("market_name", base.get("market_name")),
         "state": raw.get("state", base.get("state")),
+        "sort_order": raw.get("sort_order", base.get("sort_order")),
     }
     for key in ("radius_km", "lookback_days"):
         val = out.get(key)
@@ -147,12 +213,14 @@ def _normalize_intent(raw: dict[str, Any] | None, query: str) -> dict[str, Any]:
             out[key] = float(val) if key == "radius_km" else int(val)
         except (TypeError, ValueError):
             out[key] = base.get(key)
-    for key in ("from_date", "to_date", "market_name", "state"):
+    for key in ("from_date", "to_date", "market_name", "state", "sort_order"):
         val = out.get(key)
         if val is None or str(val).strip().lower() in {"", "null", "none"}:
             out[key] = None
         else:
-            out[key] = str(val).strip()
+            out[key] = str(val).strip().lower() if key == "sort_order" else str(val).strip()
+    if out["action"] == "get_extreme_arrival" and out["sort_order"] not in {"highest", "lowest"}:
+        out["sort_order"] = "highest"
     return out
 
 
@@ -218,33 +286,50 @@ async def extract_daily_price_intent(query: str) -> dict[str, Any]:
     return intent
 
 
+def _unwrap_tool_payload(result: Any) -> Any:
+    """Normalize MCP content wrappers like [{'type':'text','text':'{...}'}]."""
+    if isinstance(result, str):
+        try:
+            return json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            return result
+    if isinstance(result, list) and result:
+        first = result[0]
+        if isinstance(first, dict) and isinstance(first.get("text"), str):
+            try:
+                return json.loads(first["text"])
+            except (json.JSONDecodeError, TypeError):
+                return first["text"]
+    return result
+
+
 def _tool_result_is_empty(result: Any) -> bool:
+    result = _unwrap_tool_payload(result)
     if result is None or result == "":
         return True
     if isinstance(result, str):
-        try:
-            result = json.loads(result)
-        except (json.JSONDecodeError, TypeError):
-            return not result.strip()
+        return not result.strip()
     if not isinstance(result, dict):
         return False
     if result.get("error"):
         return True
-    if "price_records" in result:
-        records = result.get("price_records") or []
-        return len(records) == 0
-    if "markets" in result:
-        return len(result.get("markets") or []) == 0
-    if "resolutions" in result:
-        resolutions = result.get("resolutions") or {}
-        if not resolutions:
-            return True
-        return not any(
-            isinstance(v, dict) and v.get("matched") for v in resolutions.values()
-        )
-    if "commodities" in result or "results" in result:
-        items = result.get("commodities") or result.get("results") or []
-        return len(items) == 0
+
+    list_keys = (
+        "price_records",
+        "markets",
+        "highest_records",
+        "arrival_records",
+        "highest_arrivals",
+        "lowest_arrivals",
+    )
+    for key in list_keys:
+        if key in result:
+            return len(result.get(key) or []) == 0
+
+    if "stats" in result:
+        stats = result.get("stats")
+        return not bool(stats)
+
     if result.get("count") == 0:
         return True
     return False
@@ -277,12 +362,12 @@ def _build_tool_args(
     if tool_state and str(tool_state).strip().lower() not in {"all", "not specified", "unknown"}:
         args["state"] = str(tool_state).strip()
 
-    if action in {"get_prices", "lookup_commodity"}:
+    if action in _COMMODITY_ACTIONS:
         crop_clean = (crop or "").strip()
         if crop_clean and crop_clean.lower() not in {"all", "any", "general"}:
             args["commodity_name"] = [crop_clean]
 
-    if action in {"get_prices", "search_markets"}:
+    if action in _GEO_ACTIONS:
         if lat is not None and lon is not None:
             args["lat"] = float(lat)
             args["long"] = float(lon)
@@ -292,7 +377,7 @@ def _build_tool_args(
         if intent.get("market_name"):
             args["market_name"] = intent["market_name"]
 
-    if action == "get_prices":
+    if action in _HISTORY_ACTIONS:
         if intent.get("lookback_days") is not None:
             args["lookback_days"] = intent["lookback_days"]
         else:
@@ -301,15 +386,19 @@ def _build_tool_args(
             if intent.get("to_date"):
                 args["to_date"] = intent["to_date"]
 
+    if action == "get_extreme_arrival" and intent.get("sort_order"):
+        args["sort_order"] = intent["sort_order"]
+
     return args
 
 
 async def synthesize_daily_price_answer(query: str, tool_result: Any) -> str:
     """Ask Gemma to turn tool JSON into a farmer-facing English answer."""
-    if isinstance(tool_result, (dict, list)):
-        tool_text = json.dumps(tool_result, ensure_ascii=False, default=str)
+    payload = _unwrap_tool_payload(tool_result)
+    if isinstance(payload, (dict, list)):
+        tool_text = json.dumps(payload, ensure_ascii=False, default=str)
     else:
-        tool_text = str(tool_result)
+        tool_text = str(payload)
     user_content = (
         f"{DAILY_PRICE_ANSWER_PROMPT}\n\n"
         f"Farmer query: {query}\n\n"
@@ -378,14 +467,13 @@ async def daily_price(
             state=state,
         )
 
-        if intent["action"] in {"get_prices", "lookup_commodity"} and not tool_args.get("commodity_name"):
+        if intent["action"] in _COMMODITY_ACTIONS and not tool_args.get("commodity_name"):
             logger.warning("daily_price_agent: missing commodity_name for action=%s", intent["action"])
             return ""
 
-        if intent["action"] in {"get_prices", "search_markets"} and (
+        if intent["action"] in _GEO_ACTIONS and (
             tool_args.get("lat") is None or tool_args.get("long") is None
         ):
-            # Allow state-only get_prices / search_markets when geo is unavailable
             if not tool_args.get("state") and not tool_args.get("market_name"):
                 logger.warning("daily_price_agent: missing lat/long and state for geo/price query")
                 return ""

--- a/ai/ajrasakha/agents/prompts.py
+++ b/ai/ajrasakha/agents/prompts.py
@@ -888,7 +888,9 @@ Category: district
 
 DAILY_PRICE_INTENT_PROMPT = """You extract mandi price tool parameters for Indian farmers.
 Return ONLY a valid JSON object (no markdown, no explanation) with these keys:
-- action: one of "get_prices", "search_markets", "lookup_commodity"
+- action: one of
+  "get_today_price", "get_price_history", "get_price_summary", "get_highest_price",
+  "get_today_arrival", "get_arrival_history", "get_extreme_arrival", "search_markets"
 - nearest_market: boolean (true = several nearby markets; false = single nearest)
 - radius_km: number or null
 - lookback_days: integer or null (past N days; preferred over from_date/to_date)
@@ -896,26 +898,33 @@ Return ONLY a valid JSON object (no markdown, no explanation) with these keys:
 - to_date: string or null
 - market_name: string or null
 - state: string or null (only if the farmer named a state)
+- sort_order: "highest" or "lowest" or null (only for get_extreme_arrival)
 
 Rules:
-- Default for price / rate / mandi questions: action="get_prices", nearest_market=true, lookback_days=7
-- "today" / "latest" / "current" → lookback_days=3
-- "this week" → lookback_days=7
-- "this month" → lookback_days=30
-- Asking which markets are nearby / find mandi → action="search_markets"
-- Asking crop alias / official commodity name only → action="lookup_commodity"
-- Never use action "get_unresolved_markets"
+- Default price / rate / mandi questions: action="get_today_price", nearest_market=true
+- "today" / "latest" / "current" / "now" (price) → get_today_price
+- History / last N days / week / month / date range (price) → get_price_history with lookback_days or from_date/to_date
+- Average / summary / min-max-modal stats → get_price_summary
+- Highest / maximum / best selling price → get_highest_price
+- Today's arrival / stock arrived today → get_today_arrival
+- Arrival over days / arrival history → get_arrival_history
+- Highest or lowest arrival → get_extreme_arrival + sort_order
+- Which markets / mandi near me / find APMC → search_markets
 - Omit unused filters as null
+- Never invent actions outside the list above
 
 Examples:
 Query: What is wheat price near me today?
-{"action":"get_prices","nearest_market":true,"radius_km":null,"lookback_days":3,"from_date":null,"to_date":null,"market_name":null,"state":null}
+{"action":"get_today_price","nearest_market":true,"radius_km":null,"lookback_days":null,"from_date":null,"to_date":null,"market_name":null,"state":null,"sort_order":null}
 
 Query: Onion prices in Maharashtra last 15 days
-{"action":"get_prices","nearest_market":true,"radius_km":null,"lookback_days":15,"from_date":null,"to_date":null,"market_name":null,"state":"Maharashtra"}
+{"action":"get_price_history","nearest_market":true,"radius_km":null,"lookback_days":15,"from_date":null,"to_date":null,"market_name":null,"state":"Maharashtra","sort_order":null}
+
+Query: What is the average tomato price this week?
+{"action":"get_price_summary","nearest_market":true,"radius_km":null,"lookback_days":7,"from_date":null,"to_date":null,"market_name":null,"state":null,"sort_order":null}
 
 Query: Which mandis are near me?
-{"action":"search_markets","nearest_market":true,"radius_km":50,"lookback_days":null,"from_date":null,"to_date":null,"market_name":null,"state":null}
+{"action":"search_markets","nearest_market":true,"radius_km":50,"lookback_days":null,"from_date":null,"to_date":null,"market_name":null,"state":null,"sort_order":null}
 """
 
 DAILY_PRICE_ANSWER_PROMPT = """You are AjraSakha helping an Indian farmer with mandi/commodity prices.
@@ -923,8 +932,9 @@ You receive the farmer's question and JSON from a mandi price tool.
 Write a clear, practical answer in English WhatsApp-friendly plain text.
 
 Rules:
-- Use ONLY facts from the tool JSON (prices, markets, dates, varieties, grades).
+- Use ONLY facts from the tool JSON (prices, arrivals, markets, dates, varieties, grades, stats).
 - Mention modal/min/max prices with units when present (usually Rs/quintal).
+- Mention arrival quantities when the data includes them.
 - Name the market and date when available.
 - If records are limited, say so briefly.
 - No markdown (** ##), no emojis, no source footnotes, no disclaimers.

--- a/ai/ajrasakha/agents/tests/test_daily_price_agent.py
+++ b/ai/ajrasakha/agents/tests/test_daily_price_agent.py
@@ -14,11 +14,16 @@ from ajrasakha.agents.daily_price_agent import (
 )
 
 
-def test_heuristic_intent_defaults_to_get_prices():
+def test_heuristic_intent_defaults_to_today_price():
     intent = _heuristic_intent("What is the price of wheat today?")
-    assert intent["action"] == "get_prices"
+    assert intent["action"] == "get_today_price"
     assert intent["nearest_market"] is True
-    assert intent["lookback_days"] == 3
+
+
+def test_heuristic_intent_price_history():
+    intent = _heuristic_intent("Onion prices last 15 days")
+    assert intent["action"] == "get_price_history"
+    assert intent["lookback_days"] == 7
 
 
 def test_heuristic_intent_search_markets():
@@ -26,51 +31,98 @@ def test_heuristic_intent_search_markets():
     assert intent["action"] == "search_markets"
 
 
-def test_normalize_intent_rejects_admin_action():
+def test_normalize_intent_maps_legacy_get_prices():
+    intent = _normalize_intent({"action": "get_prices"}, "price of onion today")
+    assert intent["action"] == "get_today_price"
+
+
+def test_normalize_intent_maps_legacy_get_prices_with_lookback():
+    intent = _normalize_intent(
+        {"action": "get_prices", "lookback_days": 15, "state": "Maharashtra"},
+        "Onion prices in Maharashtra last 15 days",
+    )
+    assert intent["action"] == "get_price_history"
+    assert intent["lookback_days"] == 15
+    assert intent["state"] == "Maharashtra"
+
+
+def test_normalize_intent_rejects_unknown_action():
     intent = _normalize_intent({"action": "get_unresolved_markets"}, "price of onion")
-    assert intent["action"] == "get_prices"
+    assert intent["action"] == "search_markets"
 
 
-def test_build_tool_args_get_prices():
+def test_build_tool_args_today_price():
     args = _build_tool_args(
         {
-            "action": "get_prices",
+            "action": "get_today_price",
             "nearest_market": True,
             "radius_km": None,
-            "lookback_days": 7,
+            "lookback_days": None,
             "from_date": None,
             "to_date": None,
             "market_name": None,
             "state": None,
+            "sort_order": None,
         },
         lat=30.9,
         lon=76.5,
         crop="wheat",
         state="Punjab",
     )
-    assert args["action"] == "get_prices"
+    assert args["action"] == "get_today_price"
     assert args["commodity_name"] == ["wheat"]
     assert args["lat"] == 30.9
     assert args["long"] == 76.5
-    assert args["lookback_days"] == 7
     assert args["state"] == "Punjab"
+    assert "lookback_days" not in args
+
+
+def test_build_tool_args_price_history():
+    args = _build_tool_args(
+        {
+            "action": "get_price_history",
+            "nearest_market": True,
+            "radius_km": None,
+            "lookback_days": 15,
+            "from_date": None,
+            "to_date": None,
+            "market_name": None,
+            "state": "Maharashtra",
+            "sort_order": None,
+        },
+        lat=19.07,
+        lon=72.87,
+        crop="onion",
+        state="Maharashtra",
+    )
+    assert args["action"] == "get_price_history"
+    assert args["lookback_days"] == 15
+    assert args["commodity_name"] == ["onion"]
 
 
 def test_tool_result_is_empty_on_error_or_no_records():
     assert _tool_result_is_empty({"error": "missing"})
     assert _tool_result_is_empty({"price_records": [], "stats": {}})
+    assert _tool_result_is_empty({"highest_records": []})
     assert not _tool_result_is_empty({
         "price_records": [{"modal_price": 2000}],
         "stats": {},
     })
+    assert not _tool_result_is_empty({"stats": {"overall": {"avg_modal_price": 650}}})
+
+
+def test_tool_result_unwraps_mcp_text_envelope():
+    payload = [{"type": "text", "text": '{"price_records":[{"modal_price":700}]}'}]
+    assert not _tool_result_is_empty(payload)
+    assert _tool_result_is_empty([{"type": "text", "text": '{"error":"Unknown action"}'}])
 
 
 @pytest.mark.asyncio
 async def test_extract_daily_price_intent_uses_gemma_json():
     gemma_json = (
-        '{"action":"get_prices","nearest_market":true,"radius_km":null,'
+        '{"action":"get_price_history","nearest_market":true,"radius_km":null,'
         '"lookback_days":15,"from_date":null,"to_date":null,'
-        '"market_name":null,"state":"Maharashtra"}'
+        '"market_name":null,"state":"Maharashtra","sort_order":null}'
     )
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -83,7 +135,7 @@ async def test_extract_daily_price_intent_uses_gemma_json():
     with patch("ajrasakha.agents.daily_price_agent.httpx.AsyncClient", return_value=mock_client):
         intent = await extract_daily_price_intent("Onion prices in Maharashtra last 15 days")
 
-    assert intent["action"] == "get_prices"
+    assert intent["action"] == "get_price_history"
     assert intent["lookback_days"] == 15
     assert intent["state"] == "Maharashtra"
 
@@ -106,14 +158,15 @@ async def test_daily_price_returns_empty_when_tool_empty():
             "ajrasakha.agents.daily_price_agent.extract_daily_price_intent",
             new_callable=AsyncMock,
             return_value={
-                "action": "get_prices",
+                "action": "get_today_price",
                 "nearest_market": True,
                 "radius_km": None,
-                "lookback_days": 7,
+                "lookback_days": None,
                 "from_date": None,
                 "to_date": None,
                 "market_name": None,
                 "state": None,
+                "sort_order": None,
             },
         ),
         patch(
@@ -135,7 +188,7 @@ async def test_daily_price_returns_empty_when_tool_empty():
 @pytest.mark.asyncio
 async def test_daily_price_returns_gemma_answer():
     tool_payload = {
-        "stats": {"count": 1},
+        "action": "get_today_price",
         "price_records": [{"market_name": "Ludhiana", "modal_price": 2500, "commodity_name": "Wheat"}],
     }
     with (
@@ -143,14 +196,15 @@ async def test_daily_price_returns_gemma_answer():
             "ajrasakha.agents.daily_price_agent.extract_daily_price_intent",
             new_callable=AsyncMock,
             return_value={
-                "action": "get_prices",
+                "action": "get_today_price",
                 "nearest_market": True,
                 "radius_km": None,
-                "lookback_days": 7,
+                "lookback_days": None,
                 "from_date": None,
                 "to_date": None,
                 "market_name": None,
                 "state": None,
+                "sort_order": None,
             },
         ),
         patch(


### PR DESCRIPTION
Update Gemma intent extraction and tool args for the renamed get_today_price/history/summary/arrival actions from PR #1017.