### PR TITLE
Add short and full answer output to LangGraph

### DIFF
--- a/ai/.env.example
+++ b/ai/.env.example
@@ -67,3 +67,11 @@ GOLDEN_TIE_BREAK_MIN=2
 
 # Reviewer question channel when LangGraph configurable.question_source is not set
 QUESTION_SOURCE=AJRASAKHA
+
+# Answer Shortener service (LangGraph sends the final translated answer here).
+# Set this only when the remote API enables X-API-Key authentication. It is
+# intentionally separate from the shortener service's own runtime secret.
+ANSWER_SHORTENER_BASE_URL=http://127.0.0.1:8009
+ANSWER_SHORTENER_CLIENT_API_KEY=
+ANSWER_SHORTENER_TARGET_CHARACTERS=1500
+ANSWER_SHORTENER_TIMEOUT_SECONDS=15

--- a/ai/ajrasakha/agents/ajrasakha.py
+++ b/ai/ajrasakha/agents/ajrasakha.py
@@ -46,8 +46,9 @@ from ajrasakha.agents.prompts import (
     WARNING_TEXT,
     WHATSAPP_SYSTEM_PROMPT,
 )
-from ajrasakha.agents.state import AjraSakhaState, Location
+from ajrasakha.agents.state import AjraSakhaState, Location, TRANSLATE_PATH_EMPTY_GDB
 from ajrasakha.agents.assemble_answer_body import assemble_answer_body_node
+from ajrasakha.agents.answer_shortener import answer_shortener_node
 from ajrasakha.agents.non_agriculture_reply import non_agriculture_reply_node
 from ajrasakha.agents.weather_unavailable_reply import weather_unavailable_reply_node
 from ajrasakha.agents.tool_registry import get_main_tool_node
@@ -209,6 +210,20 @@ async def tools_node(state: AjraSakhaState, config: RunnableConfig) -> dict:
 def route_after_tools_planner(state: AjraSakhaState) -> str:
     """After execute_plan: assemble body, translate, or empty GDB catalog path."""
     return route_after_execute(state)
+
+
+def route_after_translate_answer(state: AjraSakhaState) -> str:
+    """Shorten final answers, but leave expert-queue acknowledgements unchanged.
+
+    Both normal LangGraph syntheses and direct expert-reviewed answers pass through
+    ``translate_answer`` before they become farmer-facing. The empty-GDB route is
+    different: it is only a notice that an expert answer is pending, not an answer
+    that should receive a short/full representation.
+    """
+    plan = state.get("plan") or {}
+    if plan.get("translate_path") == TRANSLATE_PATH_EMPTY_GDB:
+        return "end"
+    return "answer_shortener"
 
 
 def _tool_message_text(message: ToolMessage) -> str:
@@ -400,6 +415,7 @@ def sanitize_answer_node(state: AjraSakhaState) -> dict:
 def _build_graph():
     builder = StateGraph(AjraSakhaState)
     builder.add_node("empty_gdb_reply", with_thread_logging(empty_gdb_reply_node))
+    builder.add_node("answer_shortener", with_thread_logging(answer_shortener_node))
     # builder.add_node("sanitize_answer", sanitize_answer_node)  # disabled: 2-hour disclaimer post-process
 
     if use_planner_graph():
@@ -447,11 +463,16 @@ def _build_graph():
         )
         builder.add_edge("weather_unavailable_reply", END)
         builder.add_edge("assemble_answer_body", "translate_answer")
-        builder.add_edge("translate_answer", END)
+        builder.add_conditional_edges(
+            "translate_answer",
+            route_after_translate_answer,
+            {"answer_shortener": "answer_shortener", "end": END},
+        )
         builder.add_edge("empty_gdb_reply", "translate_answer")
         # builder.add_edge("translate_answer", "sanitize_answer")
     else:
         builder.add_edge("empty_gdb_reply", END)
+    builder.add_edge("answer_shortener", END)
     # builder.add_edge("sanitize_answer", END)
     return builder.compile()
 

