### PR TITLE
fix(daily_price): state+crop first, then in-memory nearest ranking

### DIFF
--- a/ai/ajrasakha/tools/daily_price/daily_market_price.py
+++ b/ai/ajrasakha/tools/daily_price/daily_market_price.py
@@ -1,3 +1,4 @@
+import math
 import os
 import re
 from datetime import datetime, timedelta, timezone, time as dt_time
@@ -27,11 +28,15 @@ logger = logging.getLogger("mandi_price_tool")
 # Configuration
 # --------------------------------------------------------------------------
 MONGO_URI       = os.getenv("MARKET_MONGO_URI")
-MONGO_DB_NAME   = os.getenv("MARKET_MONGO_DB_NAME", "Price")
+MONGO_DB_NAME   = os.getenv("MARKET_MONGO_DB_NAME") or os.getenv("MONGO_DB_NAME") or "Price"
 DEFAULT_TOP_N_NEAREST = int(os.getenv("MARKET_DEFAULT_TOP_N_NEAREST", 5))
 
 # Hard-coded result cap — never return more than this many price records
 PRICE_RECORD_LIMIT = 100
+# Cap how many markets we load after state+crop narrowing before distance ranking
+MAX_CANDIDATE_MARKETS = int(os.getenv("MARKET_MAX_CANDIDATE_MARKETS", 500))
+# Safety timeout for Mongo reads (ms) — prevent MCP session hangs
+MONGO_MAX_TIME_MS = int(os.getenv("MARKET_MONGO_MAX_TIME_MS", 10000))
 
 _client: Optional[MongoClient] = None
 
@@ -134,8 +139,8 @@ def mandi_price_tool(
                              from_date, to_date OR lookback_days,
                              sort_order ("highest" or "lowest").
 
-      "search_markets"     — Search for mandis/APMCs by name, state, or geo.
-                             Params: market_name, state, lat, long,
+      "search_markets"     — Search for mandis/APMCs by name and state (required).
+                             Params: state (required), market_name, lat, long,
                              nearest_market, radius_km.
                              commodity_name is optional (filters mandis that
                              trade that commodity).
@@ -143,13 +148,13 @@ def mandi_price_tool(
     Args:
         action        : One of the 8 action strings listed above (required).
         commodity_name: Raw commodity name (string) or list of names.
-        lat           : Latitude (WGS-84) for geo search.
-        long          : Longitude (WGS-84) for geo search.
+        lat           : Latitude (WGS-84) for nearest-market ranking after state filter.
+        long          : Longitude (WGS-84) for nearest-market ranking after state filter.
         nearest_market: True = return multiple nearest markets (up to 5).
                         False = only the single nearest.
-        radius_km     : Search radius in kilometres.
+        radius_km     : Search radius in kilometres (applied after state narrowing).
         market_name   : Free-text match on market name / aliases.
-        state         : State name filter (case-insensitive).
+        state         : Required standardized state name (exact match, no regex).
         from_date     : Inclusive start date (e.g. "27-Jun-2025", "2025-06-27").
         to_date       : Inclusive end date.
         lookback_days : Fetch records from the past N days.
@@ -167,6 +172,63 @@ def mandi_price_tool(
 
     def _norm(s: Optional[str]) -> Optional[str]:
         return s.strip().lower() if isinstance(s, str) else s
+
+    def _state_exact_values(state: str) -> list[str]:
+        """Exact state keys for DB match (no regex). Prefer normalized lowercase."""
+        n = _norm(state)
+        if not n:
+            return []
+        titled = " ".join(part.capitalize() for part in n.split())
+        values = [n]
+        if titled != n:
+            values.append(titled)
+        return values
+
+    def _require_state(state_val: Optional[str]) -> Optional[dict]:
+        if not state_val or not str(state_val).strip():
+            return {"error": "state name is not present"}
+        return None
+
+    def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+        r = 6371.0
+        p1, p2 = math.radians(lat1), math.radians(lat2)
+        dphi = math.radians(lat2 - lat1)
+        dlmb = math.radians(lon2 - lon1)
+        a = math.sin(dphi / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
+        return 2 * r * math.asin(math.sqrt(a))
+
+    def _market_lat_lon(doc: dict) -> Optional[tuple[float, float]]:
+        loc = doc.get("location") or {}
+        if not isinstance(loc, dict):
+            return None
+        coords = loc.get("coordinates")
+        if not coords or len(coords) < 2:
+            return None
+        try:
+            return float(coords[1]), float(coords[0])
+        except (TypeError, ValueError):
+            return None
+
+    def _rank_markets_by_distance(
+        docs: list[dict],
+        lat: float,
+        lon: float,
+        *,
+        nearest_market: bool,
+        radius_km: Optional[float],
+    ) -> list[dict]:
+        scored: list[tuple[float, dict]] = []
+        for doc in docs:
+            coords = _market_lat_lon(doc)
+            if coords is None:
+                continue
+            dist = _haversine_km(lat, lon, coords[0], coords[1])
+            if radius_km is not None and dist > float(radius_km):
+                continue
+            scored.append((dist, doc))
+        scored.sort(key=lambda item: item[0])
+        limit = DEFAULT_TOP_N_NEAREST if nearest_market else 1
+        return [doc for _, doc in scored[:limit]]
 
     def _to_oid(value: Any) -> Optional[ObjectId]:
         if value is None:
@@ -310,7 +372,7 @@ def mandi_price_tool(
                     {"aliases":        {"$regex": f"^{re.escape(norm)}$", "$options": "i"}},
                 ],
                 "active": True,
-            })
+            }, max_time_ms=MONGO_MAX_TIME_MS)
             if not doc:
                 doc = coll.find_one({
                     "$or": [
@@ -318,7 +380,7 @@ def mandi_price_tool(
                         {"aliases":        {"$regex": re.escape(norm), "$options": "i"}},
                     ],
                     "active": True,
-                })
+                }, max_time_ms=MONGO_MAX_TIME_MS)
             results[raw] = doc
             if doc:
                 logger.info("Resolved commodity '%s' to canonical name: '%s' (_id: %s)", raw, doc.get("canonical_name"), doc.get("_id"))
