### PR TITLE
feat(acc_agent): extract farmer profile fields from transcript

### DIFF
--- a/ai/ajrasakha/agents/acc_agent/nodes.py
+++ b/ai/ajrasakha/agents/acc_agent/nodes.py
@@ -1,5 +1,7 @@
 import json
 import re
+from typing import Optional
+
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage, HumanMessage
 
@@ -13,8 +15,26 @@ from ajrasakha.agents.daily_price_agent import daily_price
 from ajrasakha.agents.schemes_agent import schemes
 from ajrasakha.agents.location_context import forward_geocode
 
+def _optional_str(value) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in {"null", "none", "n/a", "na", "all", "not specified", "unknown"}:
+        return None
+    return text
+
+
+def _optional_int(value) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 async def extract_node(state: AccAgentState):
-    """Extract query, state, district, crop, and standardized_domains from transcript."""
+    """Extract query, location, crop, domains, and farmer profile fields from transcript."""
     if not state.get("transcript"):
         return {}
         
@@ -39,13 +59,25 @@ async def extract_node(state: AccAgentState):
             domains = [domains]
         if not domains:
             domains = ["Others"]  # Default fallback
+
+        primary_crop = _optional_str(data.get("primary_crop"))
+        query_crop = data.get("crop", "All")
+        if not primary_crop and query_crop and str(query_crop).strip().lower() not in {"all", "not specified", ""}:
+            primary_crop = str(query_crop).strip()
             
         return {
             "extracted_query": data.get("query", ""),
             "extracted_state": data.get("state", "All"),
             "extracted_district": data.get("district", "All"),
-            "extracted_crop": data.get("crop", "All"),
+            "extracted_crop": query_crop,
             "standardized_domains": domains,
+            "extracted_name": _optional_str(data.get("name")),
+            "extracted_phone": _optional_str(data.get("phone")),
+            "extracted_age": _optional_int(data.get("age")),
+            "extracted_gender": _optional_str(data.get("gender")),
+            "extracted_village": _optional_str(data.get("village")),
+            "extracted_block": _optional_str(data.get("block")),
+            "extracted_primary_crop": primary_crop,
             "verified_by_human": False
         }
     except Exception as e:

--- a/ai/ajrasakha/agents/acc_agent/prompts.py
+++ b/ai/ajrasakha/agents/acc_agent/prompts.py
@@ -33,14 +33,22 @@ Your job is to extract the following information:
 1. "query": A concise agricultural question that captures the farmer's core problem or query. Keep it short and searchable.
 2. "state": The Indian state where the farmer is located (e.g. "Punjab", "West Bengal"). Use "All" if unclear.
 3. "district": The district where the farmer is located. Use "All" if unclear.
-4. "crop": The crop the farmer is asking about (e.g. "Wheat", "Rice"). Use "All" if unclear.
+4. "crop": The crop the farmer is asking about in this query (e.g. "Wheat", "Rice"). Use "All" if unclear.
 5. "standardized_domains": An array of domain names that best classify this query. Can be one or more domains.
+6. "name": Farmer's name if stated in the transcript. Use null if not mentioned.
+7. "phone": Farmer's phone number if stated in the transcript. Use null if not mentioned.
+8. "age": Farmer's age as an integer if stated. Use null if not mentioned.
+9. "gender": Farmer's gender if stated (e.g. "Male", "Female", "Other"). Use null if not mentioned.
+10. "village": Village name if stated. Use null if not mentioned.
+11. "block": Block / tehsil name if stated. Use null if not mentioned.
+12. "primary_crop": Farmer's main/primary crop if stated as their usual crop (may differ from query crop). Use null if not mentioned; if only one crop is discussed, you may use that crop.
 
 """ + DOMAIN_TAXONOMY + """
 
 CRITICAL INSTRUCTIONS:
-- You MUST output ONLY a valid JSON object with the keys "query", "state", "district", "crop", and "standardized_domains".
+- You MUST output ONLY a valid JSON object with the keys "query", "state", "district", "crop", "standardized_domains", "name", "phone", "age", "gender", "village", "block", and "primary_crop".
 - The "standardized_domains" field MUST be an array of strings, even if only one domain applies.
+- For profile fields (name, phone, age, gender, village, block, primary_crop): use null when not clearly present — do NOT invent values.
 - DO NOT output any markdown formatting, preamble, conversational text, or reasoning.
 - START your response immediately with the `{` character.
 """

--- a/ai/ajrasakha/agents/acc_agent/state.py
+++ b/ai/ajrasakha/agents/acc_agent/state.py
@@ -11,6 +11,15 @@ class AccAgentState(TypedDict):
     extracted_district: Optional[str]
     extracted_crop: Optional[str]
     standardized_domains: list[str]  # NEW: Domain classification by LLM
+
+    # Farmer profile fields (from transcript when mentioned)
+    extracted_name: Optional[str]
+    extracted_phone: Optional[str]
+    extracted_age: Optional[int]
+    extracted_gender: Optional[str]
+    extracted_village: Optional[str]
+    extracted_block: Optional[str]
+    extracted_primary_crop: Optional[str]
     
     # Verified and merged location structure
     location: Optional[Location]


### PR DESCRIPTION
Capture name, phone, age, gender, village, block, and primary crop during HITL extract so call-center agents can populate farmer details.