### PR TITLE
fix(question): Respect Auto-Allocation Settings during Absent Expert Cleanup

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -4140,12 +4140,15 @@ export class QuestionService extends BaseService implements IQuestionService {
         questionId.toString(),
         session,
       );
-      if (question.isAutoAllocate === false) {
-        await this.questionRepo.updateAutoAllocate(
-          questionId.toString(),
-          true,
-          session,
+      // Do NOT reset isAutoAllocate here. If a moderator deliberately turned off
+      // auto-allocation for this question, that decision must be respected even
+      // when the absent-expert cleanup removes experts from the queue.
+      // Only attempt re-allocation when the question still has isAutoAllocate: true.
+      if (!question.isAutoAllocate) {
+        console.log(
+          `[AbsentExpert] Skipping auto-reallocation for question ${questionId} — isAutoAllocate is false (moderator override).`,
         );
+        continue;
       }
       const latestSubmission =
         await this.questionSubmissionRepo.getByQuestionId(


### PR DESCRIPTION
# fix(question): Respect Auto-Allocation Settings during Absent Expert Cleanup — PR #1051

## Overview
This PR corrects a logical bug in the absent-expert queue cleanup routine where moderator overrides on auto-allocation (`isAutoAllocate: false`) were ignored and force-reset to `true` during cleanup. 

With this change, the background scheduler and cleanup services respect a moderator's decision to disable auto-allocation, ensuring manual queue management is never overridden by automated cleanup jobs.

---

## How the Cleanup Check Works (End-to-End)
[1] Absent expert cleanup routine triggers (e.g. via cron / check)
          ↓
[2] System identifies questions where the active expert is absent
          ↓
[3] Absent expert is removed from the queue
          ↓
[4] System retrieves the Question document
          ↓
[5] Check: Is auto-allocation disabled (isAutoAllocate === false)?
          ↓
          ├── YES → Skip re-allocation & continue loop ⏭️ (Keeps manual queue override)
          └── NO  → Reset/confirm isAutoAllocate is true & trigger auto-allocation ⚙️

---

## 🏗️ Architecture & Code Changes

This is a backend logic correction inside the queue cleaning sequence.

### Modules Modified:

* **`backend/src/modules/question/services/QuestionService.ts`**:
  Replaced the logic that unconditionally updated `isAutoAllocate` to `true` during absent expert removal with a check that skips the question entirely if auto-allocation has been disabled:
  ```typescript
  // Do NOT reset isAutoAllocate here. If a moderator deliberately turned off
  // auto-allocation for this question, that decision must be respected even
  // when the absent-expert cleanup removes experts from the queue.
  // Only attempt re-allocation when the question still has isAutoAllocate: true.
  if (!question.isAutoAllocate) {
    console.log(
      `[AbsentExpert] Skipping auto-reallocation for question ${questionId} — isAutoAllocate is false (moderator override).`,
    );
    continue;
  }
  ```

---

## ⚙️ Verification Plan

### Automated Tests
Run compilation checks and the Question module test suite to prevent regressions:
```bash
npx tsc --noEmit
npx vitest run backend/src/modules/question
```

### Manual Verification
1. Create a question and manually disable auto-allocation (`isAutoAllocate: false`).
2. Populate the queue with an expert, then mark the expert as absent to trigger the cleanup sequence.
3. Once the cleanup routine runs, check the database to confirm that the question's queue was cleaned up but `isAutoAllocate` remained `false` and no new auto-allocation occurred.