@@ -326,8 +388,40 @@ def mandi_price_tool(
                 logger.warning("Could not resolve commodity alias for input name: '%s'", raw)
         return results
 
+    def _date_query(
+        *,
+        lookback_days_arg: Optional[int] = None,
+        from_date_arg: Optional[str] = None,
+        to_date_arg: Optional[str] = None,
+        ignore_date_filters: bool = False,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Build price_records date clause + metadata."""
+        date_meta: dict[str, Any] = {}
+        if ignore_date_filters:
+            return {}, {"mode": "all_dates"}
+        if lookback_days_arg is not None:
+            cutoff = _day_start(datetime.now(timezone.utc) - timedelta(days=int(lookback_days_arg) - 1))
+            return {"date": {"$gte": cutoff}}, {
+                "mode": "lookback",
+                "lookback_days": lookback_days_arg,
+                "from": cutoff.date().isoformat(),
+            }
+        if from_date_arg or to_date_arg:
+            date_range: dict[str, Any] = {}
+            if from_date_arg:
+                fd = _parse_date(from_date_arg)
+                date_range["$gte"] = _day_start(fd)
+                date_meta["from_date"] = fd.date().isoformat()
+            if to_date_arg:
+                td = _parse_date(to_date_arg)
+                date_range["$lte"] = _day_end(td)
+                date_meta["to_date"] = td.date().isoformat()
+            date_meta["mode"] = "range"
+            return {"date": date_range}, date_meta
+        return {}, {"mode": "all_dates"}
+
     # ------------------------------------------------------------------
-    # Market search (shared helper + action 8 handler)
+    # Market search — state required; exact match; distance in-memory
     # ------------------------------------------------------------------
     def _do_search_markets(
         market_name: Optional[str] = None,
@@ -336,62 +430,70 @@ def mandi_price_tool(
         long: Optional[float] = None,
         nearest_market: bool = False,
         radius_km: Optional[float] = None,
+        market_ids: Optional[list[ObjectId]] = None,
     ) -> dict:
+        missing = _require_state(state)
+        if missing:
+            return missing
+
         logger.info(
-            "Searching markets | name=%s, state=%s, lat=%s, long=%s, nearest_market=%s, radius_km=%s",
-            market_name, state, lat, long, nearest_market, radius_km
+            "Searching markets | name=%s, state=%s, lat=%s, long=%s, nearest_market=%s, radius_km=%s, market_ids=%s",
+            market_name, state, lat, long, nearest_market, radius_km,
+            len(market_ids) if market_ids is not None else None,
         )
         coll = available_mandi_col()
-        query: dict[str, Any] = {}
-        use_geo = lat is not None and long is not None
-
-        if use_geo:
-            near: dict[str, Any] = {
-                "$geometry": {"type": "Point", "coordinates": [float(long), float(lat)]}
-            }
-            if radius_km is not None:
-                near["$maxDistance"] = float(radius_km) * 1000
-            query["location"] = {"$near": near}
-            if market_name:
-                query["$or"] = [
-                    {"name":    {"$regex": re.escape(market_name), "$options": "i"}},
-                    {"aliases": {"$regex": re.escape(market_name), "$options": "i"}},
-                ]
-            if state:
-                query["state"] = {"$regex": f"^{re.escape(state)}$", "$options": "i"}
-            fetch_limit = 1 if not nearest_market else DEFAULT_TOP_N_NEAREST
-            logger.info("Executing geo-search query on available_mandi: %s", query)
-            docs = list(coll.find(query).limit(fetch_limit))
-            logger.info("Geo-search returned %d markets.", len(docs))
-            return {
-                "count":     len(docs),
-                "mode":      "geo_near",
-                "markets":   [_serialize_market(d) for d in docs],
-                "_raw_docs": docs,
-            }
-
+        state_values = _state_exact_values(state or "")
+        query: dict[str, Any] = {"state": {"$in": state_values}}
+        if market_ids is not None:
+            query["_id"] = {"$in": list(market_ids)}
         if market_name:
             query["$or"] = [
                 {"name":    {"$regex": re.escape(market_name), "$options": "i"}},
                 {"aliases": {"$regex": re.escape(market_name), "$options": "i"}},
             ]
-        if state:
-            query["state"] = {"$regex": f"^{re.escape(state)}$", "$options": "i"}
-        if not query:
-            logger.warning("Market search query is empty. Providing at least one search filter is required.")
-            return {"error": "Provide at least market_name, state, or lat/long."}
-        logger.info("Executing text-search query on available_mandi: %s", query)
-        docs = list(coll.find(query).limit(50))
-        logger.info("Text-search returned %d markets.", len(docs))
+
+        logger.info("Executing exact-state market query on available_mandi: %s", query)
+        cursor = coll.find(query).limit(MAX_CANDIDATE_MARKETS).max_time_ms(MONGO_MAX_TIME_MS)
+        docs = list(cursor)
+        logger.info("State-filtered available_mandi returned %d markets.", len(docs))
+        if not docs:
+            return {
+                "count": 0,
+                "mode": "state_exact",
+                "markets": [],
+                "_raw_docs": [],
+                "error": f"APMC not available for state '{state}'.",
+            }
+
+        mode = "state_exact"
+        if lat is not None and long is not None:
+            ranked = _rank_markets_by_distance(
+                docs, float(lat), float(long),
+                nearest_market=nearest_market, radius_km=radius_km,
+            )
+            if ranked:
+                docs = ranked
+                mode = "state_then_distance"
+            else:
+                # Keep state hits but cap when no geo coords / outside radius
+                limit = DEFAULT_TOP_N_NEAREST if nearest_market else 1
+                docs = docs[:limit]
+                mode = "state_exact_no_geo_match"
+        else:
+            limit = 50
+            if market_name:
+                limit = DEFAULT_TOP_N_NEAREST if nearest_market else min(10, len(docs))
+            docs = docs[:limit]
+
         return {
             "count":     len(docs),
-            "mode":      "text_search",
+            "mode":      mode,
             "markets":   [_serialize_market(d) for d in docs],
             "_raw_docs": docs,
         }
 
     # ------------------------------------------------------------------
-    # Shared core: fetch price/arrival data (used by actions 1-7)
+    # Shared core: state+crop(+date) first, then nearest ranking
     # ------------------------------------------------------------------
     def _fetch_price_data(
         commodity_list: list[str],
@@ -407,103 +509,164 @@ def mandi_price_tool(
         latest_price_fallback: bool = False,
     ) -> dict:
         """
-        Orchestrated flow:
-          1) Resolve market/APMC via _do_search_markets.
+        Orchestrated flow (avoids $near hangs):
+          1) Require standardized state (exact match).
           2) Resolve commodity aliases.
