### PR TITLE
feat(backend): add 200 OK ResponseSchema for getUserReviewLevel in UserController

### DIFF
--- a/backend/src/modules/core/classes/validators/UserResponseValidators.ts
+++ b/backend/src/modules/core/classes/validators/UserResponseValidators.ts
@@ -220,6 +220,46 @@ export class UserNotificationCountResponse {
   count: number;
 }
 
+// ─── User Review Level Item ───────────────────────────────────────────────────
+
+export class UserReviewLevelItemResponse {
+  @JSONSchema({
+    description: 'Name of the review level (e.g. Author, Level 1, Level 2)',
+    example: 'Level 1',
+    type: 'string',
+    readOnly: true,
+  })
+  @IsString()
+  Review_level: string;
+
+  @JSONSchema({
+    description: 'Total questions allocated at this review level',
+    example: 12,
+    type: 'number',
+    readOnly: true,
+  })
+  @IsNumber()
+  count: number;
+
+  @JSONSchema({
+    description: 'Number of questions currently in review at this level',
+    example: 3,
+    type: 'number',
+    readOnly: true,
+  })
+  @IsNumber()
+  inReview: number;
+
+  @JSONSchema({
+    description: 'Number of delayed questions at this level',
+    example: 1,
+    type: 'number',
+    readOnly: true,
+  })
+  @IsNumber()
+  delayed: number;
+}
+
 // ─── Export all validators ────────────────────────────────────────────────────
 
 export const USER_RESPONSE_VALIDATORS = [
@@ -230,4 +270,5 @@ export const USER_RESPONSE_VALIDATORS = [
   PaginatedUsersResponse,
   ToggleUserRoleResponse,
   UserNotificationCountResponse,
+  UserReviewLevelItemResponse,
 ];

--- a/backend/src/modules/user/controllers/UserController.ts
+++ b/backend/src/modules/user/controllers/UserController.ts
@@ -49,6 +49,7 @@ import {
   PaginatedUsersResponse,
   ToggleUserRoleResponse,
   UserEntryResponse,
+  UserReviewLevelItemResponse,
 } from '../../core/classes/validators/UserResponseValidators.js';
 
 @OpenAPI({
@@ -94,11 +95,14 @@ export class UserController {
     return user;
   }
 
-
-  // TODO: Add OpenAPI documentation 200 type definition
   @OpenAPI({
     summary: 'Get current user review level',
     description: 'Retrieves the review level statistics for the current user or moderator based on query parameters.',
+  })
+  @ResponseSchema(UserReviewLevelItemResponse, {
+    statusCode: 200,
+    isArray: true,
+    description: 'User review level statistics retrieved successfully',
   })
   @ResponseSchema(UserErrorResponse, {
     statusCode: 401,


### PR DESCRIPTION
**Summary**
This PR completes the OpenAPI documentation response schemas for the `getUserReviewLevel` endpoint in `UserController.ts`, resolving the unfulfilled TODO.

**Changes Made**
- Created `UserReviewLevelItemResponse` DTO class in `UserResponseValidators.ts` with full `@JSONSchema` metadata for `Review_level`, `count`, `inReview`, and `delayed`.
- Registered `UserReviewLevelItemResponse` in `USER_RESPONSE_VALIDATORS`.
- Decorated `getUserReviewLevel` in `UserController.ts` with `@ResponseSchema(UserReviewLevelItemResponse, { statusCode: 200, isArray: true })`.
- Removed `// TODO: Add OpenAPI documentation 200 type definition`.

**Verification**
- Ran `pnpm run build` (`tsc`) in `backend` — compiled with zero errors.