--- a/ai/ajrasakha/agents/answer_shortener.py
+++ b/ai/ajrasakha/agents/answer_shortener.py
@@ -1,0 +1,173 @@
+"""Final-answer integration with the AjraSakha answer-shortener service."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.runnables import RunnableConfig
+
+from ajrasakha.agents.state import AjraSakhaState
+
+
+logger = logging.getLogger(__name__)
+
+
+class AnswerShortenerError(RuntimeError):
+    """The shortener service could not provide a usable response."""
+
+
+@dataclass(frozen=True)
+class AnswerShortenerSettings:
+    base_url: str
+    api_key: str
+    target_characters: int
+    timeout_seconds: float
+
+
+def _read_positive_int(name: str, default: int) -> int:
+    raw = os.getenv(name, str(default)).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise AnswerShortenerError(f"{name} must be an integer") from exc
+    if value < 1:
+        raise AnswerShortenerError(f"{name} must be positive")
+    return value
+
+
+def _read_positive_float(name: str, default: float) -> float:
+    raw = os.getenv(name, str(default)).strip()
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise AnswerShortenerError(f"{name} must be a number") from exc
+    if value <= 0:
+        raise AnswerShortenerError(f"{name} must be positive")
+    return value
+
+
+def _shortener_settings() -> AnswerShortenerSettings | None:
+    base_url = os.getenv("ANSWER_SHORTENER_BASE_URL", "").strip().rstrip("/")
+    if not base_url:
+        return None
+    return AnswerShortenerSettings(
+        base_url=base_url,
+        api_key=os.getenv("ANSWER_SHORTENER_CLIENT_API_KEY", "").strip(),
+        target_characters=_read_positive_int("ANSWER_SHORTENER_TARGET_CHARACTERS", 1500),
+        timeout_seconds=_read_positive_float("ANSWER_SHORTENER_TIMEOUT_SECONDS", 15.0),
+    )
+
+
+def _message_text(message: BaseMessage) -> str:
+    content = message.content
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return " ".join(parts).strip()
+    return str(content or "").strip()
+
+
+def _last_human_query(messages: list[BaseMessage]) -> str:
+    for message in reversed(messages):
+        if isinstance(message, HumanMessage):
+            return _message_text(message)
+    return ""
+
+
+def _last_farmer_answer(messages: list[BaseMessage]) -> str:
+    for message in reversed(messages):
+        if isinstance(message, AIMessage) and not getattr(message, "tool_calls", None):
+            return _message_text(message)
+    return ""
+
+
+async def _request_shortening(
+    settings: AnswerShortenerSettings,
+    *,
+    original_query: str,
+    answer: str,
+) -> dict[str, Any]:
+    headers = {"X-API-Key": settings.api_key} if settings.api_key else {}
+    payload = {
+        "original_query": original_query,
+        "answer": answer,
+        "expected_character_count": settings.target_characters,
+    }
+    timeout = aiohttp.ClientTimeout(total=settings.timeout_seconds)
+    url = f"{settings.base_url}/v1/answers/shorten"
+
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, json=payload, headers=headers) as response:
+                if response.status != 200:
+                    raise AnswerShortenerError(f"shortener returned HTTP {response.status}")
+                data = await response.json(content_type=None)
+    except (aiohttp.ClientError, TimeoutError) as exc:
+        raise AnswerShortenerError("shortener request failed") from exc
+
+    if not isinstance(data, dict) or not isinstance(data.get("short_answer"), str):
+        raise AnswerShortenerError("shortener response is missing short_answer")
+    return data
+
+
+def _fallback(full_answer: str, status: str) -> dict[str, str]:
+    return {
+        "short_answer": full_answer,
+        "full_answer": full_answer,
+        "answer_shortening_status": status,
+    }
+
+
+async def answer_shortener_node(
+    state: AjraSakhaState,
+    config: RunnableConfig,
+) -> dict[str, str]:
+    """Attach a source-only short answer without changing graph messages.
+
+    The graph must remain usable if this optional downstream service is down,
+    misconfigured, or cannot shorten a particular response. In every fallback,
+    callers receive the original final answer in both fields.
+    """
+
+    del config  # Node behavior is configured through service environment values.
+    messages = state.get("messages") or []
+    full_answer = _last_farmer_answer(messages)
+    if not full_answer:
+        return _fallback("", "fallback_no_final_answer")
+
+    original_query = _last_human_query(messages)
+    if not original_query:
+        return _fallback(full_answer, "fallback_no_original_query")
+
+    try:
+        settings = _shortener_settings()
+        if settings is None:
+            return _fallback(full_answer, "fallback_shortener_not_configured")
+        response = await _request_shortening(
+            settings,
+            original_query=original_query,
+            answer=full_answer,
+        )
+    except AnswerShortenerError as exc:
+        logger.warning("answer shortener unavailable; returning full answer (%s)", exc)
+        return _fallback(full_answer, "fallback_shortener_unavailable")
+    except Exception:
+        logger.exception("answer shortener failed unexpectedly; returning full answer")
+        return _fallback(full_answer, "fallback_shortener_unavailable")
+
+    return {
+        "short_answer": response["short_answer"],
+        "full_answer": full_answer,
+        "answer_shortening_status": str(response.get("status") or "shortened"),
+    }

--- a/ai/ajrasakha/agents/state.py
+++ b/ai/ajrasakha/agents/state.py
@@ -155,3 +155,6 @@ class AjraSakhaState(TypedDict):
     plan: Annotated[Optional[PlannerPlan], merge_plan]
     sanitizer_audit: Annotated[Optional[RetrievalSanitizerAudit], replace_sanitizer_audit]
     golden_retrieval_audit: Annotated[Optional[GoldenRetrievalAudit], replace_golden_retrieval_audit]
+    short_answer: Optional[str]
+    full_answer: Optional[str]
+    answer_shortening_status: Optional[str]

--- a/ai/ajrasakha/agents/tests/test_answer_shortener.py
+++ b/ai/ajrasakha/agents/tests/test_answer_shortener.py
@@ -1,0 +1,84 @@
+"""Tests for final LangGraph answer-shortener integration."""
+
+from __future__ import annotations
+
+import asyncio
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from ajrasakha.agents import answer_shortener
+
+
+def _state(answer: str) -> dict:
+    return {
+        "messages": [
+            HumanMessage(content="How should I manage pea germination?"),
+            AIMessage(content=answer),
+        ]
+    }
+
+
+def test_shortener_returns_pair_without_replacing_messages(monkeypatch):
+    full_answer = "Use certified seed.\n\n👤 Answered by: Expert"
+
+    async def fake_request(settings, *, original_query, answer):
+        assert settings.base_url == "http://shortener.test"
+        assert settings.api_key == "client-secret"
+        assert original_query == "How should I manage pea germination?"
+        assert answer == full_answer
+        return {
+            "short_answer": "Use certified seed.\n\n👤 Answered by: Expert",
+            "full_answer": full_answer,
+            "status": "shortened",
+        }
+
+    monkeypatch.setenv("ANSWER_SHORTENER_BASE_URL", "http://shortener.test")
+    monkeypatch.setenv("ANSWER_SHORTENER_CLIENT_API_KEY", "client-secret")
+    monkeypatch.setattr(answer_shortener, "_request_shortening", fake_request)
+
+    result = asyncio.run(answer_shortener.answer_shortener_node(_state(full_answer), {}))
+
+    assert result == {
+        "short_answer": "Use certified seed.\n\n👤 Answered by: Expert",
+        "full_answer": full_answer,
+        "answer_shortening_status": "shortened",
+    }
+    assert "messages" not in result
+
+
+def test_shortener_missing_configuration_falls_back_to_full_answer(monkeypatch):
+    full_answer = "Complete final advisory."
+    monkeypatch.delenv("ANSWER_SHORTENER_BASE_URL", raising=False)
+
+    result = asyncio.run(answer_shortener.answer_shortener_node(_state(full_answer), {}))
+
+    assert result["short_answer"] == full_answer
+    assert result["full_answer"] == full_answer
+    assert result["answer_shortening_status"] == "fallback_shortener_not_configured"
+
+
+def test_shortener_service_error_falls_back_to_full_answer(monkeypatch):
+    full_answer = "Complete final advisory with a footer.\n\n👤 Answered by: Expert"
+
+    async def fake_request(*args, **kwargs):
+        raise answer_shortener.AnswerShortenerError("shortener returned HTTP 422")
+
+    monkeypatch.setenv("ANSWER_SHORTENER_BASE_URL", "http://shortener.test")
+    monkeypatch.setattr(answer_shortener, "_request_shortening", fake_request)
+
+    result = asyncio.run(answer_shortener.answer_shortener_node(_state(full_answer), {}))
+
+    assert result["short_answer"] == full_answer
+    assert result["full_answer"] == full_answer
+    assert result["answer_shortening_status"] == "fallback_shortener_unavailable"
+
+
+def test_shortener_without_a_farmer_question_falls_back():
+    answer = "A final answer."
+    state = {"messages": [AIMessage(content=answer)]}
+
+    result = asyncio.run(answer_shortener.answer_shortener_node(state, {}))
+
+    assert result["short_answer"] == answer
+    assert result["full_answer"] == answer
+    assert result["answer_shortening_status"] == "fallback_no_original_query"

--- a/ai/ajrasakha/agents/tests/test_expert_queue_reply.py
+++ b/ai/ajrasakha/agents/tests/test_expert_queue_reply.py
@@ -6,7 +6,10 @@ import json
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-from ajrasakha.agents.ajrasakha import empty_gdb_reply_node
+from ajrasakha.agents.ajrasakha import (
+    empty_gdb_reply_node,
+    route_after_translate_answer,
+)
 from ajrasakha.agents.plan_executor import (
     route_after_execute,
     should_expert_queue_reply,
@@ -96,6 +99,23 @@ def test_route_after_execute_assemble_when_weather_has_content():
         ToolMessage(content="Rain expected tomorrow", tool_call_id="w1", name="weather")
     )
     assert route_after_execute(state) == "assemble_answer_body"
+
+
+def test_final_langgraph_and_expert_reviewed_answers_are_shortened():
+    assert route_after_translate_answer({"plan": {}}) == "answer_shortener"
+    assert (
+        route_after_translate_answer({"plan": {"skip_synthesize": True}})
+        == "answer_shortener"
+    )
+
+
+def test_expert_queue_reply_is_not_sent_to_answer_shortener():
+    assert (
+        route_after_translate_answer(
+            {"plan": {"translate_path": TRANSLATE_PATH_EMPTY_GDB}}
+        )
+        == "end"
+    )
 
 
 async def test_empty_gdb_reply_sets_translate_path():


### PR DESCRIPTION
- Added an `answer_shortener` LangGraph node after final answer translation.
- Normal LangGraph-generated agricultural answers now return:
  - `short_answer`
  - `full_answer`