-          3) Fetch price records with date filters.
-          4) State-wide fallback if no records found at specific market.
-        Returns dict with keys: stats, resolution, price_records,
-        total_records_returned  — or  error.
+          3) Narrow markets_commodities by state + crop.
+          4) Optional date narrowing via price_records.
+          5) Load remaining mandis and rank by lat/long in memory.
+          6) Fetch price records; fallbacks for empty date / market.
         """
-        # ── Step 1: resolve market ──────────────────────────────────────
-        market_result = _do_search_markets(
-            market_name=market_name, state=state,
-            lat=lat, long=long,
-            nearest_market=nearest_market, radius_km=radius_km,
+        missing = _require_state(state)
+        if missing:
+            return missing
+
+        # ── Step 1: resolve commodity ───────────────────────────────────
+        resolved = _resolve_commodity_aliases(commodity_list)
+        alias_ids = [doc["_id"] for doc in resolved.values() if doc]
+        unmatched = [name for name, doc in resolved.items() if not doc]
+        if not alias_ids:
+            return {
+                "error": f"We do not have {', '.join(commodity_list)} available in {state}.",
+                "unresolved_commodities": unmatched,
+            }
+
+        state_norm = _norm(state)
+        mc_coll = markets_commodities_col()
+        pr_coll = price_records_col()
+
+        # ── Step 2: state + crop on markets_commodities ──────────────────
+        mc_filter: dict[str, Any] = {
+            "commodity_alias_lookup_id": {"$in": alias_ids},
+            "state": state_norm,
+        }
+        logger.info("Narrowing markets_commodities by state+crop: %s", mc_filter)
+        mc_docs_list = list(mc_coll.find(mc_filter).max_time_ms(MONGO_MAX_TIME_MS))
+        logger.info("Found %d markets_commodities for state+crop.", len(mc_docs_list))
+        if not mc_docs_list:
+            return {
+                "error": f"No markets_commodities entries matched crop={commodity_list} in state={state}.",
+            }
+
+        candidate_market_ids = list({
+            d["market_id"] for d in mc_docs_list if d.get("market_id")
+        })
+        if not candidate_market_ids:
+            return {"error": f"No linked markets found for crop={commodity_list} in state={state}."}
+
+        # ── Step 3: optional date narrowing on price_records ────────────
+        date_clause, date_meta = _date_query(
+            lookback_days_arg=lookback_days,
+            from_date_arg=from_date,
+            to_date_arg=to_date,
+            ignore_date_filters=False,
         )
-        if market_result.get("error"):
+        mc_by_id_all = {d["_id"]: d for d in mc_docs_list}
+        date_filtered_market_ids = candidate_market_ids
+        if date_clause:
+            mc_ids = list(mc_by_id_all.keys())
+            pr_filter = {"market_commodity_id": {"$in": mc_ids}, **date_clause}
+            logger.info(
+                "Date-narrowing price_records before geo ranking | filter=%s",
+                {**pr_filter, "market_commodity_id": f"$in[{len(mc_ids)}]"},
+            )
+            # Distinct market_commodity_ids that have rows in the date window
+            active_mc_ids = pr_coll.distinct(
+                "market_commodity_id",
+                pr_filter,
+            )
+            # pymongo distinct may not take max_time_ms in older versions; wrap safely
+            if active_mc_ids:
+                date_filtered_market_ids = list({
+                    mc_by_id_all[mid]["market_id"]
+                    for mid in active_mc_ids
+                    if mid in mc_by_id_all and mc_by_id_all[mid].get("market_id")
+                })
+                logger.info(
+                    "Date filter kept %d markets (from %d).",
+                    len(date_filtered_market_ids), len(candidate_market_ids),
+                )
+            else:
+                logger.info("Date filter matched no price_records; keeping state+crop market set for ranking.")
+                date_filtered_market_ids = candidate_market_ids
+
+        # ── Step 4: load mandis + in-memory nearest ranking ─────────────
+        market_result = _do_search_markets(
+            market_name=market_name,
+            state=state,
+            lat=lat,
+            long=long,
+            nearest_market=nearest_market,
+            radius_km=radius_km,
+            market_ids=date_filtered_market_ids,
+        )
+        if market_result.get("error") and not market_result.get("_raw_docs"):
             return {"error": market_result["error"]}
         raw_docs = market_result.get("_raw_docs") or []
         if not raw_docs:
             label = market_name or state or "the given location"
             return {"error": f"APMC '{label}' is not available."}
 
-        # ── Step 2: resolve commodity ───────────────────────────────────
-        resolved = _resolve_commodity_aliases(commodity_list)
-        alias_ids = [doc["_id"] for doc in resolved.values() if doc]
-        unmatched = [name for name, doc in resolved.items() if not doc]
-        if not alias_ids:
-            label = market_name or state or "this APMC"
-            return {
-                "error": f"We do not have {', '.join(commodity_list)} available at {label}.",
-                "unresolved_commodities": unmatched,
-            }
-
         mandi_docs = {d["_id"]: d for d in raw_docs}
         market_ids = list(mandi_docs.keys())
 
-        # ── Step 3: fetch price records ─────────────────────────────────
+        # ── Step 5: fetch price records ─────────────────────────────────
         def _do_fetch(market_ids_arg, alias_ids_arg, state_arg, mandi_docs_arg, ignore_date_filters=False):
-            logger.info("Executing _do_fetch | market_ids=%s, alias_ids=%s, state=%s, ignore_date_filters=%s", market_ids_arg, alias_ids_arg, state_arg, ignore_date_filters)
-            mc_coll = markets_commodities_col()
-            pr_coll = price_records_col()
+            logger.info(
+                "Executing _do_fetch | market_ids=%s, alias_ids=%s, state=%s, ignore_date_filters=%s",
+                len(market_ids_arg) if market_ids_arg is not None else None,
+                alias_ids_arg, state_arg, ignore_date_filters,
+            )
             resolution_meta: dict[str, Any] = {}
 
-            mc_filter: dict[str, Any] = {
-                "commodity_alias_lookup_id": {"$in": alias_ids_arg}
+            mc_filter_local: dict[str, Any] = {
+                "commodity_alias_lookup_id": {"$in": alias_ids_arg},
             }
             if state_arg:
-                mc_filter["state"] = _norm(state_arg)
+                mc_filter_local["state"] = _norm(state_arg)
             if market_ids_arg:
-                mc_filter["market_id"] = {"$in": list(market_ids_arg)}
+                mc_filter_local["market_id"] = {"$in": list(market_ids_arg)}
 
-            logger.info("Querying markets_commodities with filter: %s", mc_filter)
-            mc_docs_list = list(mc_coll.find(mc_filter))
-            logger.info("Found %d markets_commodities documents.", len(mc_docs_list))
-            if not mc_docs_list:
+            logger.info("Querying markets_commodities with filter: %s", {
+                **mc_filter_local,
+                "market_id": f"$in[{len(market_ids_arg)}]" if market_ids_arg else None,
+            })
+            mc_docs = list(mc_coll.find(mc_filter_local).max_time_ms(MONGO_MAX_TIME_MS))
+            logger.info("Found %d markets_commodities documents.", len(mc_docs))
+            if not mc_docs:
                 return {
                     "error": "No markets_commodities entries matched the given filters.",
                     "resolution": resolution_meta,
                 }
-            mc_by_id = {d["_id"]: d for d in mc_docs_list}
+            mc_by_id = {d["_id"]: d for d in mc_docs}
 
             if mandi_docs_arg is not None:
                 mandi_by_id = mandi_docs_arg
             else:
                 mandi_coll = available_mandi_col()
-                market_oid_set = {d["market_id"] for d in mc_docs_list if d.get("market_id")}
-                mandi_by_id: dict[ObjectId, dict] = {}
+                market_oid_set = {d["market_id"] for d in mc_docs if d.get("market_id")}
+                mandi_by_id = {}
                 if market_oid_set:
-                    for m in mandi_coll.find({"_id": {"$in": list(market_oid_set)}}):
+                    for m in mandi_coll.find(
+                        {"_id": {"$in": list(market_oid_set)}}
+                    ).max_time_ms(MONGO_MAX_TIME_MS):
                         mandi_by_id[m["_id"]] = m
 
-            pr_query: dict[str, Any] = {"market_commodity_id": {"$in": list(mc_by_id.keys())}}
-            date_meta: dict[str, Any] = {}
+            clause, local_date_meta = _date_query(
+                lookback_days_arg=lookback_days,
+                from_date_arg=from_date,
+                to_date_arg=to_date,
+                ignore_date_filters=ignore_date_filters,
+            )
+            pr_query: dict[str, Any] = {"market_commodity_id": {"$in": list(mc_by_id.keys())}, **clause}
+            resolution_meta["date_filter"] = local_date_meta
 
-            if not ignore_date_filters and lookback_days is not None:
-                cutoff = _day_start(datetime.now(timezone.utc) - timedelta(days=int(lookback_days) - 1))
-                pr_query["date"] = {"$gte": cutoff}
-                date_meta = {"mode": "lookback", "lookback_days": lookback_days, "from": cutoff.date().isoformat()}
-            elif not ignore_date_filters and (from_date or to_date):
-                date_range: dict[str, Any] = {}
-                if from_date:
-                    fd = _parse_date(from_date)
-                    date_range["$gte"] = _day_start(fd)
-                    date_meta["from_date"] = fd.date().isoformat()
-                if to_date:
-                    td = _parse_date(to_date)
-                    date_range["$lte"] = _day_end(td)
-                    date_meta["to_date"] = td.date().isoformat()
-                pr_query["date"] = date_range
-                date_meta["mode"] = "range"
-            else:
-                date_meta = {"mode": "all_dates"}
-
-            resolution_meta["date_filter"] = date_meta
-
-            logger.info("Querying price_records with query: %s (limit: %d)", pr_query, PRICE_RECORD_LIMIT)
+            logger.info("Querying price_records with query: %s (limit: %d)", {
+                **pr_query,
+                "market_commodity_id": f"$in[{len(mc_by_id)}]",
+            }, PRICE_RECORD_LIMIT)
             raw_records = list(
-                pr_coll.find(pr_query).sort("date", -1).limit(PRICE_RECORD_LIMIT)
+                pr_coll.find(pr_query).sort("date", -1).limit(PRICE_RECORD_LIMIT).max_time_ms(MONGO_MAX_TIME_MS)
             )
             logger.info("Found %d raw price records.", len(raw_records))
             formatted: list[dict] = []
@@ -523,25 +686,24 @@ def mandi_price_tool(
 
         result = _do_fetch(market_ids, alias_ids, state, mandi_docs)
 
-        # ── Step 4: state-wide fallback ─────────────────────────────────
-        fallback_state = state or (raw_docs[0].get("state") if raw_docs else None)
+        # ── Step 6: state-wide fallback (same commodity, all state markets) ──
         no_records = (
             isinstance(result, dict)
             and (result.get("error") or result.get("total_records_returned", 0) == 0)
         )
-        if no_records and fallback_state:
-            logger.info("No records found at specific market. Retrying with state-wide fallback for state: '%s'", fallback_state)
-            result = _do_fetch(None, alias_ids, fallback_state, None)
+        if no_records and state_norm:
+            logger.info("No records at nearest markets. Retrying state-wide for state='%s'", state)
+            result = _do_fetch(None, alias_ids, state, None)
             if isinstance(result, dict):
                 market_label = market_name or (
                     raw_docs[0].get("name") if raw_docs else "the specified market"
                 )
                 result.setdefault("resolution", {})["fallback"] = (
                     f"No price records found at '{market_label}'. "
-                    f"Showing results from other APMCs in {fallback_state}."
+                    f"Showing results from other APMCs in {state}."
                 )
 
-        # ── Step 5: latest-price fallback (for price actions when date filter yields nothing) ──
+        # ── Step 7: latest-price fallback when date window empty ────────
         still_no_records = (
             isinstance(result, dict)
             and result.get("total_records_returned", 0) == 0
@@ -553,11 +715,9 @@ def mandi_price_tool(
                 "No price records found for the requested date range. "
                 "Falling back to latest available price (no date filter)."
             )
-            # Re-fetch without any date filter, using market-level result if available,
-            # otherwise state-wide.
             latest_result = _do_fetch(market_ids, alias_ids, state, mandi_docs, ignore_date_filters=True)
-            if isinstance(latest_result, dict) and latest_result.get("total_records_returned", 0) == 0 and fallback_state:
-                latest_result = _do_fetch(None, alias_ids, fallback_state, None, ignore_date_filters=True)
+            if isinstance(latest_result, dict) and latest_result.get("total_records_returned", 0) == 0:
+                latest_result = _do_fetch(None, alias_ids, state, None, ignore_date_filters=True)
             if isinstance(latest_result, dict) and latest_result.get("total_records_returned", 0) > 0:
                 records = latest_result.get("price_records") or []
                 latest_date = records[0].get("date") if records else None
@@ -572,17 +732,22 @@ def mandi_price_tool(
                     latest_result["total_records_returned"] = len(filtered_records)
                 result = latest_result
 
-        # ── Enrich resolution metadata ──────────────────────────────────
         if isinstance(result, dict):
+            resolution = result.setdefault("resolution", {})
+            resolution["date_filter"] = resolution.get("date_filter") or date_meta
+            resolution["selection_mode"] = market_result.get("mode")
             if lat is not None and long is not None and raw_docs:
-                resolution = result.setdefault("resolution", {})
                 if "nearest_markets" not in resolution:
                     resolution["nearest_markets"] = [
-                        {"name": m.get("name"), "state": m.get("state"), "district": m.get("district")}
+                        {
+                            "name": m.get("name"),
+                            "state": m.get("state"),
+                            "district": m.get("district"),
+                        }
                         for m in raw_docs
                     ]
             if unmatched and "error" not in result:
-                result.setdefault("resolution", {})["unresolved_commodity_names"] = unmatched
+                resolution["unresolved_commodity_names"] = unmatched
 
         return result
 


### PR DESCRIPTION
Require exact state match and drop Mongo $near to stop ~30s geo hangs; narrow by commodity/date before haversine ranking on remaining markets.