### PR TITLE
fix(daily_price): have Gemma say data is unavailable on tool errors

### DIFF
--- a/ai/ajrasakha/agents/daily_price_agent.py
+++ b/ai/ajrasakha/agents/daily_price_agent.py
@@ -392,7 +392,28 @@ def _build_tool_args(
     return args
 
 
-async def synthesize_daily_price_answer(query: str, tool_result: Any) -> str:
+def _fallback_unavailable_answer(payload: Any, *, crop: str | None = None, state: str | None = None) -> str:
+    """Deterministic English reply when Gemma cannot phrase an unavailable result."""
+    parts = ["Mandi price data is not available"]
+    crop_clean = (crop or "").strip()
+    state_clean = (state or "").strip()
+    if crop_clean and crop_clean.lower() not in {"all", "any", "general"}:
+        parts.append(f"for {crop_clean}")
+    if state_clean and state_clean.lower() not in {"all", "not specified", "unknown"}:
+        parts.append(f"in {state_clean}")
+    parts.append("right now.")
+    if isinstance(payload, dict) and payload.get("error"):
+        return " ".join(parts)
+    return " ".join(parts)
+
+
+async def synthesize_daily_price_answer(
+    query: str,
+    tool_result: Any,
+    *,
+    crop: str | None = None,
+    state: str | None = None,
+) -> str:
     """Ask Gemma to turn tool JSON into a farmer-facing English answer."""
     payload = _unwrap_tool_payload(tool_result)
     if isinstance(payload, (dict, list)):
@@ -412,9 +433,11 @@ async def synthesize_daily_price_answer(query: str, tool_result: Any) -> str:
         temperature=0.2,
         query=query,
     )
-    if not answer:
-        return ""
-    return answer.strip()
+    if answer and answer.strip():
+        return answer.strip()
+    if _tool_result_is_empty(payload):
+        return _fallback_unavailable_answer(payload, crop=crop, state=state)
+    return ""
 
 
 class DailyPriceInput(BaseModel):
@@ -485,14 +508,14 @@ async def daily_price(
             "daily_price_agent tool_data: %s",
             json.dumps(tool_payload, ensure_ascii=False, default=str)[:8000],
         )
-        if _tool_result_is_empty(tool_result):
-            return json.dumps(
-                {"answer": "", "tool_data": tool_payload},
-                ensure_ascii=False,
-                default=str,
-            )
 
-        answer = await synthesize_daily_price_answer(query, tool_result)
+        # Always ask Gemma — including error/empty payloads — so farmers get a clear "not available".
+        answer = await synthesize_daily_price_answer(
+            query,
+            tool_result,
+            crop=crop,
+            state=tool_args.get("state") or state,
+        )
         return json.dumps(
             {"answer": answer or "", "tool_data": tool_payload},
             ensure_ascii=False,
@@ -500,4 +523,10 @@ async def daily_price(
         )
     except Exception as exc:
         logger.error("daily_price agent failed: %s", exc, exc_info=True)
-        return json.dumps({"answer": "", "tool_data": {"error": str(exc)}}, default=str)
+        return json.dumps(
+            {
+                "answer": _fallback_unavailable_answer({"error": str(exc)}, crop=crop, state=state),
+                "tool_data": {"error": str(exc)},
+            },
+            default=str,
+        )

--- a/ai/ajrasakha/agents/prompts.py
+++ b/ai/ajrasakha/agents/prompts.py
@@ -937,6 +937,9 @@ Rules:
 - Mention arrival quantities when the data includes them.
 - Name the market and date when available.
 - If records are limited, say so briefly.
+- If the tool JSON has an "error" field, empty price/arrival lists, or otherwise no usable data,
+  clearly tell the farmer that mandi price data is not available for that crop/location/date.
+  Do not invent prices. You may briefly restate crop and place from the error/query.
 - No markdown (** ##), no emojis, no source footnotes, no disclaimers.
 - Return ONLY the answer body.
 """

--- a/ai/ajrasakha/agents/tests/test_daily_price_agent.py
+++ b/ai/ajrasakha/agents/tests/test_daily_price_agent.py
@@ -153,7 +153,7 @@ async def test_extract_daily_price_intent_heuristic_on_gemma_failure():
 
 
 @pytest.mark.asyncio
-async def test_daily_price_returns_empty_when_tool_empty():
+async def test_daily_price_asks_gemma_when_tool_empty():
     with (
         patch(
             "ajrasakha.agents.daily_price_agent.extract_daily_price_intent",
@@ -175,6 +175,11 @@ async def test_daily_price_returns_empty_when_tool_empty():
             new_callable=AsyncMock,
             return_value={"price_records": [], "stats": {}},
         ),
+        patch(
+            "ajrasakha.agents.daily_price_agent.synthesize_daily_price_answer",
+            new_callable=AsyncMock,
+            return_value="Mandi price data is not available for wheat in Punjab right now.",
+        ) as synthesize,
     ):
         out = await daily_price.ainvoke({
             "query": "wheat price",
@@ -184,8 +189,54 @@ async def test_daily_price_returns_empty_when_tool_empty():
             "state": "Punjab",
         })
     data = json.loads(out)
-    assert data["answer"] == ""
+    synthesize.assert_awaited_once()
+    assert "not available" in data["answer"].lower()
     assert data["tool_data"]["price_records"] == []
+
+
+@pytest.mark.asyncio
+async def test_daily_price_asks_gemma_when_tool_error():
+    tool_payload = {
+        "error": "No markets_commodities entries matched crop=['Wheat'] in state=Andhra Pradesh."
+    }
+    with (
+        patch(
+            "ajrasakha.agents.daily_price_agent.extract_daily_price_intent",
+            new_callable=AsyncMock,
+            return_value={
+                "action": "get_today_price",
+                "nearest_market": True,
+                "radius_km": None,
+                "lookback_days": None,
+                "from_date": None,
+                "to_date": None,
+                "market_name": None,
+                "state": None,
+                "sort_order": None,
+            },
+        ),
+        patch(
+            "ajrasakha.agents.daily_price_agent.call_mandi_price_tool",
+            new_callable=AsyncMock,
+            return_value=tool_payload,
+        ),
+        patch(
+            "ajrasakha.agents.daily_price_agent.synthesize_daily_price_answer",
+            new_callable=AsyncMock,
+            return_value="Wheat mandi price data is not available in Andhra Pradesh right now.",
+        ) as synthesize,
+    ):
+        out = await daily_price.ainvoke({
+            "query": "wheat price in Andhra Pradesh",
+            "latitude": 15.9,
+            "longitude": 80.0,
+            "crop": "Wheat",
+            "state": "Andhra Pradesh",
+        })
+    data = json.loads(out)
+    synthesize.assert_awaited_once()
+    assert "not available" in data["answer"].lower()
+    assert data["tool_data"] == tool_payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Always synthesize an answer from empty/error mandi payloads so farmers get a clear not-available reply instead of an empty answer field.