### PR TITLE
feat: Showing notify user instead of approve answer for static dynami…

### DIFF
--- a/frontend/src/components/SelectedPannel.tsx
+++ b/frontend/src/components/SelectedPannel.tsx
@@ -374,6 +374,7 @@ export default function SelectedAnswerPanel({
             handleUpdateAnswer={handleUpdateAnswer}
             lastReroutedTo={lastReroutedTo}
             approvalCount={answer.approvalCount}
+            isStaticDynamic={question.tag === "static_dynamic"}
           />
         )}
         {(answer.approvalCount >= 3 || showActions) &&

--- a/frontend/src/features/question_details/components/AnswerItem.tsx
+++ b/frontend/src/features/question_details/components/AnswerItem.tsx
@@ -32,6 +32,7 @@ interface AnswerItemProps {
   currentUserId: string | undefined;
   submissionData?: ISubmissionHistory;
   questionId: string;
+  questionTag?: "dynamic" | "static_dynamic";
   lastAnswerId: string;
   firstAnswerId: string;
   userRole: UserRole;
@@ -403,6 +404,7 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
         isRejected={isRejected}
         submissionData={props.submissionData}
         questionId={props.questionId}
+        questionTag={props.questionTag}
         reviews={reviews}
         firstTrueIndex={firstTrueIndex}
         firstFalseOrMissingIndex={firstFalseOrMissingIndex}

--- a/frontend/src/features/question_details/components/AnswerTimeline.tsx
+++ b/frontend/src/features/question_details/components/AnswerTimeline.tsx
@@ -125,6 +125,7 @@ export const AnswerTimeline = ({
               currentUserId={currentUserId}
               questionStatus={question.status}
               questionId={question._id}
+              questionTag={question.tag}
               ref={commentRef}
               userRole={userRole}
               queue={queue}

--- a/frontend/src/features/question_details/components/answer_item/AnswerActions.tsx
+++ b/frontend/src/features/question_details/components/answer_item/AnswerActions.tsx
@@ -60,6 +60,7 @@ interface AnswerActionsProps {
   /** Whether the current user is the moderator this question is assigned to. Required
    *  for pae_submitted questions so Approve/Re-route only show for the assigned moderator. */
   isAssignedModerator?: boolean;
+  questionTag?: "dynamic" | "static_dynamic";
 }
 
 export const AnswerActions = ({
@@ -106,6 +107,7 @@ export const AnswerActions = ({
   isDedicatedView = false,
   assignedModerator,
   isAssignedModerator = false,
+  questionTag,
 }: AnswerActionsProps) => {
   // Approve and Re-route are restricted to the Dedicated (moderator-assigned) tab.
   // For pae_submitted questions (PAE tab) they are restricted to the assigned moderator
@@ -149,6 +151,7 @@ export const AnswerActions = ({
             approvalCount={answer.approvalCount}
             questionStatus={questionStatus}
             paeReview={paeReview}
+            isStaticDynamic={questionTag === "static_dynamic"}
           />
         )
       }

--- a/frontend/src/features/question_details/components/answer_item/ApproveAnswerDialog.tsx
+++ b/frontend/src/features/question_details/components/answer_item/ApproveAnswerDialog.tsx
@@ -66,6 +66,7 @@ interface ApproveAnswerDialogProps {
   questionStatus?: string;
   paeReview?: boolean;
   mode?: DialogMode;
+  isStaticDynamic?: boolean;
 }
 
 export const ApproveAnswerDialog = ({
@@ -83,6 +84,7 @@ export const ApproveAnswerDialog = ({
   questionStatus,
   paeReview,
   mode = "approve",
+  isStaticDynamic = false,
 }: ApproveAnswerDialogProps) => {
   const isEdit = mode === "edit";
   const isPaeSubmitted = questionStatus === "pae_submitted";
@@ -209,7 +211,7 @@ export const ApproveAnswerDialog = ({
             `}
           >
             <CheckCircle2 className="h-4 w-4" />
-            Approve Answer
+            {isStaticDynamic ? "Notify User" : "Approve Answer"}
           </button>
         )}
       </DialogTrigger>


### PR DESCRIPTION
For static dynamic question showing notify button instead of approve answer.

<img width="1039" height="524" alt="image" src="https://github.com/user-attachments/assets/652e9edb-7592-4f76-b7e6-8c4b70e447f5" />
<img width="1049" height="536" alt="image" src="https://github.com/user-attachments/assets/c6cf17fc-1488-40d9-ac0b-76154ae6c34b" />
