### PR TITLE
fix(question): Block Status Modification on Re-routed Questions

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2130,6 +2130,16 @@ export class QuestionService extends BaseService implements IQuestionService {
           throw new BadRequestError(`Question with ID ${questionId} not found`);
         }
 
+        // Block changing status to 'open' or 'delayed' when the question is re-routed
+        if (
+          (updates.status === 'open' || updates.status === 'delayed') &&
+          existingQuestion.status === 're-routed'
+        ) {
+          throw new BadRequestError(
+            `Cannot change the status, this question is currently re-routed.`,
+          );
+        }
+
         // if (existingQuestion.status == 'closed')
         //   throw new BadRequestError(
         //     'You cannot modify a question that has already been closed.',

--- a/backend/src/modules/question/tests/updateQuestion.test.ts
+++ b/backend/src/modules/question/tests/updateQuestion.test.ts
@@ -1,0 +1,84 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QuestionService } from '../services/QuestionService.js';
+import { BadRequestError } from 'routing-controllers';
+
+// ── Mock dependencies ─────────────────────────────────────────────────────────
+const mockQuestionRepo = {
+  getById: vi.fn(),
+  updateQuestion: vi.fn(),
+};
+
+const mockAnswerRepo = {
+  getByQuestionId: vi.fn().mockResolvedValue([]),
+};
+
+function buildService(): QuestionService {
+  return new QuestionService(
+    {} as any, // aiService
+    {} as any, // contextRepo
+    mockQuestionRepo as any,
+    {} as any, // userRepo
+    {} as any, // questionSubmissionRepo
+    {} as any, // requestRepository
+    mockAnswerRepo as any, // answerRepo
+    {} as any, // notificationRepository
+    {} as any, // notificationService
+    {} as any, // reRouteRepository
+    {} as any, // duplicateQuestionRepository
+    {} as any, // cropRepository
+    {} as any, // mongoDatabase
+  );
+}
+
+describe('QuestionService.updateQuestion — re-routed status validation', () => {
+  let service: QuestionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = buildService();
+
+    // Bypass MongoDB transaction — execute the callback directly with null session
+    vi.spyOn(service as any, '_withTransaction').mockImplementation(
+      (fn: any) => fn(null),
+    );
+  });
+
+  it('blocks changing status to open when existing status is re-routed', async () => {
+    mockQuestionRepo.getById.mockResolvedValue({
+      _id: 'q123',
+      status: 're-routed',
+    });
+
+    const updates = { status: 'open' };
+
+    await expect(service.updateQuestion('q123', updates as any)).rejects.toThrow(
+      new BadRequestError('Cannot change the status, this question is currently re-routed.')
+    );
+  });
+
+  it('blocks changing status to delayed when existing status is re-routed', async () => {
+    mockQuestionRepo.getById.mockResolvedValue({
+      _id: 'q123',
+      status: 're-routed',
+    });
+
+    const updates = { status: 'delayed' };
+
+    await expect(service.updateQuestion('q123', updates as any)).rejects.toThrow(
+      new BadRequestError('Cannot change the status, this question is currently re-routed.')
+    );
+  });
+
+  it('allows other status updates when existing status is re-routed', async () => {
+    mockQuestionRepo.getById.mockResolvedValue({
+      _id: 'q123',
+      status: 're-routed',
+    });
+    mockQuestionRepo.updateQuestion.mockResolvedValue({ modifiedCount: 1 });
+
+    const updates = { status: 'closed' };
+
+    await expect(service.updateQuestion('q123', updates as any)).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
# fix(question): Block Status Modification on Re-routed Questions — PR #1050

## Overview
This PR introduces a crucial backend validation rule to prevent manual status modifications on `re-routed` questions. Once a question enters the expert re-routing flow, its status is locked from being reverted to `open` or `delayed` by standard moderator actions.

This change ensures strict data integrity, preserves the accuracy of the system audit trails, and prevents users/moderators from bypassing the re-routing lifecycle rules.

---

## How the Status Lock Works (End-to-End)
[1] Question is assigned to an Expert
          ↓
[2] Question status becomes 're-routed'
          ↓
[3] User/Moderator attempts to update the question
          ↓
[4] QuestionService interceptor checks existing question status
          ↓
[5] If updates.status is 'open' or 'delayed' AND existingStatus is 're-routed'
          ↓
[6] Validation blocks change and throws 400 Bad Request Error 🛑
    (Prevents state corruption and queue mismatches)

---

## 🏗️ Architecture & Code Changes

The validation is handled entirely within the backend question service layer.

### Modules Modified:

* **`backend/src/modules/question/services/QuestionService.ts`**:
  Added a validation block inside `updateQuestion`'s transaction scope immediately after retrieving `existingQuestion`:
  ```typescript
  // Block changing status to 'open' or 'delayed' when the question is re-routed
  if (
    (updates.status === 'open' || updates.status === 'delayed') &&
    existingQuestion.status === 're-routed'
  ) {
    throw new BadRequestError(
      `Cannot change the status, this question is currently re-routed.`,
    );
  }
  ```

### New Test Suites:

* **`backend/src/modules/question/tests/updateQuestion.test.ts`**:
  Created a mock-based unit test suite verifying the behavior:
  - `blocks changing status to open when existing status is re-routed` (asserts `BadRequestError` thrown)
  - `blocks changing status to delayed when existing status is re-routed` (asserts `BadRequestError` thrown)
  - `allows other status updates when existing status is re-routed` (asserts resolves successfully)

---

## 🔌 API Changes
* **PUT** `/questions/:id` (Updates a question)
  - **Before**: Any status transition was permitted.
  - **After**: Returning `{ status: "open" }` or `{ status: "delayed" }` on a `re-routed` question returns a `400 Bad Request` error.

---

## ⚙️ Verification Plan

### Automated Tests
Run the new vitest suite to verify validation rules:
```bash
npx vitest run backend/src/modules/question/tests/updateQuestion.test.ts
```

### Manual Verification
1. Open the Database/Admin client.
2. Locate a question with status `"re-routed"`.
3. Dispatch a PUT request to the update question endpoint updating the status to `"open"`.
4. Verify that the response returns `400 Bad Request` with the message: `"Cannot change the status, this question is currently re-routed."`
