### PR TITLE
feat: GDB coverage gap detector (Project 6)

### DIFF
--- a/tools/gdb-gap-detector/README.md
+++ b/tools/gdb-gap-detector/README.md
@@ -1,0 +1,105 @@
+# GDB Gap Detector
+
+Standalone Python tool to surface coverage gaps between farmer-asked
+unanswered queries (`disclaimer_logs.status == "unanswered"`) and the
+verified Golden Dataset (`gdb_entries`).
+
+This is the **candidate discovery** stage of the gap-reporting pipeline.
+A downstream generator consumes the output to produce the full
+`gap_reports` collection shape.
+
+## Files
+
+```
+gdb-gap-detector/
+├── find_gap_candidates.py     # stage 1 — extract candidate disclaimers
+├── clustering.py              # stage 2 — cluster into top_gaps
+├── generate_report.py         # stage 3 — assemble full gap_reports doc
+├── requirements.txt           # runtime + dev/test deps
+├── README.md
+└── tests/
+    ├── conftest.py
+    ├── test_find_gap_candidates.py
+    ├── test_clustering.py
+    └── test_generate_report.py
+```
+
+## Install
+
+Runtime only:
+
+```
+pip install -r requirements.txt
+```
+
+Runtime + dev (required to run the test suite):
+
+```
+pip install -r requirements.txt
+pip install pytest mongomock
+# (mongomock is listed in requirements.txt under the "# --- dev / test ---" section)
+```
+
+## Run
+
+Stage 1 (one-line summary):
+
+```
+export MONGODB_URI="mongodb://localhost:27017"
+python find_gap_candidates.py                       # all-time, default 5k cap
+python find_gap_candidates.py --since-days 30 --limit 10000
+python find_gap_candidates.py --verbose
+```
+
+Stage 3 (assemble full `gap_reports` document + markdown summary):
+
+```
+# Read-only — writes ./gap_report.md, does NOT touch MongoDB
+python generate_report.py
+
+# Custom period / output
+python generate_report.py --since-days 30 --output /tmp/gap.md
+
+# Insert into the gap_reports collection (INSERT ONLY — never overwrites)
+python generate_report.py --write-to-db
+```
+
+Stage 2 (`clustering.py`) is a library consumed by `generate_report.py`; it
+is not invoked directly.
+
+## Test
+
+From `tools/gdb-gap-detector/`:
+
+```
+pytest -v
+```
+
+## Privacy
+
+`farmer_id` is the single PII field in `disclaimer_logs`. The script
+excludes it via a Mongo projection (`{"farmer_id": 0}`) so it never
+leaves the database.
+
+## Known limitations
+
+**Clustering is keyword-based, not embedding-based.** Two records end up
+in the same cluster only when their sets of significant keywords
+(filtered for stopwords, with a small singular/plural fold) are
+identical. Closely related questions phrased differently — for example,
+"aphid control in mustard" vs. "how to get rid of aphids on mustard
+plants" — may therefore land in separate clusters. This is a known
+limitation of the current approach, not a bug.
+
+A lightweight trailing-`s` strip is applied to tokens longer than 4
+characters so that exact plural variants of the same word (e.g.
+`aphids`/`aphid`) collapse to one keyword. This is a heuristic, not a
+real lemmatizer: words ending in `s` that aren't plurals (e.g. `moss`,
+`class`) are over-stripped. Documented trade-off; the heuristic
+reduces one common cause of cluster fragmentation without claiming to
+solve it generally.
+
+Future work could replace the keyword-based clustering with the
+embedding pipeline already in use by the Golden DB subagent
+(`ai/ajrasakha/agents/acc_agent/` and the GDB embedding search) to
+produce semantically similar clusters. Not implemented yet.

