### PR TITLE
fix(logging): respect THREAD_FILE_LOGGING flag in direct append path

### DIFF
--- a/ai/ajrasakha/agents/thread_logging.py
+++ b/ai/ajrasakha/agents/thread_logging.py
@@ -255,6 +255,8 @@ def _append_to_turn_buffer(text: str, *, thread_id: str | None = None) -> None:
 
 def _append_to_file(thread_id: str, text: str) -> None:
     """Append text to the local thread log file only (fast path during request)."""
+    if os.getenv("THREAD_FILE_LOGGING", "true").lower() not in ("true", "1", "yes"):
+        return
     block = text if text.endswith("\n") else f"{text}\n"
     path = _thread_log_path(thread_id)
     path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What this does

`THREAD_FILE_LOGGING=false` only disabled the logging `Handler` installation, but `append_thread_block()` still called `_append_to_file()` directly on every node execution, unconditionally performing a synchronous `mkdir` + file write. Under `langgraph dev`'s blocking-call detector, this raised `BlockingError` even with the flag set — every graph run failed on the first node, regardless of `THREAD_FILE_LOGGING`.

## Fix

`_append_to_file()` now checks the same flag before doing any disk I/O, so `THREAD_FILE_LOGGING=false` actually disables all file-logging code paths, not just the Handler-based one.

## How it was found and verified

Found while setting up the local dev environment — every LangGraph Studio run failed immediately with:
\`\`\`
BlockingError: Blocking call to os.mkdir
\`\`\`
Reproduced consistently on a clean local setup with `THREAD_FILE_LOGGING=false` set. After the fix, confirmed the graph runs end-to-end without the blocking error, with `THREAD_FILE_LOGGING` correctly suppressing file writes in both code paths.

Minimal, single-file change — no other logging behavior modified, just a small fix