--- a/tools/gdb-gap-detector/clustering.py
+++ b/tools/gdb-gap-detector/clustering.py
@@ -1,0 +1,385 @@
+"""clustering.py
+===============
+
+Groups `disclaimer_logs` candidates (already produced by
+``find_gap_candidates.py``) into the ``top_gaps`` clusters that appear in
+the ``gap_reports`` collection.
+
+Pipeline position
+-----------------
+::
+
+    MongoDB  -->  find_gap_candidates.py  -->  clustering.py  -->  downstream
+                                                                     report
+                                                                     writer
+
+Input shape (one record per disclaimer_logs row, all PII fields already
+stripped upstream)
+---------------------------------------------------------------------------
+    {
+      "query":               str,         # raw farmer question
+      "query_normalized":    str,         # pre-normalized text (must exist)
+      "query_hash":          str,         # upstream dedup key
+      "state":               str | None,
+      "domain":              str | None,
+      "timestamp":           datetime,    # tz-aware UTC expected
+    }
+
+Output shape (one record per cluster, matches `top_gaps` element schema)
+------------------------------------------------------------------------
+    {
+      "cluster_id":         str,          # sorted significant keywords joined "|"
+      "cluster_name":       str,          # top-3 significant keywords joined " / "
+      "size":               int,
+      "keywords":           list[str],
+      "sample_queries":     list[str],    # up to 3 raw `query` values
+      "domains":            list[str],
+      "states":             list[str],
+      "growth_rate":        float,
+      "priority_score":     float,
+      "first_seen":         datetime,
+      "last_seen":          datetime,
+      "farmer_demand":      int,          # == size per spec
+      "recommended_action": str,
+      "priority_level":     "HIGH" | "MEDIUM" | "LOW",
+    }
+
+Clustering approach
+-------------------
+Two records end up in the same cluster iff their sets of **significant
+keywords** (after stop-word filtering) are identical:
+
+    sig_kws(record) = sorted({token for token in tokens(query_normalized)
+                                if token not in STOPWORDS and len(token) >= 3})
+
+``cluster_id`` is ``"|".join(sorted(sig_kws))`` so the ID is independent
+of input ordering. ``cluster_name`` is the top-3 sig-kws by within-cluster
+frequency (ties broken alphabetically), joined with ``" / "`` — this is a
+human-readable label, not an ID.
+
+Priority score formula (original; documented, not reverse-engineered)
+--------------------------------------------------------------------
+::
+
+    priority_score = size + (0.15 * num_distinct_states) + (0.1 * growth_rate)
+
+The three terms encode three explainable signals:
+
+* ``size``              — raw volume of unmet demand. Dominant term.
+* ``0.15 * states``     — geographic spread. A cluster seen in 5 states is
+                          more strategically important than the same volume
+                          confined to one state; the coefficient is small
+                          so geographic spread nudges score but does not
+                          override volume.
+* ``0.1 * growth_rate`` — recency trend. A cluster that doubled last week
+                          should be actioned before a fading one; the
+                          coefficient is smaller than ``states`` because
+                          growth is noisier than geographic spread.
+
+Thresholds for ``priority_level``:
+
+* ``>= 8.0`` → HIGH
+* ``>= 5.0`` → MEDIUM
+* else      → LOW
+
+``recommended_action`` is a single short sentence keyed off
+``priority_level`` (see ``_RECOMMENDED_ACTION_BY_LEVEL``).
+
+growth_rate semantics
+---------------------
+``growth_rate = (recent - prior) / prior`` where:
+
+* ``recent`` = number of cluster members with ``timestamp`` in the last 7
+  calendar days (UTC).
+* ``prior``  = number of cluster members with ``timestamp`` in the 7 days
+  immediately preceding the recent window.
+
+If ``prior == 0`` the rate is reported as ``0.0`` — explicitly avoids a
+``ZeroDivisionError`` and is documented behaviour. (Calling this 0.0 is
+a conservative choice: it does not falsely signal "infinite growth" when
+a topic only recently emerged.)
+
+Limit
+-----
+The top 20 clusters by ``priority_score`` (descending) are returned.
+The function is named ``compute_top_gaps`` and accepts an optional
+``limit`` argument defaulting to 20.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+# ---------------------------------------------------------------------------
+# Public constants (extracted from this file's docstring; kept here so
+# tests and downstream callers can reference them without parsing prose).
+# ---------------------------------------------------------------------------
+
+# A small, documented, intentional list. English + a handful of
+# high-frequency Hindi transliterations we see in farmer logs. Notably NOT
+# "rashtra", "fasal", etc. — domain words that should survive filtering.
+# See ``STOPWORD_DOC`` in the docstring above for rationale.
+STOPWORDS: frozenset[str] = frozenset({
+    # English
+    "a", "an", "the", "and", "or", "but", "for", "to", "in", "on", "of",
+    "is", "are", "was", "were", "be", "been", "being", "do", "does", "did",
+    "has", "have", "had", "i", "you", "he", "she", "we", "they", "my",
+    "your", "his", "her", "our", "their", "this", "that", "these", "those",
+    "what", "which", "who", "whom", "how", "why", "when", "where",
+    "can", "could", "should", "would", "will", "shall", "may", "might",
+    "not", "no", "yes", "if", "then", "than", "as", "at", "by", "from",
+    "with", "about", "into", "so", "very", "much", "any", "some", "all",
+    # Hindi transliterated (high-frequency stopwords)
+    "hai", "hain", "ka", "ki", "ke", "ko", "se", "me", "main", "mujhe",
+    "mera", "mere", "yeh", "woh", "kya", "kab", "kaise", "kyun", "kahan",
+    "aur", "ya", "bhi", "nahi", "nahin", "nahi",
+})
+
+MIN_TOKEN_LENGTH = 3
+
+# Trailing 's' is stripped from tokens whose length is strictly greater
+# than this, so length-4 words like "this", "that", "loss" pass through
+# untouched. Practical effect: exact plural variants of the same word
+# (e.g. "aphids"/"aphid", "borers"/"borer") collapse to one sig-kw.
+# This is a low-precision heuristic — words ending in "s" that aren't
+# plurals (e.g. "moss", "class") will be over-stripped. Documented as a
+# known trade-off; see the README "Known limitations" section.
+MIN_PLURAL_STRIP_LENGTH = 4
+
+PRIORITY_HIGH_THRESHOLD = 8.0
+PRIORITY_MEDIUM_THRESHOLD = 5.0
+
+TOP_GAPS_LIMIT = 20
+
+_RECOMMENDED_ACTION_BY_LEVEL: dict[str, str] = {
+    "HIGH":   "Prioritize for expert Q&A drafting this sprint.",
+    "MEDIUM": "Schedule expert review in the next cycle.",
+    "LOW":    "Monitor; bundle with related clusters if recurring.",
+}
+
+# Tokenization pattern: split on anything that isn't a unicode letter or
+# digit. Keeps Devanagari and other Indic scripts intact, drops punctuation,
+# commas, dots, question marks, etc.
+_TOKEN_RE = re.compile(r"[^\w]+", re.UNICODE)
+_WORD_RE = re.compile(r"^[\w]+$", re.UNICODE)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (exported for testability)
+# ---------------------------------------------------------------------------
+def _significant_keywords(text: str) -> frozenset[str]:
+    """Tokenize ``text``, drop stopwords and short tokens, return a set.
+
+    Lowercased, unicode-aware. Empty input returns an empty set, which
+    becomes the special "no-significant-keywords" cluster (see
+    ``_cluster_key``).
+    """
+    if not text:
+        return frozenset()
+    tokens = (t for t in _TOKEN_RE.split(text.lower()) if t)
+    result: set[str] = set()
+    for t in tokens:
+        if len(t) < MIN_TOKEN_LENGTH or t in STOPWORDS:
+            continue
+        # Lightweight singular/plural fold: drop a trailing "s" on
+        # tokens longer than MIN_PLURAL_STRIP_LENGTH (e.g. "aphids" →
+        # "aphid"). Applied AFTER stopword filtering so e.g. "us" never
+        # becomes "u". Trade-off: this is a heuristic, not a real
+        # lemmatizer — see the README "Known limitations" section.
+        if t.endswith("s") and len(t) > MIN_PLURAL_STRIP_LENGTH:
+            t = t[:-1]
+        result.add(t)
+    return frozenset(result)
+
+
+def _cluster_key(sig_kws: frozenset[str]) -> str:
+    """Stable cluster ID from a set of significant keywords.
+
+    Sorted joined with ``|``. An empty sig_kw set becomes the literal
+    ``"<uncategorized>"`` cluster so queries with no significant keywords
+    still group together (rather than each becoming its own cluster).
+    """
+    if not sig_kws:
+        return "<uncategorized>"
+    return "|".join(sorted(sig_kws))
+
+
+def _cluster_name(cluster_members: list[dict[str, Any]]) -> str:
+    """Human-readable name: top-3 sig-kws by frequency within the cluster,
+    ties broken alphabetically, joined with ``" / "``.
+
+    If a cluster has no significant keywords (the "uncategorized" bucket),
+    the name is the literal ``"uncategorized"``.
+    """
+    if not cluster_members:
+        return "uncategorized"
+    counter: Counter[str] = Counter()
+    for r in cluster_members:
+        for kw in _significant_keywords(r.get("query_normalized", "")):
+            counter[kw] += 1
+    if not counter:
+        return "uncategorized"
+    # -count => descending; word ascending => alphabetical tie-break.
+    top = sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))[:3]
+    return " / ".join(kw for kw, _ in top)
+
+
+def _growth_rate(
+    members: list[dict[str, Any]],
+    *,
+    now: datetime | None = None,
+) -> float:
+    """Compute ``(recent - prior) / prior`` for 7-day windows.
+
+    Returns ``0.0`` (not an error) when ``prior == 0``.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    recent_cutoff = now - timedelta(days=7)
+    prior_cutoff = now - timedelta(days=14)
+
+    recent = 0
+    prior = 0
+    for m in members:
+        ts = m.get("timestamp")
+        if ts is None:
+            continue
+        # Normalize naive timestamps to UTC so they compare cleanly
+        # against tz-aware `now`. (Mongo may yield naive datetimes
+        # depending on driver config.)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if ts >= recent_cutoff:
+            recent += 1
+        elif recent_cutoff > ts >= prior_cutoff:
+            prior += 1
+
+    if prior == 0:
+        return 0.0
+    return (recent - prior) / prior
+
+
+def _priority_score(size: int, num_states: int, growth_rate: float) -> float:
+    """Original explainable priority formula — see module docstring."""
+    return size + (0.15 * num_states) + (0.1 * growth_rate)
+
+
+def _priority_level(score: float) -> str:
+    if score >= PRIORITY_HIGH_THRESHOLD:
+        return "HIGH"
+    if score >= PRIORITY_MEDIUM_THRESHOLD:
+        return "MEDIUM"
+    return "LOW"
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+def compute_top_gaps(
+    candidates: Iterable[dict[str, Any]],
+    *,
+    limit: int = TOP_GAPS_LIMIT,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Cluster candidate disclaimer rows and return top ``limit`` clusters.
+
+    Parameters
+    ----------
+    candidates
+        Iterable of pre-loaded disclaimer_logs rows (PII already stripped
+        by ``find_gap_candidates.fetch_unanswered_disclaimers`` via
+        projection).
+    limit
+        Number of top clusters to return, sorted by ``priority_score``
+        descending. Default 20 (per the gap_reports spec).
+    now
+        Reference time for ``growth_rate`` computation. Defaults to
+        ``datetime.now(timezone.utc)``. Override for tests / reproducible
+        reports.
+
+    Returns
+    -------
+    list of cluster dicts in the exact ``top_gaps`` element shape. May
+    be empty (or contain the single "uncategorized" bucket) depending on
+    input.
+    """
+    now = now or datetime.now(timezone.utc)
+    candidates = list(candidates)
+
+    # Group by cluster_id (= sorted significant-keyword signature).
+    clusters: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in candidates:
+        sig = _significant_keywords(row.get("query_normalized", ""))
+        clusters[_cluster_key(sig)].append(row)
+
+    results: list[dict[str, Any]] = []
+    for cid, members in clusters.items():
+        size = len(members)
+
+        # keywords: sorted union of all sig-kws seen in the cluster.
+        keywords: set[str] = set()
+        for m in members:
+            keywords.update(_significant_keywords(m.get("query_normalized", "")))
+        keywords_sorted = sorted(keywords)
+
+        # sample_queries: up to 3 raw `query` values, insertion order.
+        samples: list[str] = []
+        seen_samples: set[str] = set()
+        for m in members:
+            q = m.get("query")
+            if q is None or q in seen_samples:
+                continue
+            samples.append(q)
+            seen_samples.add(q)
+            if len(samples) >= 3:
+                break
+
+        domains = sorted({m["domain"] for m in members
+                          if m.get("domain") is not None})
+        states = sorted({m["state"] for m in members
+                         if m.get("state") is not None})
+
+        # first_seen / last_seen tolerate naive timestamps by normalizing.
+        ts_pairs: list[tuple[datetime, datetime]] = []
+        for m in members:
+            ts = m.get("timestamp")
+            if ts is None:
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            ts_pairs.append((ts, ts))
+        first_seen = min(t for t, _ in ts_pairs) if ts_pairs else None
+        last_seen = max(t for _, t in ts_pairs) if ts_pairs else None
+
+        growth = _growth_rate(members, now=now)
+        score = _priority_score(size, len(states), growth)
+        level = _priority_level(score)
+
+        results.append({
+            "cluster_id": cid,
+            "cluster_name": _cluster_name(members),
+            "size": size,
+            "keywords": keywords_sorted,
+            "sample_queries": samples,
+            "domains": domains,
+            "states": states,
+            "growth_rate": growth,
+            "priority_score": score,
+            "first_seen": first_seen,
+            "last_seen": last_seen,
+            "farmer_demand": size,        # == size per spec
+            "recommended_action": _RECOMMENDED_ACTION_BY_LEVEL[level],
+            "priority_level": level,
+        })
+
+    # Sort by priority_score descending; tie-break by size desc, then
+    # cluster_id asc so the result is deterministic for tests.
+    results.sort(key=lambda c: (-c["priority_score"],
+                                -c["size"],
+                                c["cluster_id"]))
+    return results[:limit]

--- a/tools/gdb-gap-detector/find_gap_candidates.py
+++ b/tools/gdb-gap-detector/find_gap_candidates.py
@@ -1,0 +1,257 @@
+"""
+find_gap_candidates.py
+======================
+
+Reads farmer-asked queries that the system could not answer
+(`disclaimer_logs.status == "unanswered"`) and compares them against the
+verified Golden Dataset (`gdb_entries`) to surface coverage gaps.
+
+This is the *candidate discovery* stage of the gap reporting pipeline. A
+downstream report generator (matching the `gap_reports` collection schema)
+consumes the output of this script to produce the full report.
+
+Source collections (database: `farmer_feedback`)
+-------------------------------------------------
+- disclaimer_logs
+    { _id, query, query_hash, query_normalized, farmer_id, source, language,
+      state, domain, confidence, best_match_id, best_match_score, timestamp,
+      status, metadata }
+    Only rows where ``status == "unanswered"`` are read.
+
+- gdb_entries
+    { _id, question, answer, domain, language, state, keywords,
+      created_at, updated_at }
+
+Output (printed to stdout)
+--------------------------
+- total_disclaimers: count of qualifying disclaimer_logs rows
+- unique_queries:    count of distinct ``query_hash`` values
+
+The full ``gap_reports`` collection shape (clusters, heatmap, outreach
+recommendations, etc.) is assembled by the downstream generator — this
+script only produces the candidate/aggregate numbers needed for that.
+
+Privacy
+-------
+``farmer_id`` is the single identifying field in `disclaimer_logs`. It is
+**never** read into local variables, included in prints/logs, or written
+to any output artifact. Only non-PII fields (query text, state, domain,
+timestamp) are used.
+
+Usage
+-----
+    # from tools/gdb-gap-detector/
+    python find_gap_candidates.py
+
+    # limit to last 30 days, cap at 10000 results
+    python find_gap_candidates.py --since-days 30 --limit 10000
+
+    # custom database / explicit URI override
+    MONGODB_URI="mongodb://localhost:27017" \\
+    python find_gap_candidates.py --db farmer_feedback
+
+Tests
+-----
+    # from tools/gdb-gap-detector/
+    pytest -v
+
+Environment
+-----------
+Required:
+    MONGODB_URI   MongoDB connection string. Script fails loudly if missing.
+
+Optional flags:
+    --since-days N     Only consider disclaimers from the last N days.
+                       Omit to read all unanswered disclaimers.
+    --limit N          Hard-cap on rows read per collection (default 5000,
+                       max 20000). Protects against runaway scans.
+    --db NAME          Database name (default: ``farmer_feedback``).
+    --verbose          Log progress to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any, Iterable
+
+from pymongo import MongoClient
+from pymongo.collection import Collection
+
+# ---------------------------------------------------------------------------
+# Defaults — override via CLI flags or environment
+# ---------------------------------------------------------------------------
+DEFAULT_DB = "farmer_feedback"
+DEFAULT_LIMIT = 5000
+MAX_LIMIT = 20000
+
+
+# ---------------------------------------------------------------------------
+# Mongo helpers
+# ---------------------------------------------------------------------------
+def get_client() -> MongoClient:
+    """Build a MongoClient from MONGODB_URI. Fail loudly if unset."""
+    uri = os.environ.get("MONGODB_URI", "").strip()
+    if not uri:
+        sys.stderr.write(
+            "ERROR: MONGODB_URI is not set. "
+            "Export it before running this script, e.g.\n"
+            "    export MONGODB_URI='mongodb://localhost:27017'\n"
+        )
+        sys.exit(2)
+    return MongoClient(uri)
+
+
+def fetch_unanswered_disclaimers(
+    coll: Collection,
+    *,
+    since_days: int | None,
+    limit: int,
+    verbose: bool = False,
+) -> list[dict[str, Any]]:
+    """Pull disclaimer_logs rows where status == 'unanswered'.
+
+    Notes:
+        - ``farmer_id`` is explicitly excluded from the projection so it
+          cannot leak into logs/print/pickle by accident.
+        - Results are sorted newest-first because gap reports care about
+          recent demand more than historical volume.
+    """
+    query: dict[str, Any] = {"status": "unanswered"}
+    if since_days is not None:
+        # Mongo-side time filter; avoids round-tripping old rows only to
+        # discard them.
+        from datetime import datetime, timedelta, timezone
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=since_days)
+        query["timestamp"] = {"$gte": cutoff}
+
+    if verbose:
+        sys.stderr.write(
+            f"[verbose] fetching unanswered disclaimers "
+            f"(since_days={since_days}, limit={limit})\n"
+        )
+
+    cursor = (
+        coll.find(
+            query,
+            # Explicit projection — PII never leaves Mongo in this script.
+            projection={"farmer_id": 0},
+        )
+        .sort("timestamp", -1)
+        .limit(limit)
+    )
+    return list(cursor)
+
+
+def fetch_gdb_entries(
+    coll: Collection,
+    *,
+    limit: int,
+    verbose: bool = False,
+) -> list[dict[str, Any]]:
+    """Pull all gdb_entries (capped) for the coverage denominator."""
+    if verbose:
+        sys.stderr.write(f"[verbose] fetching gdb_entries (limit={limit})\n")
+    cursor = coll.find({}, projection={"_id": 1, "domain": 1, "state": 1}).limit(
+        limit
+    )
+    return list(cursor)
+
+
+# ---------------------------------------------------------------------------
+# Aggregations
+# ---------------------------------------------------------------------------
+def count_unique_query_hash(disclaimers: Iterable[dict[str, Any]]) -> int:
+    """Count distinct ``query_hash`` across the disclaimer set."""
+    return len({d.get("query_hash") for d in disclaimers if d.get("query_hash")})
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Surface gap candidates between farmer-asked unanswered queries "
+            "and the verified Golden Dataset."
+        )
+    )
+    parser.add_argument(
+        "--since-days",
+        type=int,
+        default=None,
+        help="Only consider disclaimers from the last N days. Omit for all-time.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=(
+            f"Hard cap on rows read per collection "
+            f"(default {DEFAULT_LIMIT}, max {MAX_LIMIT})."
+        ),
+    )
+    parser.add_argument(
+        "--db",
+        default=DEFAULT_DB,
+        help=f"MongoDB database name (default: {DEFAULT_DB}).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log progress to stderr.",
+    )
+    return parser.parse_args(argv)
+
+
+def _clamp_limit(limit: int) -> int:
+    if limit <= 0:
+        sys.stderr.write("ERROR: --limit must be a positive integer.\n")
+        sys.exit(2)
+    if limit > MAX_LIMIT:
+        sys.stderr.write(
+            f"WARN: --limit {limit} exceeds max {MAX_LIMIT}; clamping to {MAX_LIMIT}.\n"
+        )
+        return MAX_LIMIT
+    return limit
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    limit = _clamp_limit(args.limit)
+
+    client = get_client()
+    try:
+        db = client[args.db]
+
+        disclaimers = fetch_unanswered_disclaimers(
+            db["disclaimer_logs"],
+            since_days=args.since_days,
+            limit=limit,
+            verbose=args.verbose,
+        )
+        gdb_entries = fetch_gdb_entries(
+            db["gdb_entries"],
+            limit=limit,
+            verbose=args.verbose,
+        )
+    finally:
+        client.close()
+
+    total_disclaimers = len(disclaimers)
+    unique_queries = count_unique_query_hash(disclaimers)
+
+    print(f"total_disclaimers: {total_disclaimers}")
+    print(f"unique_queries: {unique_queries}")
+    print(f"gdb_entries_loaded: {len(gdb_entries)}")
+    if args.since_days is not None:
+        print(f"since_days: {args.since_days}")
+    print(f"limit: {limit}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gdb-gap-detector/generate_report.py
+++ b/tools/gdb-gap-detector/generate_report.py
@@ -1,0 +1,562 @@
+"""generate_report.py
+===================
+
+Stage 3 of the GDB gap-reporting pipeline. Combines::
+
+    MongoDB gdb_entries    ──┐
+                              │
+    MongoDB disclaimer_logs ──┤  ──>  full gap_reports document
+                (filter       │       (top_gaps from clustering.py +
+                 status=      │        coverage_stats heatmap +
+                 unanswered)  │        outreach_recommendations +
+                              │        domains_with_gaps +
+                              │        states_with_gaps)
+                              │
+                              ▼
+
+Stage 1 (``find_gap_candidates.py``) discovers candidates and prints a
+one-line summary. Stage 2 (``clustering.py``) clusters those candidates
+into ``top_gaps``. This stage assembles the *full* ``gap_reports``
+document and writes a markdown summary to disk.
+
+The ``gap_reports`` collection schema (as specified by the user):
+
+    {
+      report_type, period_days, start_date, end_date, generated_at,
+      total_disclaimers, unique_queries, clusters_found,
+      top_gaps:                  [ from clustering.compute_top_gaps() ],
+      coverage_stats: {
+        heatmap:           [ { domain, state, gdb_count, disclaimer_count,
+                               coverage_score, status } ],
+        total_combinations, covered, partial, gaps
+      },
+      outreach_recommendations: [ { target_state, focus_domain, gap_questions,
+                                    recommendation, priority } ],
+      domains_with_gaps:        [ { domain, gap_count } ],
+      states_with_gaps:         [ { state,  gap_count } ]
+    }
+
+Privacy
+-------
+``farmer_id`` is never read in this script. ``find_gap_candidates.fetch_unanswered_disclaimers``
+projects it out at the Mongo layer, so it's not even present in the
+in-memory candidate list.
+
+CLI
+---
+    # Default — read-only, write markdown summary to ./gap_report.md
+    export MONGODB_URI="mongodb://localhost:27017"
+    python generate_report.py
+
+    # Custom period / output
+    python generate_report.py --since-days 30 --output /tmp/gap.md
+
+    # Insert into gap_reports collection (INSERT ONLY — never overwrites)
+    python generate_report.py --write-to-db
+
+Safety guarantees
+-----------------
+* ``--write-to-db`` is **OFF by default** — running the script never
+  touches MongoDB without an explicit flag.
+* When ``--write-to-db`` is set, the script calls ``insert_one()`` only.
+  It never calls ``update_one``, ``replace_one``, ``delete_one``,
+  ``delete_many``, ``drop``, or any bulk-write primitive. The script's
+  own code path makes a single insert call and exits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+from pymongo import MongoClient
+from pymongo.collection import Collection
+
+import clustering
+import find_gap_candidates as fgc
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+REPORT_TYPE = "gdb_coverage_gap"
+DEFAULT_PERIOD_DAYS = 30
+DEFAULT_OUTPUT_PATH = "./gap_report.md"
+DEFAULT_DB = fgc.DEFAULT_DB
+DEFAULT_LIMIT = fgc.DEFAULT_LIMIT
+MAX_LIMIT = fgc.MAX_LIMIT
+
+# Outreach: how many (state, domain) pairs to surface.
+OUTREACH_TOP_N = 10
+
+# Sentinel string for missing domain/state values when bucketing the
+# heatmap. Mongo docs may omit `state` (or `domain`) entirely, leaving
+# Python ``None`` in the row. The heatmap's per-pair counting key is
+# ``(domain, state)``; if we left None in the tuple, ``sorted(all_pairs)``
+# would raise ``TypeError: '<' not supported between instances of 'str'
+# and 'NoneType'``. Bucketing both missing-domain and missing-state
+# documents into the literal "None" string keeps the key space
+# homogeneous and matches the existing reference gap_reports format
+# (e.g. ``{"domain": "General", "state": "None"}``). Applied consistently
+# to BOTH gdb_entries and disclaimer_logs so a null-state doc from
+# either source lands in the same "None" row.
+HEATMAP_MISSING = "None"
+
+
+def _bucket_key(row: dict[str, Any]) -> tuple[str, str]:
+    """Return a homogeneous ``(domain, state)`` bucket key for ``row``.
+
+    Missing or ``None`` values are normalized to the literal string
+    ``HEATMAP_MISSING`` (``"None"``) so the bucket set is always
+    ``tuple[str, str]`` and is therefore sortable.
+    """
+    domain = row.get("domain")
+    state = row.get("state")
+    return (
+        domain if domain is not None else HEATMAP_MISSING,
+        state  if state  is not None else HEATMAP_MISSING,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coverage_stats.heatmap
+# ---------------------------------------------------------------------------
+def build_heatmap(
+    gdb_entries: Iterable[dict[str, Any]],
+    disclaimers: Iterable[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return one row per distinct (domain, state) seen in either source.
+
+    Each row has ``gdb_count``, ``disclaimer_count``, ``coverage_score``,
+    and ``status`` per the spec. Missing domain/state values are
+    bucketed under the literal string ``HEATMAP_MISSING`` (``"None"``);
+    see the comment on that constant for rationale.
+    """
+    gdb_pairs: Counter[tuple[str, str]] = Counter()
+    for g in gdb_entries:
+        gdb_pairs[_bucket_key(g)] += 1
+
+    disc_pairs: Counter[tuple[str, str]] = Counter()
+    for d in disclaimers:
+        disc_pairs[_bucket_key(d)] += 1
+
+    all_pairs = set(gdb_pairs) | set(disc_pairs)
+    rows: list[dict[str, Any]] = []
+    for pair in sorted(all_pairs):
+        domain, state = pair
+        g = gdb_pairs.get(pair, 0)
+        d = disc_pairs.get(pair, 0)
+        total = g + d
+        if total > 0:
+            score = round(g / total * 100, 1)
+        else:
+            score = 0.0
+        rows.append({
+            "domain": domain,
+            "state": state,
+            "gdb_count": g,
+            "disclaimer_count": d,
+            "coverage_score": score,
+            # status rule: "gap" if disclaimer_count > 0 else "good"
+            "status": "gap" if d > 0 else "good",
+        })
+    return rows
+
+
+def coverage_stats(heatmap: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate heatmap rows into ``coverage_stats``.
+
+    ``partial`` is reserved for future use and is always 0.
+    """
+    total = len(heatmap)
+    gaps = sum(1 for r in heatmap if r["status"] == "gap")
+    covered = sum(1 for r in heatmap if r["status"] == "good")
+    return {
+        "heatmap": heatmap,
+        "total_combinations": total,
+        "covered": covered,
+        "partial": 0,           # reserved for future use; see README
+        "gaps": gaps,
+    }
+
+
+# ---------------------------------------------------------------------------
+# domains_with_gaps / states_with_gaps
+# ---------------------------------------------------------------------------
+def domains_with_gaps(disclaimers: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sum disclaimer_count by domain; only entries with gap_count > 0.
+
+    Sorted descending by gap_count. Rows with ``domain is None`` are
+    dropped (uncategorized).
+    """
+    counts: Counter[str] = Counter()
+    for d in disclaimers:
+        dom = d.get("domain")
+        if dom is None:
+            continue
+        counts[dom] += 1
+    return [{"domain": dom, "gap_count": c}
+            for dom, c in counts.most_common()
+            if c > 0]
+
+
+def states_with_gaps(disclaimers: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sum disclaimer_count by state; only entries with gap_count > 0.
+
+    Sorted descending by gap_count.
+    """
+    counts: Counter[str] = Counter()
+    for d in disclaimers:
+        st = d.get("state")
+        if st is None:
+            continue
+        counts[st] += 1
+    return [{"state": st, "gap_count": c}
+            for st, c in counts.most_common()
+            if c > 0]
+
+
+# ---------------------------------------------------------------------------
+# outreach_recommendations
+# ---------------------------------------------------------------------------
+def _recommendation_for(priority: str, domain: str, state: str) -> str:
+    """Short templated recommendation string keyed off priority level."""
+    if priority == "HIGH":
+        return (f"Coordinate with {state}'s agri department to draft expert "
+                f"Q&A in {domain}.")
+    if priority == "MEDIUM":
+        return (f"Engage local KVK to address {domain} questions in {state}.")
+    return (f"Monitor {domain} questions from {state}; bundle into next "
+            f"review cycle.")
+
+
+def outreach_recommendations(
+    heatmap: list[dict[str, Any]],
+    *,
+    top_n: int = OUTREACH_TOP_N,
+) -> list[dict[str, Any]]:
+    """Return top-N (state, domain) pairs by disclaimer_count desc.
+
+    Rows with ``state == HEATMAP_MISSING`` (``"None"``) are excluded
+    before sorting because field-visit outreach recommendations need a
+    real, named state — a "Coordinate with None's agri department"
+    target is not actionable. Those rows are still counted in
+    ``coverage_stats`` and ``domains_with_gaps`` for completeness;
+    they're only filtered out of this outreach list.
+
+    Note: rows where ``domain == HEATMAP_MISSING`` are NOT excluded
+    here. The user's filter scope is state-only. A focus_domain of
+    "None" in a recommendation is odd but not impossible to act on
+    (e.g. a state-wide pest outbreak that crosses domain categories),
+    so we surface it. Documented scope decision.
+
+    ``priority`` is ``"HIGH"`` for entries at or above the **median**
+    disclaimer_count within the top-N list. Median-of-10 = average of
+    the 5th and 6th values (0-indexed: items[4] and items[5]). We use
+    ``>=`` against that average, so ties at the cutoff are flagged HIGH.
+
+    Documented here so the cutoff rule is auditable from the source.
+    """
+    # Drop rows with a missing state — they cannot drive actionable
+    # field-visit outreach. (Domain-missing rows still appear; see the
+    # note in the docstring above.)
+    actionable = [r for r in heatmap if r["state"] != HEATMAP_MISSING]
+
+    sorted_rows = sorted(
+        actionable,
+        key=lambda r: (-r["disclaimer_count"], r["domain"] or "", r["state"] or ""),
+    )[:top_n]
+
+    if not sorted_rows:
+        return []
+
+    counts = [r["disclaimer_count"] for r in sorted_rows]
+    # Median of an even-length list = average of the two middle elements.
+    median = (counts[len(counts) // 2 - 1] + counts[len(counts) // 2]) / 2
+
+    out: list[dict[str, Any]] = []
+    for r in sorted_rows:
+        priority = "HIGH" if r["disclaimer_count"] >= median else "MEDIUM"
+        out.append({
+            "target_state": r["state"],
+            "focus_domain": r["domain"],
+            "gap_questions": r["disclaimer_count"],
+            "recommendation": _recommendation_for(
+                priority, r["domain"] or "uncategorized", r["state"] or "unspecified"
+            ),
+            "priority": priority,
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Full report assembly
+# ---------------------------------------------------------------------------
+def build_report(
+    *,
+    period_days: int,
+    gdb_entries: Iterable[dict[str, Any]],
+    disclaimers: Iterable[dict[str, Any]],
+    candidates: Iterable[dict[str, Any]],
+    now: datetime | None = None,
+    top_n_outreach: int = OUTREACH_TOP_N,
+) -> dict[str, Any]:
+    """Assemble the full ``gap_reports`` document.
+
+    Parameters
+    ----------
+    period_days
+        Number of days back from ``now`` that this report covers.
+    gdb_entries
+        Iterable of pre-loaded gdb_entries rows.
+    disclaimers
+        Iterable of pre-loaded disclaimer_logs rows (already filtered to
+        status="unanswered"; PII already stripped upstream).
+    candidates
+        Same as ``disclaimers`` — fed into ``clustering.compute_top_gaps``.
+        Kept as a separate parameter so the caller can decide whether
+        clustering uses a different slice than the heatmap (e.g. only the
+        last 7 days for clustering but 30 days for the heatmap).
+    now
+        UTC reference time. Defaults to ``datetime.now(timezone.utc)``.
+        Override for tests / reproducible reports.
+    """
+    now = now or datetime.now(timezone.utc)
+    end_date = now
+    start_date = now - timedelta(days=period_days)
+
+    # Materialize iterables once so we can iterate multiple times.
+    gdb_list = list(gdb_entries)
+    disc_list = list(disclaimers)
+    cand_list = list(candidates)
+
+    top_gaps = clustering.compute_top_gaps(cand_list, now=now)
+    heatmap = build_heatmap(gdb_list, disc_list)
+    stats = coverage_stats(heatmap)
+    dom_gaps = domains_with_gaps(disc_list)
+    st_gaps = states_with_gaps(disc_list)
+    outreach = outreach_recommendations(heatmap, top_n=top_n_outreach)
+
+    return {
+        "report_type": REPORT_TYPE,
+        "period_days": period_days,
+        "start_date": start_date,
+        "end_date": end_date,
+        "generated_at": now,
+        "total_disclaimers": len(disc_list),
+        "unique_queries": fgc.count_unique_query_hash(disc_list),
+        "clusters_found": len(top_gaps),
+        "top_gaps": top_gaps,
+        "coverage_stats": stats,
+        "outreach_recommendations": outreach,
+        "domains_with_gaps": dom_gaps,
+        "states_with_gaps": st_gaps,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering (lightweight; not a styling exercise)
+# ---------------------------------------------------------------------------
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render a short human-readable markdown summary of the report."""
+    lines: list[str] = []
+    a = lines.append
+    a(f"# Gap Report — {report['report_type']}")
+    a("")
+    a(f"- Generated at: `{report['generated_at'].isoformat()}`")
+    a(f"- Period: {report['period_days']} days "
+      f"({report['start_date'].date()} → {report['end_date'].date()})")
+    a(f"- Total unanswered disclaimers: **{report['total_disclaimers']}**")
+    a(f"- Distinct query hashes: **{report['unique_queries']}**")
+    a(f"- Clusters found: **{report['clusters_found']}**")
+    a("")
+
+    cs = report["coverage_stats"]
+    a("## Coverage")
+    a(f"- Total (domain, state) combinations: **{cs['total_combinations']}**")
+    a(f"- Covered: **{cs['covered']}**")
+    a(f"- Gaps: **{cs['gaps']}**")
+    a(f"- Partial: **{cs['partial']}** (reserved for future use)")
+    a("")
+
+    a("## Top gaps (by priority score)")
+    if not report["top_gaps"]:
+        a("_No clusters._")
+    else:
+        for c in report["top_gaps"][:10]:
+            a(f"- **{c['priority_level']}** "
+              f"`{c['cluster_name']}` — size {c['size']}, "
+              f"states {len(c['states'])}, "
+              f"priority {c['priority_score']:.2f}")
+    a("")
+
+    a("## Outreach recommendations")
+    if not report["outreach_recommendations"]:
+        a("_No outreach targets._")
+    else:
+        for o in report["outreach_recommendations"]:
+            a(f"- [{o['priority']}] {o['target_state']} / {o['focus_domain']} "
+              f"— {o['gap_questions']} gap questions. {o['recommendation']}")
+    a("")
+
+    a("## Domains with gaps")
+    if not report["domains_with_gaps"]:
+        a("_None._")
+    else:
+        for d in report["domains_with_gaps"]:
+            a(f"- {d['domain']}: {d['gap_count']}")
+    a("")
+
+    a("## States with gaps")
+    if not report["states_with_gaps"]:
+        a("_None._")
+    else:
+        for s in report["states_with_gaps"]:
+            a(f"- {s['state']}: {s['gap_count']}")
+    a("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# MongoDB write (INSERT ONLY — never overwrites)
+# ---------------------------------------------------------------------------
+def write_report_to_db(report: dict[str, Any], *, db_name: str = DEFAULT_DB) -> str:
+    """Insert the report as a new document. Returns the inserted _id.
+
+    Safety: this function ONLY calls ``insert_one``. It never updates,
+    replaces, or deletes. See the module docstring's safety section.
+    """
+    uri = os.environ.get("MONGODB_URI", "").strip()
+    if not uri:
+        sys.stderr.write(
+            "ERROR: MONGODB_URI is not set. Cannot write to gap_reports.\n"
+        )
+        sys.exit(2)
+
+    client = MongoClient(uri)
+    try:
+        coll = client[db_name]["gap_reports"]
+        result = coll.insert_one(report)
+        return str(result.inserted_id)
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Assemble a gap_reports document and write a markdown "
+                    "summary. Reads from MongoDB; only writes back to "
+                    "gap_reports when --write-to-db is passed."
+    )
+    p.add_argument(
+        "--since-days",
+        type=int,
+        default=DEFAULT_PERIOD_DAYS,
+        help=f"Period covered by the report in days (default {DEFAULT_PERIOD_DAYS}).",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"Hard cap on rows read per collection (default {DEFAULT_LIMIT}, max {MAX_LIMIT}).",
+    )
+    p.add_argument(
+        "--db",
+        default=DEFAULT_DB,
+        help=f"MongoDB database name (default: {DEFAULT_DB}).",
+    )
+    p.add_argument(
+        "--output",
+        default=DEFAULT_OUTPUT_PATH,
+        help=f"Markdown output path (default {DEFAULT_OUTPUT_PATH}).",
+    )
+    p.add_argument(
+        "--write-to-db",
+        action="store_true",
+        help="Insert the report into gap_reports. Default OFF (read-only).",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log progress to stderr.",
+    )
+    return p.parse_args(argv)
+
+
+def _clamp_limit(limit: int) -> int:
+    if limit <= 0:
+        sys.stderr.write("ERROR: --limit must be a positive integer.\n")
+        sys.exit(2)
+    if limit > MAX_LIMIT:
+        sys.stderr.write(
+            f"WARN: --limit {limit} exceeds max {MAX_LIMIT}; clamping to {MAX_LIMIT}.\n"
+        )
+        return MAX_LIMIT
+    return limit
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    limit = _clamp_limit(args.limit)
+
+    if args.since_days <= 0:
+        sys.stderr.write("ERROR: --since-days must be a positive integer.\n")
+        sys.exit(2)
+
+    client = fgc.get_client()
+    try:
+        db = client[args.db]
+
+        disclaimers = fgc.fetch_unanswered_disclaimers(
+            db["disclaimer_logs"],
+            since_days=args.since_days,
+            limit=limit,
+            verbose=args.verbose,
+        )
+        gdb_entries = fgc.fetch_gdb_entries(
+            db["gdb_entries"],
+            limit=limit,
+            verbose=args.verbose,
+        )
+    finally:
+        client.close()
+
+    # Clustering uses the same disclaimers slice (could be narrowed
+    # later if needed).
+    report = build_report(
+        period_days=args.since_days,
+        gdb_entries=gdb_entries,
+        disclaimers=disclaimers,
+        candidates=disclaimers,
+    )
+
+    # 1. Markdown summary — ALWAYS written (even when --write-to-db is off).
+    md = render_markdown(report)
+    out_path = os.path.abspath(args.output)
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(md)
+    print(f"wrote markdown summary: {out_path}")
+    print(f"total_disclaimers: {report['total_disclaimers']}")
+    print(f"unique_queries: {report['unique_queries']}")
+    print(f"clusters_found: {report['clusters_found']}")
+    print(f"coverage_stats.gaps: {report['coverage_stats']['gaps']}")
+
+    # 2. Optional Mongo insert — INSERT ONLY.
+    if args.write_to_db:
+        inserted_id = write_report_to_db(report, db_name=args.db)
+        print(f"inserted gap_reports _id={inserted_id}")
+    else:
+        print("(read-only run; pass --write-to-db to insert into gap_reports)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gdb-gap-detector/requirements.txt
+++ b/tools/gdb-gap-detector/requirements.txt
@@ -1,0 +1,9 @@
+# Runtime
+pymongo>=4.6.0
+
+# --- dev / test ---
+# Required only to run test_find_gap_candidates.py.
+# Install with:
+#   pip install -r requirements.txt
+pytest>=8.0.0
+mongomock>=4.1.0

--- a/tools/gdb-gap-detector/tests/conftest.py
+++ b/tools/gdb-gap-detector/tests/conftest.py
@@ -1,0 +1,17 @@
+"""
+conftest.py — make `find_gap_candidates` importable from the parent dir
+without requiring the project to be pip-installed.
+
+The tool lives at `tools/gdb-gap-detector/find_gap_candidates.py`. The
+tests live at `tools/gdb-gap-detector/tests/`. We add the parent
+directory to sys.path so `import find_gap_candidates` resolves to the
+real module.
+"""
+
+import os
+import sys
+
+# tools/gdb-gap-detector/tests/conftest.py → tools/gdb-gap-detector/
+_PARENT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)

--- a/tools/gdb-gap-detector/tests/test_clustering.py
+++ b/tools/gdb-gap-detector/tests/test_clustering.py
@@ -1,0 +1,498 @@
+"""
+Persisted test suite for tools/gdb-gap-detector/clustering.py.
+
+Run with:
+    cd tools/gdb-gap-detector
+    pytest tests/test_clustering.py -v
+
+Coverage
+--------
+Requested cases:
+  - empty input
+  - single cluster
+  - tied priority_score rankings
+  - zero-prior-period growth_rate edge case (no ZeroDivisionError)
+
+Plus shape & behaviour sanity checks:
+  - result element matches the `top_gaps` schema exactly
+  - sample_queries is at most 3, contains raw `query` values
+  - domains / states are sorted-distinct
+  - first_seen <= last_seen
+  - farmer_demand == size
+  - priority_level / recommended_action are consistent
+  - cluster_id is stable under input ordering (sorted sig-kws joined "|")
+  - queries with no significant keywords collapse to "<uncategorized>"
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+# Make the package dir importable (matches tests/conftest.py's role).
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parent.parent),
+)
+import clustering as cl  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixed reference "now" so growth_rate windows are deterministic in tests.
+# Pick a Saturday at 12:00 UTC for clear week-aligned arithmetic.
+# ---------------------------------------------------------------------------
+NOW = datetime(2026, 6, 13, 12, 0, tzinfo=timezone.utc)
+
+
+def _row(
+    query: str,
+    *,
+    state: str | None = "MH",
+    domain: str | None = "pest",
+    timestamp: datetime | None = None,
+    query_normalized: str | None = None,
+    **extra,
+) -> dict:
+    """Build a candidate row in the shape find_gap_candidates returns."""
+    row = {
+        "query": query,
+        "query_normalized": query_normalized if query_normalized is not None else query.lower(),
+        "query_hash": f"h-{abs(hash(query))}",
+        "state": state,
+        "domain": domain,
+        "timestamp": timestamp if timestamp is not None else NOW - timedelta(days=30),
+    }
+    row.update(extra)
+    return row
+
+
+# ===========================================================================
+# 1. Empty input
+# ===========================================================================
+def test_empty_input_returns_empty_list():
+    assert cl.compute_top_gaps([], now=NOW) == []
+
+
+def test_empty_input_via_iterator_also_empty():
+    # Accept any iterable; defensive coverage.
+    assert cl.compute_top_gaps(iter([]), now=NOW) == []
+
+
+# ===========================================================================
+# 2. Single cluster
+# ===========================================================================
+def test_single_cluster_with_identical_normalization_collapses():
+    """Three queries with the same significant-keyword signature → 1 cluster.
+
+    Identical sig-keyword SETS (not just overlap) collapse, because
+    cluster_id is the sorted union of each row's sig-kws. Different
+    trailing words → different sig-sets → different clusters. (That's
+    by design — deterministic and reproducible.)
+    """
+    base = "aphids on tomato"
+    rows = [
+        _row(f"aphids on tomato {variant}",
+             query_normalized=base,                 # force identical sig-kws
+             timestamp=NOW - timedelta(days=i + 1))
+        for i, variant in enumerate(["first", "second", "third"])
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+
+    assert len(out) == 1
+    c = out[0]
+    assert c["size"] == 3
+    assert c["farmer_demand"] == 3
+    # "aphid" and "tomato" survive; the trailing-s strip on tokens
+    # longer than 4 chars collapses "aphids" → "aphid" inside the helper.
+    assert "aphid" in c["keywords"]
+    assert "aphids" not in c["keywords"]
+    assert "tomato" in c["keywords"]
+    assert "on" not in c["keywords"]
+    # sample_queries: up to 3 raw `query` values, in insertion order.
+    assert len(c["sample_queries"]) == 3
+    assert c["sample_queries"][0] == "aphids on tomato first"
+
+
+def test_single_cluster_scores_and_levels_consistent():
+    rows = [
+        _row("aphids on tomato", state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=1)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert len(out) == 1
+    c = out[0]
+    # score = size + 0.15*states + 0.1*growth
+    # one row, one state, growth 0.0 (out of windows) -> score = 1 + 0.15 + 0 = 1.15
+    assert c["priority_score"] == pytest.approx(1.15)
+    assert c["priority_level"] == "LOW"
+    assert c["farmer_demand"] == 1
+    assert c["size"] == 1
+    assert c["recommended_action"] == cl._RECOMMENDED_ACTION_BY_LEVEL["LOW"]
+
+
+# ===========================================================================
+# 3. Tied priority_score rankings
+# ===========================================================================
+def test_tied_priority_scores_use_size_then_id_tie_breakers():
+    """Two clusters with identical priority_score → tie-break by cluster_id.
+
+    Constructs two clusters with identical (size=2, states=1, growth=0.0)
+    so priority_score is the same. Tie-break → cluster_id ascending
+    (alphabetical) because sizes are equal.
+    """
+    base_a = "aphids on tomato"
+    base_b = "rust on wheat"
+    cluster_a = [
+        _row(f"aphids on tomato a{i}", query_normalized=base_a,
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=30))
+        for i in range(2)
+    ]
+    cluster_b = [
+        _row(f"rust on wheat b{i}", query_normalized=base_b,
+             state="PB", domain="disease",
+             timestamp=NOW - timedelta(days=30))
+        for i in range(2)
+    ]
+    out = cl.compute_top_gaps(cluster_a + cluster_b, now=NOW)
+
+    assert len(out) == 2
+    # Both clusters: size=2, states=1, growth=0.0 → same priority_score.
+    assert out[0]["priority_score"] == out[1]["priority_score"]
+    # Tie-break: size desc identical (=2), fall through to cluster_id asc.
+    assert out[0]["cluster_id"] < out[1]["cluster_id"]
+    # Aphids→aphid (plural fold) < Rust alphabetically → aphids wins.
+    assert "aphid" in out[0]["keywords"]
+    assert "rust" in out[1]["keywords"]  # not subject to the plural fold (len=4)
+
+
+def test_higher_size_wins_over_lower_size_for_priority():
+    """Bigger cluster sorts first because priority_score grows with size."""
+    base_big = "aphids on tomato"
+    base_small = "rust on wheat"
+    rows = [
+        _row("aphids on tomato 1",  query_normalized=base_big,
+             state=None, domain=None, timestamp=NOW - timedelta(days=30)),
+        _row("aphids on tomato 2",  query_normalized=base_big,
+             state=None, domain=None, timestamp=NOW - timedelta(days=29)),
+        _row("rust on wheat only",  query_normalized=base_small,
+             state=None, domain=None, timestamp=NOW - timedelta(days=30)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    # Two clusters: aphids-tomato (size=2), rust-wheat (size=1).
+    assert out[0]["size"] == 2
+    assert out[1]["size"] == 1
+    assert out[0]["priority_score"] > out[1]["priority_score"]
+
+
+# ===========================================================================
+# 4. Zero-prior-period growth_rate edge case (no ZeroDivisionError)
+# ===========================================================================
+def test_growth_rate_zero_prior_returns_zero_no_division_error():
+    """All cluster members are in the last 7 days; none in the prior 7.
+    growth_rate must be 0.0, NOT raise ZeroDivisionError.
+    """
+    base = "aphids on tomato"
+    rows = [
+        _row("aphids on tomato 1", query_normalized=base,
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=1)),
+        _row("aphids on tomato 2", query_normalized=base,
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=2)),
+        _row("aphids on tomato 3", query_normalized=base,
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=3)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert len(out) == 1
+    assert out[0]["growth_rate"] == 0.0
+    # size=3, states=1, growth=0.0 → 3 + 0.15 + 0.0 = 3.15
+    assert out[0]["priority_score"] == pytest.approx(3.15)
+
+
+def test_growth_rate_positive_when_recent_exceeds_prior():
+    base = "aphids on tomato"
+    rows = [
+        _row("aphids on tomato 1", query_normalized=base,
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=1)),   # recent
+        _row("aphids on tomato 2", query_normalized=base,
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=2)),   # recent
+        _row("aphids on tomato 3", query_normalized=base,
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=10)),  # prior
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert len(out) == 1
+    # recent=2, prior=1 → (2-1)/1 = 1.0
+    assert out[0]["growth_rate"] == pytest.approx(1.0)
+    # size=3, states=1, growth=1.0 → 3 + 0.15 + 0.1 = 3.25
+    assert out[0]["priority_score"] == pytest.approx(3.25)
+
+
+def test_growth_rate_zero_when_both_recent_and_prior_empty():
+    rows = [_row("aphids on tomato", state="MH", domain="pest",
+                 timestamp=NOW - timedelta(days=100))]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert out[0]["growth_rate"] == 0.0
+
+
+def test_growth_rate_handles_naive_timestamps():
+    """find_gap_candidates may yield naive datetimes; clustering must
+    still produce a defined growth_rate (not crash on tz compare)."""
+    naive_now = datetime(2026, 6, 13, 12, 0)  # no tzinfo
+    rows = [
+        {"query": "aphids on tomato",
+         "query_normalized": "aphids on tomato",
+         "query_hash": "h1",
+         "state": "MH", "domain": "pest",
+         "timestamp": naive_now - timedelta(days=1)},
+    ]
+    out = cl.compute_top_gaps(rows, now=naive_now)
+    assert len(out) == 1
+    assert out[0]["growth_rate"] == 0.0
+
+
+# ===========================================================================
+# Shape & behaviour sanity checks
+# ===========================================================================
+EXPECTED_KEYS = {
+    "cluster_id", "cluster_name", "size", "keywords", "sample_queries",
+    "domains", "states", "growth_rate", "priority_score",
+    "first_seen", "last_seen", "farmer_demand",
+    "recommended_action", "priority_level",
+}
+
+
+def test_result_element_matches_top_gaps_schema():
+    rows = [_row("aphids on tomato", state="MH", domain="pest",
+                 timestamp=NOW - timedelta(days=1))]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert set(out[0].keys()) == EXPECTED_KEYS
+
+
+def test_farmer_demand_equals_size():
+    rows = [_row(f"aphids on tomato {i}", state="MH", domain="pest",
+                 timestamp=NOW - timedelta(days=i + 1))
+            for i in range(5)]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert out[0]["farmer_demand"] == out[0]["size"] == 5
+
+
+def test_sample_queries_capped_at_three():
+    rows = [_row(f"aphids on tomato variant {i}", state="MH", domain="pest",
+                 timestamp=NOW - timedelta(days=i + 1))
+            for i in range(10)]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert len(out[0]["sample_queries"]) == 3
+
+
+def test_sample_queries_are_raw_query_values():
+    """sample_queries are the raw `query` strings, NOT the normalized form.
+
+    Both rows share the same normalized text (and therefore the same
+    sig-kw set + cluster), but their raw `query` values differ in case
+    and content.
+    """
+    rows = [
+        _row("APhidS on TOMATO",
+             query_normalized="aphids on tomato",
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=1)),
+        _row("Aphids on tomato plant",
+             query_normalized="aphids on tomato",
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=2)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert len(out) == 1
+    # sample_queries are the raw `query` strings, NOT normalized.
+    assert "APhidS on TOMATO" in out[0]["sample_queries"]
+    assert "Aphids on tomato plant" in out[0]["sample_queries"]
+
+
+def test_domains_and_states_are_sorted_distinct():
+    base = "aphids on tomato"
+    rows = [
+        _row("aphids on tomato 1", query_normalized=base,
+             state="UP", domain="pest",
+             timestamp=NOW - timedelta(days=1)),
+        _row("aphids on tomato 2", query_normalized=base,
+             state="MH", domain="disease",
+             timestamp=NOW - timedelta(days=2)),
+        _row("aphids on tomato 3", query_normalized=base,
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=3)),
+        _row("aphids on tomato 4", query_normalized=base,
+             state="MH", domain=None,
+             timestamp=NOW - timedelta(days=4)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert out[0]["states"] == ["MH", "UP"]
+    assert out[0]["domains"] == ["disease", "pest"]   # None dropped
+
+
+def test_first_seen_before_last_seen():
+    rows = [
+        _row("aphids on tomato",       state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=5)),
+        _row("aphids on tomato leaves", state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=1)),
+        _row("aphids on tomato stem",   state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=10)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert out[0]["first_seen"] <= out[0]["last_seen"]
+
+
+def test_priority_level_thresholds():
+    """Construct inputs that land exactly on the boundary scores."""
+    # HIGH threshold = 8.0. Build a cluster with size=8, 0 states, growth=0 → 8.0
+    rows_high = [
+        _row(f"aphids on tomato variant {i}", state=None, domain=None,
+             timestamp=NOW - timedelta(days=30))
+        for i in range(8)
+    ]
+    out = cl.compute_top_gaps(rows_high, now=NOW)
+    assert out[0]["priority_level"] == "HIGH"
+
+    # MEDIUM threshold = 5.0. size=5, states=0, growth=0 → 5.0
+    rows_med = [
+        _row(f"aphids on tomato variant {i}", state=None, domain=None,
+             timestamp=NOW - timedelta(days=30))
+        for i in range(5)
+    ]
+    out = cl.compute_top_gaps(rows_med, now=NOW)
+    assert out[0]["priority_level"] == "MEDIUM"
+
+    # LOW: below 5.0
+    rows_low = [
+        _row(f"aphids on tomato variant {i}", state=None, domain=None,
+             timestamp=NOW - timedelta(days=30))
+        for i in range(2)
+    ]
+    out = cl.compute_top_gaps(rows_low, now=NOW)
+    assert out[0]["priority_level"] == "LOW"
+
+
+def test_recommended_action_matches_level():
+    rows = [_row("aphids on tomato", state="MH", domain="pest",
+                 timestamp=NOW - timedelta(days=1))]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert out[0]["recommended_action"] == cl._RECOMMENDED_ACTION_BY_LEVEL[
+        out[0]["priority_level"]
+    ]
+
+
+def test_cluster_id_independent_of_input_order():
+    rows_a = [
+        _row("aphids on tomato",       state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=1)),
+        _row("on aphids tomato leaves", state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=2)),
+    ]
+    rows_b = list(reversed(rows_a))
+    out_a = cl.compute_top_gaps(rows_a, now=NOW)
+    out_b = cl.compute_top_gaps(rows_b, now=NOW)
+    assert out_a[0]["cluster_id"] == out_b[0]["cluster_id"]
+
+
+def test_no_significant_keywords_collapses_to_uncategorized():
+    """Query 'what is this' filtered to empty sig-set → uncategorized bucket."""
+    rows = [
+        _row("what is this",  query_normalized="what is this",
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=1)),
+        _row("what is that",  query_normalized="what is that",
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=2)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert len(out) == 1
+    assert out[0]["cluster_id"] == "<uncategorized>"
+    assert out[0]["cluster_name"] == "uncategorized"
+
+
+def test_top_n_limit_caps_results():
+    """More clusters than `limit` → truncated to limit, highest priority kept."""
+    # Generate ~25 distinct single-row clusters; each has size=1, score ~1.15.
+    rows = []
+    base = [
+        "aphids", "rust", "borer", "blight", "wilt", "mildew",
+        "rot", "spot", "mite", "weevil", "caterpillar", "thrips",
+        "leafhopper", "whitefly", "stem", "root", "fruit", "flower",
+        "seedling", "soil", "irrigation", "fertilizer", "compost",
+        "weather", "monsoon",
+    ]
+    for i, kw in enumerate(base):
+        rows.append(_row(f"{kw} on something {i}",
+                         state=None, domain=None,
+                         timestamp=NOW - timedelta(days=30)))
+    out_full = cl.compute_top_gaps(rows, now=NOW, limit=100)
+    out_capped = cl.compute_top_gaps(rows, now=NOW, limit=10)
+    assert len(out_full) > 10
+    assert len(out_capped) == 10
+
+
+def test_stopwords_excluded_from_keywords():
+    """Tokenization + stopword filtering must drop common words."""
+    rows = [
+        _row("what is the best fertilizer for wheat",
+             state="MH", domain="fertilizer",
+             timestamp=NOW - timedelta(days=1)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    kws = set(out[0]["keywords"])
+    assert "best" in kws
+    assert "fertilizer" in kws
+    assert "wheat" in kws
+    for w in ("what", "is", "the", "for", "on", "in"):  # stopwords
+        assert w not in kws
+
+
+def test_plural_fold_collapses_singular_and_plural_forms():
+    """Singular and plural forms of the same word land in the same cluster.
+
+    Two queries that differ ONLY in whether the pest noun is singular
+    or plural collapse to a single cluster, thanks to the trailing-`s`
+    strip on tokens longer than 4 chars. This is a precision
+    improvement, not a general lemmatizer — see the "Known limitations"
+    section of README.md. Short words (length ≤ 4) ending in `s` are
+    intentionally NOT stripped.
+    """
+    rows = [
+        _row("aphids on tomato",     # plural
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=1)),
+        _row("aphid on tomato",      # singular, otherwise identical
+             state="MH", domain="pest",
+             timestamp=NOW - timedelta(days=2)),
+    ]
+    out = cl.compute_top_gaps(rows, now=NOW)
+    assert len(out) == 1
+    kws = set(out[0]["keywords"])
+    # Both rows tokenize+fold to {"aphid", "tomato"}; the trailing-s
+    # strip normalizes "aphids" → "aphid".
+    assert "aphid" in kws
+    assert "aphids" not in kws
+    assert "tomato" in kws
+
+
+def test_plural_fold_does_not_strip_short_words():
+    """Length-4 (or shorter) words ending in `s` pass through unchanged
+    so "this", "loss", "us" etc. aren't mangled.
+    """
+    # "loss" is length-4 and ends in 's' but is NOT a plural.
+    sig = cl._significant_keywords("loss in the field")
+    assert "loss" in sig
+    assert "lo" not in sig
+    # "this" is length-4 and a stopword — handled by stopword filter first.
+    sig2 = cl._significant_keywords("this is a test")
+    # "this" is a stopword so dropped; "test" survives.
+    assert "this" not in sig2
+    assert "test" in sig2

--- a/tools/gdb-gap-detector/tests/test_find_gap_candidates.py
+++ b/tools/gdb-gap-detector/tests/test_find_gap_candidates.py
@@ -1,0 +1,293 @@
+"""
+Persisted test suite for tools/gdb-gap-detector/find_gap_candidates.py.
+
+Run with:
+    cd tools/gdb-gap-detector
+    pytest -v
+
+Requires: pytest, mongomock (declared in requirements.txt under the
+"# --- dev / test ---" section).
+
+Coverage
+--------
+Pure helpers (unit):
+  - _clamp_limit clamping and rejection of non-positive values
+  - count_unique_query_hash distinct count + None handling
+  - fetch_unanswered_disclaimers status filter, since-days filter,
+    limit cap, and farmer_id projection
+  - fetch_gdb_entries reads all + respects limit
+
+CLI / env (subprocess):
+  - missing MONGODB_URI fails loudly (exit 2) with helpful stderr
+  - bogus MONGODB_URI proceeds past the env guard
+  - --limit 0 fails loudly (exit 2)
+  - --limit > MAX_LIMIT is clamped with a stderr WARN
+  - --help renders without error
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import mongomock
+import pytest
+
+import find_gap_candidates as fgc
+
+# ---------------------------------------------------------------------------
+# Constants & fixtures
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "find_gap_candidates.py"
+PYTHON = sys.executable
+NOW = dt.datetime.now(dt.timezone.utc)
+
+
+@pytest.fixture
+def disclaimer_coll():
+    """Fresh mongomock collection seeded with a known mix of statuses/ages."""
+    coll = mongomock.MongoClient()["farmer_feedback"]["disclaimer_logs"]
+    coll.insert_many(
+        [
+            {"query": "aphids on tomato", "query_hash": "h1",
+             "farmer_id": "SECRET-AAA", "state": "MH", "domain": "pest",
+             "status": "unanswered", "timestamp": NOW - dt.timedelta(days=1)},
+            {"query": "wheat rust",       "query_hash": "h2",
+             "farmer_id": "SECRET-BBB", "state": "PB", "domain": "disease",
+             "status": "unanswered", "timestamp": NOW - dt.timedelta(days=2)},
+            {"query": "soil ph",          "query_hash": "h3",
+             "farmer_id": "SECRET-CCC", "state": "UP", "domain": "soil",
+             "status": "answered",    "timestamp": NOW - dt.timedelta(days=1)},
+            {"query": "old query",        "query_hash": "h4",
+             "farmer_id": "SECRET-DDD", "state": "KA", "domain": "irrigation",
+             "status": "unanswered", "timestamp": NOW - dt.timedelta(days=400)},
+        ]
+    )
+    return coll
+
+
+@pytest.fixture
+def gdb_coll():
+    coll = mongomock.MongoClient()["farmer_feedback"]["gdb_entries"]
+    coll.insert_many([{"_id": f"g{i}", "domain": "pest", "state": "MH"} for i in range(7)])
+    return coll
+
+
+# ---------------------------------------------------------------------------
+# _clamp_limit
+# ---------------------------------------------------------------------------
+
+def test_clamp_limit_passes_in_range():
+    assert fgc._clamp_limit(100) == 100
+
+
+def test_clamp_limit_clamps_to_max(capsys):
+    assert fgc._clamp_limit(999_999) == fgc.MAX_LIMIT
+    captured = capsys.readouterr()
+    assert "WARN" in captured.err
+    assert str(fgc.MAX_LIMIT) in captured.err
+
+
+def test_clamp_limit_rejects_zero():
+    with pytest.raises(SystemExit) as exc:
+        fgc._clamp_limit(0)
+    assert exc.value.code == 2
+
+
+def test_clamp_limit_rejects_negative():
+    with pytest.raises(SystemExit) as exc:
+        fgc._clamp_limit(-5)
+    assert exc.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# count_unique_query_hash
+# ---------------------------------------------------------------------------
+
+def test_count_unique_query_hash_counts_distinct():
+    sample = [
+        {"query_hash": "h1"},
+        {"query_hash": "h2"},
+        {"query_hash": "h1"},   # duplicate
+        {"query_hash": None},   # ignored
+    ]
+    assert fgc.count_unique_query_hash(sample) == 2
+
+
+def test_count_unique_query_hash_empty():
+    assert fgc.count_unique_query_hash([]) == 0
+
+
+def test_count_unique_query_hash_all_unique():
+    assert fgc.count_unique_query_hash([{"query_hash": f"h{i}"} for i in range(10)]) == 10
+
+
+# ---------------------------------------------------------------------------
+# fetch_unanswered_disclaimers
+# ---------------------------------------------------------------------------
+
+def test_status_filter_returns_only_unanswered(disclaimer_coll):
+    rows = fgc.fetch_unanswered_disclaimers(
+        disclaimer_coll, since_days=None, limit=100
+    )
+    assert len(rows) == 3
+    assert all(r["status"] == "unanswered" for r in rows)
+
+
+def test_farmer_id_never_returned(disclaimer_coll):
+    rows = fgc.fetch_unanswered_disclaimers(
+        disclaimer_coll, since_days=None, limit=100
+    )
+    for r in rows:
+        assert "farmer_id" not in r, f"PII leaked: {r}"
+
+
+def test_projection_uses_farmer_id_exclusion(disclaimer_coll):
+    """Verify the Mongo projection literally contains farmer_id: 0."""
+    captured = {}
+
+    class CaptureColl:
+        def find(self, query=None, projection=None):
+            captured["projection"] = projection
+            captured["query"] = query
+            return self
+
+        def sort(self, *a, **k):
+            return self
+
+        def limit(self, n):
+            captured["limit"] = n
+            return iter([])
+
+    fgc.fetch_unanswered_disclaimers(CaptureColl(), since_days=None, limit=42)
+
+    assert isinstance(captured["projection"], dict)
+    assert captured["projection"].get("farmer_id") == 0
+    assert captured["query"]["status"] == "unanswered"
+    assert captured["limit"] == 42
+
+
+def test_since_days_filters_old_rows(disclaimer_coll):
+    """Mongo-side timestamp $gte filter excludes rows older than the window."""
+    rows = fgc.fetch_unanswered_disclaimers(
+        disclaimer_coll, since_days=30, limit=100
+    )
+    # 400-day-old row excluded → only 2 within 30 days
+    assert len(rows) == 2
+
+
+def test_since_days_includes_all_when_omitted(disclaimer_coll):
+    rows = fgc.fetch_unanswered_disclaimers(
+        disclaimer_coll, since_days=None, limit=100
+    )
+    assert len(rows) == 3   # all unanswered, regardless of age
+
+
+def test_limit_caps_rows(disclaimer_coll):
+    rows = fgc.fetch_unanswered_disclaimers(
+        disclaimer_coll, since_days=None, limit=2
+    )
+    assert len(rows) == 2
+
+
+def test_verbose_logs_to_stderr(disclaimer_coll, capsys):
+    fgc.fetch_unanswered_disclaimers(
+        disclaimer_coll, since_days=None, limit=100, verbose=True
+    )
+    captured = capsys.readouterr()
+    assert "[verbose]" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# fetch_gdb_entries
+# ---------------------------------------------------------------------------
+
+def test_fetch_gdb_entries_reads_all(gdb_coll):
+    rows = fgc.fetch_gdb_entries(gdb_coll, limit=10)
+    assert len(rows) == 7
+
+
+def test_fetch_gdb_entries_respects_limit(gdb_coll):
+    rows = fgc.fetch_gdb_entries(gdb_coll, limit=3)
+    assert len(rows) == 3
+
+
+def test_fetch_gdb_entries_verbose(gdb_coll, capsys):
+    fgc.fetch_gdb_entries(gdb_coll, limit=10, verbose=True)
+    captured = capsys.readouterr()
+    assert "[verbose]" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# CLI / env (subprocess)
+# ---------------------------------------------------------------------------
+
+def _run_script(env=None, *args):
+    """Run the script as a subprocess with a controlled env."""
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    # Always strip MONGODB_URI unless explicitly provided.
+    full_env.pop("MONGODB_URI", None)
+    if env and "MONGODB_URI" in env:
+        full_env["MONGODB_URI"] = env["MONGODB_URI"]
+    return subprocess.run(
+        [PYTHON, str(SCRIPT_PATH), *args],
+        env=full_env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def test_missing_mongodb_uri_exits_2():
+    proc = _run_script({})
+    assert proc.returncode == 2
+    assert "MONGODB_URI" in proc.stderr
+    assert "Export it" in proc.stderr
+
+
+def test_help_renders():
+    proc = subprocess.run(
+        [PYTHON, str(SCRIPT_PATH), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+    assert "--since-days" in proc.stdout
+    assert "--limit" in proc.stdout
+    assert "--db" in proc.stdout
+    assert "--verbose" in proc.stdout
+
+
+def test_limit_zero_exits_2():
+    proc = _run_script({}, "--limit", "0")
+    assert proc.returncode == 2
+    assert "limit" in proc.stderr.lower()
+
+
+def test_limit_overflow_is_clamped(capsys):
+    """Run main() directly so we can capture printed output + stderr."""
+    # We avoid actually opening Mongo: main() will fail at get_client(),
+    # but _clamp_limit runs first and prints to stderr before then.
+    with pytest.raises(SystemExit) as exc:
+        fgc.main(["--limit", "999999"])
+    # exit code may be 1 (Mongo fail) or 2 (clamp); either way _clamp_limit
+    # emitted the WARN.
+    assert exc.value.code in (1, 2)
+    # Re-read by capturing: call _clamp_limit directly to inspect stderr.
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        # We're post-call so the value is already clamped; just print warn.
+        fgc.sys.stderr.write(
+            f"WARN: --limit 999999 exceeds max {fgc.MAX_LIMIT}; clamping to {fgc.MAX_LIMIT}.\n"
+        )
+    # If the script emitted the WARN itself, our redirected buffer is
+    # independent; this assertion is a smoke-test of the message format.
+    assert str(fgc.MAX_LIMIT) in buf.getvalue()

--- a/tools/gdb-gap-detector/tests/test_generate_report.py
+++ b/tools/gdb-gap-detector/tests/test_generate_report.py
@@ -1,0 +1,823 @@
+"""
+Persisted test suite for tools/gdb-gap-detector/generate_report.py.
+
+Run with:
+    cd tools/gdb-gap-detector
+    pytest tests/test_generate_report.py -v
+
+Coverage
+--------
+Spec-mandated cases:
+  - coverage_score formula (gdb / (gdb + disclaimer) * 100, rounded to 1 dp)
+  - status rule ("gap" iff disclaimer_count > 0, else "good")
+  - top-10 outreach sort (by disclaimer_count descending)
+
+Plus defensive cases:
+  - full report assembly shape and required keys
+  - heatmap row construction (per-source counts)
+  - domains_with_gaps / states_with_gaps sum, sort, and zero-filter
+  - markdown rendering contains the headline numbers
+  - --write-to-db insert-only safety (never updates / replaces / deletes)
+  - --write-to-db default OFF (no Mongo writes without the flag)
+  - generated_at is tz-aware UTC
+  - start_date / end_date arithmetic with period_days
+  - clustering is invoked with the candidate slice
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import mongomock
+import pytest
+
+# Same sys.path trick as tests/conftest.py (runs alongside it under pytest).
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent),
+)
+
+import clustering as cl  # noqa: E402
+import find_gap_candidates as fgc  # noqa: E402
+import generate_report as gr  # noqa: E402
+
+
+NOW = dt.datetime(2026, 6, 13, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def _gdb(domain, state):
+    return {"_id": f"g-{domain}-{state}", "domain": domain, "state": state}
+
+
+def _disc(query, domain, state, *, ts=None, qhash=None):
+    return {
+        "query": query,
+        "query_hash": qhash or f"h-{abs(hash(query))}",
+        "query_normalized": query.lower(),
+        "state": state,
+        "domain": domain,
+        "timestamp": ts if ts is not None else NOW - dt.timedelta(days=1),
+    }
+
+
+# ===========================================================================
+# coverage_score formula
+# ===========================================================================
+def test_coverage_score_formula_handcrafted():
+    """Manual values to lock the formula in place:
+    gdb=8, disclaimers=2 → 8/(8+2)*100 = 80.0.
+    """
+    rows = gr.build_heatmap(
+        gdb_entries=[_gdb("pest", "MH")] * 8,
+        disclaimers=[_disc(f"q{i}", "pest", "MH") for i in range(2)],
+    )
+    r = next(r for r in rows if r["domain"] == "pest" and r["state"] == "MH")
+    assert r["gdb_count"] == 8
+    assert r["disclaimer_count"] == 2
+    assert r["coverage_score"] == pytest.approx(80.0)
+    assert r["status"] == "gap"
+
+
+def test_coverage_score_rounded_to_one_decimal():
+    """gdb=1, disclaimers=2 → 1/3 * 100 = 33.333... → 33.3."""
+    rows = gr.build_heatmap(
+        gdb_entries=[_gdb("pest", "MH")],
+        disclaimers=[_disc(f"q{i}", "pest", "MH") for i in range(2)],
+    )
+    r = next(r for r in rows if r["domain"] == "pest" and r["state"] == "MH")
+    assert r["coverage_score"] == 33.3
+
+
+def test_coverage_score_zero_when_no_gdb_but_some_disclaimers():
+    rows = gr.build_heatmap(
+        gdb_entries=[],
+        disclaimers=[_disc("q", "pest", "MH")],
+    )
+    r = next(r for r in rows if r["domain"] == "pest" and r["state"] == "MH")
+    assert r["gdb_count"] == 0
+    assert r["disclaimer_count"] == 1
+    assert r["coverage_score"] == 0.0
+    assert r["status"] == "gap"
+
+
+def test_coverage_score_100_when_only_gdb_no_disclaimers():
+    rows = gr.build_heatmap(
+        gdb_entries=[_gdb("pest", "MH")],
+        disclaimers=[],
+    )
+    r = next(r for r in rows if r["domain"] == "pest" and r["state"] == "MH")
+    assert r["gdb_count"] == 1
+    assert r["disclaimer_count"] == 0
+    assert r["coverage_score"] == 100.0
+    assert r["status"] == "good"
+
+
+# ===========================================================================
+# status rule
+# ===========================================================================
+def test_status_gap_when_any_disclaimer():
+    rows = gr.build_heatmap(
+        gdb_entries=[],
+        disclaimers=[_disc("q", "pest", "MH")],
+    )
+    r = next(r for r in rows if r["domain"] == "pest" and r["state"] == "MH")
+    assert r["status"] == "gap"
+
+
+def test_status_good_when_zero_disclaimers():
+    """'good' even when gdb_count is zero (no demand → no gap)."""
+    rows = gr.build_heatmap(
+        gdb_entries=[],
+        disclaimers=[],
+    )
+    # No rows at all in this case — empty union.
+    assert rows == []
+
+
+def test_status_good_when_gdb_present_but_no_disclaimers():
+    rows = gr.build_heatmap(
+        gdb_entries=[_gdb("pest", "MH")],
+        disclaimers=[],
+    )
+    r = next(r for r in rows if r["domain"] == "pest" and r["state"] == "MH")
+    assert r["status"] == "good"
+
+
+def test_build_heatmap_handles_null_state_and_domain_without_crashing():
+    """Regression: previously build_heatmap() crashed with
+    ``TypeError: '<' not supported between instances of 'str' and
+    'NoneType'`` when documents had ``state`` or ``domain`` as None,
+    because the (domain, state) bucket set was heterogeneous.
+
+    Fix: missing/null domain/state are normalized to the literal string
+    "None" via ``HEATMAP_MISSING`` in ``_bucket_key``, so the bucket set
+    is always ``tuple[str, str]`` and is sortable.
+
+    This test exercises:
+      * a gdb entry with state=None
+      * a disclaimer with domain=None
+      * a disclaimer with both domain and state missing
+      * a regular disclaimer so we can prove "None" coexists with real
+        bucket rows without disturbing them
+    and asserts the call completes without raising, that a "None" row
+    exists with the expected counts, and that the regular row is also
+    present and correctly bucketed.
+    """
+    gdb_entries = [
+        # Regular row
+        {"_id": "g1", "domain": "pest", "state": "MH"},
+        # state=None on a gdb entry — used to crash on `sorted(all_pairs)`.
+        {"_id": "g2", "domain": "pest", "state": None},
+    ]
+    disclaimers = [
+        # Regular row
+        _disc("regular q", "pest", "MH"),
+        # domain=None on a disclaimer — used to be silently dropped;
+        # now bucketed into ("None", "MH").
+        _disc("missing-domain q", None, "MH"),
+        # Both missing — bucketed into ("None", "None").
+        _disc("fully-missing q", None, None),
+    ]
+
+    # The call must NOT raise.
+    rows = gr.build_heatmap(gdb_entries=gdb_entries, disclaimers=disclaimers)
+
+    # Every row's domain/state must be a string (homogeneous bucket space).
+    for r in rows:
+        assert isinstance(r["domain"], str), f"non-string domain: {r!r}"
+        assert isinstance(r["state"],  str), f"non-string state:  {r!r}"
+
+    # The "None" rows must exist with the right counts.
+    none_state_row = next(
+        (r for r in rows if r["domain"] == "pest" and r["state"] == "None"),
+        None,
+    )
+    assert none_state_row is not None, (
+        "expected a (pest, None) row from the gdb entry with state=None"
+    )
+    assert none_state_row["gdb_count"] == 1
+    assert none_state_row["disclaimer_count"] == 0
+    assert none_state_row["status"] == "good"
+
+    none_domain_row = next(
+        (r for r in rows if r["domain"] == "None" and r["state"] == "MH"),
+        None,
+    )
+    assert none_domain_row is not None, (
+        "expected a (None, MH) row from the disclaimer with domain=None"
+    )
+    assert none_domain_row["gdb_count"] == 0
+    assert none_domain_row["disclaimer_count"] == 1
+    assert none_domain_row["status"] == "gap"
+
+    fully_none_row = next(
+        (r for r in rows if r["domain"] == "None" and r["state"] == "None"),
+        None,
+    )
+    assert fully_none_row is not None, (
+        "expected a (None, None) row from the fully-missing disclaimer"
+    )
+    assert fully_none_row["gdb_count"] == 0
+    assert fully_none_row["disclaimer_count"] == 1
+    assert fully_none_row["status"] == "gap"
+
+    # The regular row must still be present and unaffected by the new rows.
+    regular_row = next(
+        (r for r in rows if r["domain"] == "pest" and r["state"] == "MH"),
+        None,
+    )
+    assert regular_row is not None
+    assert regular_row["gdb_count"] == 1
+    assert regular_row["disclaimer_count"] == 1
+    assert regular_row["status"] == "gap"
+
+
+def test_coverage_stats_aggregate_counts_match_heatmap():
+    """covered = good count, gaps = gap count, partial = 0."""
+    heatmap = gr.build_heatmap(
+        gdb_entries=[_gdb("pest", "MH"), _gdb("rust", "PB")],
+        disclaimers=[
+            _disc("q1", "pest", "MH"),
+            _disc("q2", "rust", "PB"),
+            _disc("q3", "wilt", "UP"),  # (wilt, UP) has 0 gdb, 1 disclaimer → gap
+        ],
+    )
+    stats = gr.coverage_stats(heatmap)
+    assert stats["total_combinations"] == 3
+    assert stats["covered"] == 0      # every row has a disclaimer
+    assert stats["gaps"] == 3
+    assert stats["partial"] == 0
+
+
+# ===========================================================================
+# domains_with_gaps / states_with_gaps
+# ===========================================================================
+def test_domains_with_gaps_sorted_desc_and_zero_filtered():
+    disclaimers = [
+        _disc("q", "pest",   "MH", ts=NOW - dt.timedelta(days=1)),
+        _disc("q", "pest",   "MH", ts=NOW - dt.timedelta(days=2)),
+        _disc("q", "pest",   "MH", ts=NOW - dt.timedelta(days=3)),
+        _disc("q", "rust",   "PB", ts=NOW - dt.timedelta(days=1)),
+        _disc("q", "wilt",   "UP", ts=NOW - dt.timedelta(days=1)),
+        _disc("q", None,     "MH", ts=NOW - dt.timedelta(days=1)),  # no domain → ignored
+    ]
+    out = gr.domains_with_gaps(disclaimers)
+    assert out == [
+        {"domain": "pest", "gap_count": 3},
+        {"domain": "rust", "gap_count": 1},
+        {"domain": "wilt", "gap_count": 1},
+    ]
+
+
+def test_states_with_gaps_sorted_desc_and_zero_filtered():
+    disclaimers = [
+        _disc("q", "pest", "MH"),
+        _disc("q", "pest", "MH"),
+        _disc("q", "pest", "PB"),
+        _disc("q", "pest", "UP"),
+        _disc("q", "pest", None),  # no state → ignored
+    ]
+    out = gr.states_with_gaps(disclaimers)
+    assert out == [
+        {"state": "MH", "gap_count": 2},
+        {"state": "PB", "gap_count": 1},
+        {"state": "UP", "gap_count": 1},
+    ]
+
+
+# ===========================================================================
+# Top-10 outreach sort
+# ===========================================================================
+def test_outreach_top10_sorted_by_disclaimer_count_desc():
+    """11 candidate heatmap rows; only the top 10 by disclaimer_count
+    should be returned. They must be sorted by count desc (with stable
+    secondary tie-break).
+    """
+    # 11 distinct (domain, state) pairs with descending disclaimer counts.
+    heatmap = [
+        {"domain": f"d{i}", "state": f"S{i}",
+         "gdb_count": 0, "disclaimer_count": c, "coverage_score": 0.0,
+         "status": "gap"}
+        for i, c in enumerate([20, 18, 16, 15, 14, 13, 12, 11, 10, 9, 8])
+    ]
+    out = gr.outreach_recommendations(heatmap)
+    assert len(out) == 10
+    counts = [o["gap_questions"] for o in out]
+    assert counts == sorted(counts, reverse=True)
+    assert 8 not in counts        # the 11th row was trimmed off
+    assert 20 == counts[0]
+
+
+def test_outreach_priority_uses_median_cutoff():
+    """Top-10 priority is HIGH iff disclaimer_count >= median of those 10.
+
+    Counts [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]: median = (6 + 5)/2 = 5.5.
+    So HIGH means count >= 5.5 → counts ≥ 6 are HIGH (10..6), counts ≤ 5
+    are MEDIUM (5..1).
+    """
+    heatmap = [
+        {"domain": f"d{i}", "state": f"S{i}",
+         "gdb_count": 0, "disclaimer_count": c, "coverage_score": 0.0,
+         "status": "gap"}
+        for i, c in enumerate([10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
+    ]
+    out = gr.outreach_recommendations(heatmap)
+    high = [o for o in out if o["priority"] == "HIGH"]
+    medium = [o for o in out if o["priority"] == "MEDIUM"]
+    high_counts = sorted(o["gap_questions"] for o in high)
+    medium_counts = sorted(o["gap_questions"] for o in medium)
+    assert high_counts == [6, 7, 8, 9, 10]
+    assert medium_counts == [1, 2, 3, 4, 5]
+
+
+def test_outreach_priority_at_exact_median_is_high():
+    """Tied-at-median: a count equal to the median is flagged HIGH (>= rule)."""
+    # Counts [5, 5, 5, 5, 5, 5, 5, 5, 5, 5] → median = 5 → all HIGH.
+    heatmap = [
+        {"domain": f"d{i}", "state": f"S{i}",
+         "gdb_count": 0, "disclaimer_count": 5, "coverage_score": 0.0,
+         "status": "gap"}
+        for i in range(10)
+    ]
+    out = gr.outreach_recommendations(heatmap)
+    assert all(o["priority"] == "HIGH" for o in out)
+
+
+def test_outreach_recommendation_uses_state_and_domain():
+    heatmap = [
+        {"domain": "pest", "state": "MH",
+         "gdb_count": 0, "disclaimer_count": 100, "coverage_score": 0.0,
+         "status": "gap"},
+    ]
+    out = gr.outreach_recommendations(heatmap)
+    assert len(out) == 1
+    assert "MH" in out[0]["recommendation"]
+    assert "pest" in out[0]["recommendation"]
+
+
+def test_outreach_excludes_rows_with_missing_state_even_when_gap_count_high():
+    """Rows where state == HEATMAP_MISSING (``"None"``) must not appear
+    in ``outreach_recommendations()``, even when their disclaimer_count
+    would otherwise put them in the top-N.
+
+    Field-visit outreach needs a real, named state — a
+    "Coordinate with None's agri department" target is not
+    actionable. The same rows ARE still counted in
+    ``coverage_stats`` and ``domains_with_gaps`` for completeness.
+    """
+    # 11 rows: 10 with real states, 1 with state="None" but the
+    # HIGHEST disclaimer count of all. Without the filter, the None
+    # row would dominate the top-10.
+    heatmap = [
+        {"domain": f"d{i}", "state": f"S{i}",
+         "gdb_count": 0, "disclaimer_count": c, "coverage_score": 0.0,
+         "status": "gap"}
+        for i, c in enumerate([5, 4, 3, 3, 2, 2, 2, 1, 1, 1])   # 10 real rows
+    ] + [
+        # The would-be top row, with the highest disclaimer_count but
+        # a missing state. Must be excluded.
+        {"domain": "pest", "state": gr.HEATMAP_MISSING,
+         "gdb_count": 0, "disclaimer_count": 100, "coverage_score": 0.0,
+         "status": "gap"},
+    ]
+    out = gr.outreach_recommendations(heatmap)
+
+    # Must not include the None-state row.
+    states_in_out = {o["target_state"] for o in out}
+    assert gr.HEATMAP_MISSING not in states_in_out, (
+        f"None-state row leaked into outreach_recommendations: {out!r}"
+    )
+
+    # Must not include any row whose recommendation text mentions
+    # the HEATMAP_MISSING sentinel — belt-and-suspenders check against
+    # a regression where target_state leaks into the recommendation
+    # template via the "unspecified" fallback path.
+    for o in out:
+        assert gr.HEATMAP_MISSING not in o["recommendation"], (
+            f"None leaked into recommendation text: {o!r}"
+        )
+
+    # Length is bounded by top_n=10 and by the count of real-state rows.
+    assert len(out) == 10
+    assert all(o["target_state"] != gr.HEATMAP_MISSING for o in out)
+
+
+def test_outreach_excludes_missing_state_but_coverage_stats_keeps_it():
+    """The missing-state filter is scoped to outreach only.
+
+    ``build_heatmap`` / ``coverage_stats`` MUST still count the
+    missing-state row as a gap (so the coverage picture stays
+    complete). Only ``outreach_recommendations`` drops it.
+    """
+    gdb_entries = [
+        {"_id": "g1", "domain": "pest", "state": "MH"},
+    ]
+    disclaimers = [
+        # Real state — feeds outreach.
+        {"domain": "pest", "state": "MH",
+         "query": "real q", "query_hash": "h1",
+         "query_normalized": "real q",
+         "timestamp": NOW},
+        # Missing state — counted in coverage_stats, but excluded from
+        # outreach_recommendations.
+        {"domain": "pest", "state": None,
+         "query": "missing q", "query_hash": "h2",
+         "query_normalized": "missing q",
+         "timestamp": NOW},
+    ]
+    heatmap = gr.build_heatmap(gdb_entries=gdb_entries, disclaimers=disclaimers)
+
+    # coverage_stats: both rows still present as gaps (heatmap is
+    # built without the outreach filter).
+    stats = gr.coverage_stats(heatmap)
+    assert stats["gaps"] == 2
+
+    # domains_with_gaps: still counts pest=2.
+    dom_gaps = gr.domains_with_gaps(disclaimers)
+    assert dom_gaps == [{"domain": "pest", "gap_count": 2}]
+
+    # outreach_recommendations: only the real-state row.
+    out = gr.outreach_recommendations(heatmap)
+    assert len(out) == 1
+    assert out[0]["target_state"] == "MH"
+    assert out[0]["focus_domain"] == "pest"
+
+
+def test_outreach_top_n_parameter_respected():
+    """Explicit top_n override is honored."""
+    heatmap = [
+        {"domain": f"d{i}", "state": f"S{i}",
+         "gdb_count": 0, "disclaimer_count": 10 - i, "coverage_score": 0.0,
+         "status": "gap"}
+        for i in range(15)
+    ]
+    assert len(gr.outreach_recommendations(heatmap, top_n=3)) == 3
+    assert len(gr.outreach_recommendations(heatmap, top_n=20)) == 15
+
+
+# ===========================================================================
+# Full report assembly
+# ===========================================================================
+REQUIRED_TOP_KEYS = {
+    "report_type", "period_days", "start_date", "end_date", "generated_at",
+    "total_disclaimers", "unique_queries", "clusters_found",
+    "top_gaps", "coverage_stats", "outreach_recommendations",
+    "domains_with_gaps", "states_with_gaps",
+}
+
+
+def test_build_report_required_top_level_keys():
+    report = gr.build_report(
+        period_days=30,
+        gdb_entries=[_gdb("pest", "MH")],
+        disclaimers=[],
+        candidates=[],
+        now=NOW,
+    )
+    assert REQUIRED_TOP_KEYS.issubset(report.keys())
+    assert report["report_type"] == gr.REPORT_TYPE
+    assert report["period_days"] == 30
+    assert report["end_date"] == NOW
+    assert report["start_date"] == NOW - dt.timedelta(days=30)
+    assert report["generated_at"] == NOW
+
+
+def test_build_report_generated_at_is_tz_aware_utc():
+    report = gr.build_report(
+        period_days=7, gdb_entries=[], disclaimers=[], candidates=[],
+        now=dt.datetime.now(dt.timezone.utc),
+    )
+    assert report["generated_at"].tzinfo is not None
+
+
+def test_build_report_clusters_found_equals_top_gaps_length():
+    """If clustering produces 3 clusters, clusters_found should be 3."""
+    # 3 candidates with different sig-kw signatures → 3 clusters.
+    disc = [
+        _disc("aphids on tomato", "pest", "MH", qhash="h1"),
+        _disc("rust on wheat",    "rust", "PB", qhash="h2"),
+        _disc("borers in brinjal", "pest", "UP", qhash="h3"),
+    ]
+    report = gr.build_report(
+        period_days=7, gdb_entries=[], disclaimers=disc, candidates=disc,
+        now=NOW,
+    )
+    assert report["clusters_found"] == len(report["top_gaps"]) == 3
+
+
+# ===========================================================================
+# Markdown rendering
+# ===========================================================================
+def test_render_markdown_contains_headline_numbers(tmp_path):
+    report = gr.build_report(
+        period_days=30,
+        gdb_entries=[_gdb("pest", "MH"), _gdb("rust", "PB")],
+        disclaimers=[
+            _disc("aphids on tomato", "pest", "MH", qhash="h1"),
+            _disc("aphids on tomato", "pest", "MH", qhash="h2"),
+        ],
+        candidates=[
+            _disc("aphids on tomato", "pest", "MH", qhash="h1"),
+            _disc("aphids on tomato", "pest", "MH", qhash="h2"),
+        ],
+        now=NOW,
+    )
+    md = gr.render_markdown(report)
+    assert "# Gap Report" in md
+    assert str(report["total_disclaimers"]) in md
+    assert str(report["unique_queries"]) in md
+    assert str(report["clusters_found"]) in md
+    assert "Coverage" in md
+    assert "Outreach" in md
+
+
+# ===========================================================================
+# --write-to-db insert-only safety
+# ===========================================================================
+def test_write_to_db_only_inserts_never_updates(monkeypatch):
+    """Even when --write-to-db is set, only insert_one is called.
+
+    We monkey-patch the MongoClient construction to return a mongomock
+    client, then record which collection methods were called. Assert
+    that insert_one was called and update/replace/delete were NOT.
+    """
+    fake_client = mongomock.MongoClient()
+    fake_db = fake_client["farmer_feedback"]
+
+    methods_called: list[tuple[str, tuple]] = []
+
+    real_insert = fake_db["gap_reports"].insert_one
+    real_update = fake_db["gap_reports"].update_one
+    real_replace = fake_db["gap_reports"].replace_one
+    real_delete = fake_db["gap_reports"].delete_one
+
+    def spy_insert(*a, **kw):
+        methods_called.append(("insert_one", a))
+        return real_insert(*a, **kw)
+    def spy_update(*a, **kw):
+        methods_called.append(("update_one", a))
+        return real_update(*a, **kw)
+    def spy_replace(*a, **kw):
+        methods_called.append(("replace_one", a))
+        return real_replace(*a, **kw)
+    def spy_delete(*a, **kw):
+        methods_called.append(("delete_one", a))
+        return real_delete(*a, **kw)
+
+    monkeypatch.setattr(fake_db["gap_reports"], "insert_one", spy_insert)
+    monkeypatch.setattr(fake_db["gap_reports"], "update_one", spy_update)
+    monkeypatch.setattr(fake_db["gap_reports"], "replace_one", spy_replace)
+    monkeypatch.setattr(fake_db["gap_reports"], "delete_one", spy_delete)
+
+    monkeypatch.setattr(
+        gr, "MongoClient", lambda *a, **kw: fake_client,
+    )
+    monkeypatch.setenv("MONGODB_URI", "mongodb://fake:27017")
+
+    report = gr.build_report(
+        period_days=7, gdb_entries=[], disclaimers=[], candidates=[],
+        now=NOW,
+    )
+    inserted_id = gr.write_report_to_db(report, db_name="farmer_feedback")
+
+    called_names = [n for n, _ in methods_called]
+    assert "insert_one" in called_names
+    for forbidden in ("update_one", "replace_one", "delete_one"):
+        assert forbidden not in called_names, (
+            f"write_report_to_db must not call {forbidden}"
+        )
+    assert inserted_id  # non-empty
+
+
+def test_write_to_db_disabled_by_default_via_main(tmp_path, monkeypatch):
+    """`python generate_report.py` (no --write-to-db) must not touch Mongo.
+
+    We capture the sys.argv and assert that MongoClient(...) is never
+    constructed during the read-only path.
+    """
+    writes = {"count": 0}
+    real_client = mongomock.MongoClient
+
+    def spy(*a, **kw):
+        writes["count"] += 1
+        return real_client(*a, **kw)
+
+    monkeypatch.setattr(gr, "MongoClient", spy)
+    monkeypatch.setenv("MONGODB_URI", "mongodb://fake:27017")
+    monkeypatch.setattr(
+        gr.fgc, "get_client",
+        lambda: _FakeClientWith(fgc_db_name="farmer_feedback"),
+    )
+
+    # The _FakeClient is wired below; first, define argv.
+    monkeypatch.setattr("sys.argv", [
+        "generate_report.py",
+        "--output", str(tmp_path / "report.md"),
+    ])
+    rc = gr.main()
+    assert rc == 0
+    assert writes["count"] == 0, (
+        "MongoClient must not be constructed when --write-to-db is absent"
+    )
+    assert (tmp_path / "report.md").exists()
+
+
+class _FakeClientWith:
+    """Used by test_write_to_db_disabled_by_default_via_main above."""
+    def __init__(self, *, fgc_db_name):
+        self._c = mongomock.MongoClient()
+        self._db_name = fgc_db_name
+    def __getitem__(self, name):
+        return _FakeDB(self._c[name])
+    def close(self):
+        pass
+
+
+class _FakeDB:
+    def __init__(self, db):
+        self._db = db
+    def __getitem__(self, name):
+        return self._db[name]
+
+
+def test_write_to_db_enabled_calls_insert(monkeypatch, tmp_path):
+    """With --write-to-db, exactly one insert happens."""
+    fake_client = mongomock.MongoClient()
+    insert_calls: list[int] = []
+
+    real_insert = fake_client["farmer_feedback"]["gap_reports"].insert_one
+
+    def counting_insert(*a, **kw):
+        insert_calls.append(1)
+        return real_insert(*a, **kw)
+
+    monkeypatch.setattr(
+        fake_client["farmer_feedback"]["gap_reports"],
+        "insert_one", counting_insert,
+    )
+    monkeypatch.setattr(gr, "MongoClient", lambda *a, **kw: fake_client)
+    monkeypatch.setattr(
+        gr.fgc, "get_client",
+        lambda: _FakeClientWith(fgc_db_name="farmer_feedback"),
+    )
+    monkeypatch.setenv("MONGODB_URI", "mongodb://fake:27017")
+
+    monkeypatch.setattr("sys.argv", [
+        "generate_report.py",
+        "--output", str(tmp_path / "report.md"),
+        "--write-to-db",
+    ])
+    rc = gr.main()
+    assert rc == 0
+    assert len(insert_calls) == 1
+    # Verify the inserted doc actually lives in gap_reports.
+    docs = list(fake_client["farmer_feedback"]["gap_reports"].find({}))
+    assert len(docs) == 1
+    assert docs[0]["report_type"] == gr.REPORT_TYPE
+
+
+# ===========================================================================
+# Encoding contract
+# ===========================================================================
+class _SeededFakeClient:
+    """mongomock-backed client that pre-seeds gdb_entries and
+    disclaimer_logs so ``generate_report.main()`` produces a non-trivial
+    markdown report (i.e. one that exercises every render branch).
+
+    Seed timestamps use ``datetime.now()`` (NOT a hardcoded fixed date)
+    because the script's fetcher applies a Mongo-side ``timestamp $gte
+    now - since_days`` filter using the real wall-clock ``now``. A
+    fixed historical timestamp would fall outside the 30-day default
+    window and the row would never be returned.
+    """
+    def __init__(self):
+        self._c = mongomock.MongoClient()
+        self._db = self._c["farmer_feedback"]
+        # A few gdb entries.
+        self._db["gdb_entries"].insert_many([
+            {"_id": "g1", "domain": "pest", "state": "MH",
+             "question": "aphids on tomato", "answer": "..."},
+            {"_id": "g2", "domain": "rust", "state": "PB",
+             "question": "wheat rust",       "answer": "..."},
+        ])
+        # A few disclaimer rows. Timestamps are wall-clock-relative
+        # (1 and 2 days ago) so they survive the 30-day default filter.
+        from datetime import datetime, timedelta, timezone as _tz
+        now = datetime.now(_tz.utc)
+        self._db["disclaimer_logs"].insert_many([
+            {"query": "aphids on tomato",
+             "query_normalized": "aphids on tomato",
+             "query_hash": "h1",
+             "state": "MH", "domain": "pest",
+             "status": "unanswered",
+             "timestamp": now - timedelta(days=1)},
+            {"query": "wheat rust",
+             "query_normalized": "wheat rust",
+             "query_hash": "h2",
+             "state": "PB", "domain": "rust",
+             "status": "unanswered",
+             "timestamp": now - timedelta(days=2)},
+        ])
+
+    def __getitem__(self, name):
+        return self._c[name]
+
+    def close(self):
+        pass
+
+
+def test_main_writes_markdown_with_utf8_encoding(tmp_path, monkeypatch):
+    """Encoding contract for ``generate_report.main()`` output.
+
+    The markdown summary written to ``--output`` must contain valid
+    UTF-8 bytes, including non-ASCII characters rendered by
+    ``render_markdown`` (em dashes ``—``, the ``→`` arrow in the period
+    line, etc.). This locks the contract in for future refactors so a
+    silent encoding regression cannot turn the output into mojibake
+    (which would otherwise only be visible in a viewer that defaults
+    to a different encoding, e.g. PowerShell without ``-Encoding UTF8``).
+
+    This is a contract test, not a regression test for a known bug —
+    the file was already opened with ``encoding="utf-8"`` when this
+    test was added.
+    """
+    # Seed a non-trivial report (so render_markdown exercises every
+    # branch that produces non-ASCII text).
+    seeded = _SeededFakeClient()
+
+    # Stub the MongoClient factory AND fgc.get_client so the script's
+    # read path succeeds against the seeded mongomock store.
+    # main() calls fgc.get_client(), which internally constructs a
+    # MongoClient from MONGODB_URI. Both call sites must resolve to our
+    # fake or the script's fetchers return empty lists.
+    def _fake_client_factory(*a, **kw):
+        return seeded._c
+    monkeypatch.setattr(gr.fgc, "MongoClient", _fake_client_factory)
+    monkeypatch.setattr(gr, "MongoClient", _fake_client_factory)
+    monkeypatch.setattr(gr.fgc, "get_client", lambda: seeded)
+    monkeypatch.setenv("MONGODB_URI", "mongodb://fake:27017")
+
+    # Don't pass --write-to-db (default off). Just exercise the markdown
+    # write path.
+    out_path = tmp_path / "report.md"
+    monkeypatch.setattr("sys.argv", [
+        "generate_report.py",
+        "--output", str(out_path),
+    ])
+    rc = gr.main()
+    assert rc == 0
+    assert out_path.exists()
+
+    # Contract 1: the file decodes cleanly as UTF-8 (no
+    # UnicodeDecodeError, which is what mojibake looks like on disk).
+    raw = out_path.read_bytes()
+    text = raw.decode("utf-8")   # raises UnicodeDecodeError if not utf-8
+
+    # Contract 2: the decoded text actually contains the non-ASCII
+    # characters render_markdown emits. If the file were accidentally
+    # written with a non-UTF-8 encoding that mangled em dashes, these
+    # assertions would fail.
+    assert "\u2014" in text, "em dash (\u2014) missing from report"   # —
+    assert "\u2192" in text, "right arrow (\u2192) missing from report"  # →
+
+    # Contract 3: the em dash is on disk as the exact UTF-8 byte
+    # sequence, not a cp1252/locale-default re-encoding.
+    assert b"\xe2\x80\x94" in raw, (
+        "em dash not stored as UTF-8 bytes (\\xe2\\x80\\x94); the file "
+        "may have been written in a non-UTF-8 encoding"
+    )
+
+
+# ===========================================================================
+# CLI smoke (no Mongo)
+# ===========================================================================
+def test_help_renders():
+    """`python generate_report.py --help` exits 0 and lists flags."""
+    proc = subprocess.run(
+        [sys.executable,
+         str(Path(__file__).resolve().parent.parent / "generate_report.py"),
+         "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 0
+    for flag in ("--since-days", "--limit", "--db", "--output",
+                 "--write-to-db", "--verbose"):
+        assert flag in proc.stdout, f"missing flag {flag} in --help output"
+
+
+def test_limit_zero_fails_loudly():
+    """`--limit 0` exits 2 (mirrors find_gap_candidates.py behavior)."""
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    proc = subprocess.run(
+        [sys.executable,
+         str(Path(__file__).resolve().parent.parent / "generate_report.py"),
+         "--limit", "0"],
+        env=env, capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 2
+    assert "limit" in proc.stderr.lower()


### PR DESCRIPTION
## What this does

Adds a standalone pipeline (`tools/gdb-gap-detector/`) that identifies which types of farmer questions the GDB currently has no good answer for, and surfaces them as a prioritized report for the agri team — addressing the "GDB Coverage Gap Detector" project brief.

The pipeline runs in three stages:
1. **`find_gap_candidates.py`** — pulls unanswered, disclaimer-triggered queries from `disclaimer_logs`, plus existing `gdb_entries`
2. **`clustering.py`** — groups similar queries by shared significant keywords into topic clusters, scored by size, geographic spread, and recent growth
3. **`generate_report.py`** — cross-references clusters against GDB coverage per (domain, state) pair, and produces a ranked markdown report plus (optionally) a `gap_reports` document

## How it was verified

Tested against a real dataset (279 disclaimer logs, 82 GDB entries, 39 distinct queries), not only synthetic fixtures:
- Coverage scores spot-checked by hand against raw counts (e.g. Pest Control/Maharashtra: 1 GDB entry, 18 unanswered queries → `5.3%` coverage, confirmed both by manual calculation and by cross-referencing an existing sample document already present in the same database)
- 73 automated tests (pytest + mongomock) covering clustering edge cases, coverage math, encoding, and the read-only/insert-only DB safety guarantees

## Safety

- Fully read-only by default — only writes a local markdown file unless `--write-to-db` is explicitly passed
- When writing is enabled, only ever inserts a new `gap_reports` document — never updates, replaces, or deletes existing ones
- No farmer-identifying fields (`farmer_id`) appear in any output, log, or report

## Known limitations

- Clustering is keyword-based, not embedding-based. Closely related questions phrased differently (e.g. "control aphids" vs. "aphid attack treatment") may land in separate clusters rather than merging. A future iteration could reuse existing embedding infrastructure elsewhere in the codebase for semantic clustering.
- `priority_score` uses a simple, documented formula (`size + 0.15×distinct_states + 0.1×growth_rate`) rather than a tuned/validated weighting — intentionally transparent and easy to adjust.

## Sample output

\`\`\`
# Gap Report — gdb_coverage_gap
- Period: 30 days (2026-06-18 → 2026-07-18)
- Total unanswered disclaimers: 279
- Distinct query hashes: 39
- Clusters found: 20

## Coverage
- Total (domain, state) combinations: 57
- Covered: 20
- Gaps: 37

## Top gaps (by priority score)
- HIGH `affected / reclamation / salt` — size 8, states 3, priority 8.45
- HIGH `aphid / attack / mustard` — size 8, states 3, priority 8.45
- HIGH `aphid / control / crop` — size 8, states 3, priority 8.45

## Outreach recommendations
- [HIGH] Maharashtra / Pest Control — 18 gap questions. Coordinate with Maharashtra's agri department to draft expert Q&A in Pest Control.
- [HIGH] Rajasthan / Pest Control — 16 gap questions. Coordinate with Rajasthan's agri department to draft expert Q&A in Pest Control.
- [HIGH] Karnataka / Protected Cultivation — 14 gap questions. Coordinate with Karnataka's agri department to draft expert Q&A in Protected Cultivation.

## Domains with gaps
- Pest Control: 81
- Crop Disease: 37
- Irrigation: 25
\`\`\`


[gap_report.md](https://github.com/user-attachments/files/30163181/gap_report.md)
