### PR TITLE
Mock mode fixes

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,47 @@
+# Pull Request Description
+
+## Overview
+This PR adds support for a fully working local **Mock Mode** (`VITE_ENABLE_MOCKS=true`) in the frontend, enabling developers to run and test the application dashboard and play-ground interface without requiring live Firebase instances, MongoDB databases, or upstream Plivo APIs.
+
+---
+
+## Changes and Bug Fixes
+
+### 1. Fixed Mock Session Reset in Auth Store
+* **Affected File**: `frontend/src/stores/auth-store.ts`
+* **Problem**: In mock mode, the custom email login bypasses Google Firebase. However, the Firebase SDK's active listener `onAuthStateChanged` still executes on startup and immediately triggers with `null` (since no actual session exists in the Firebase backend). This cleared the Zustand store's mock user object, redirecting the user back to the `/auth` login screen.
+* **Fix**: Updated `initAuthListener` to check `env.enableMocks()`. If active, it skips the Firebase `onAuthStateChanged` subscription and honors the persisted Zustand store state instead.
+
+### 2. Fixed Firebase Token Method Crash in apiFetch
+* **Affected File**: `frontend/src/hooks/api/api-fetch.ts`
+* **Problem**: The `apiFetch` helper called `getCurrentUser()` on each API call, which checks Firebase state and attempts to run `getIdToken()` on the mock user. Since the mock user is a plain object and lacks Firebase SDK prototype methods, this caused the app to throw runtime crashes.
+* **Fix**: Added a check for `env.enableMocks()` inside `apiFetch`. When active, it skips the Firebase user retrieval and returns a static mock string `"mock-id-token"`.
+
+### 3. Added Missing MSW User Handlers
+* **Affected File**: `frontend/src/mocks/handlers.js`
+* **Problem**: The `/api/users/me` and `/api/users/details/:email` endpoints were missing from MSW mock routes. Queries for loading user profile data failed with HTTP 404/network errors.
+* **Fix**: Added mock GET handlers for `/api/users/me` and `/api/users/details/:email` that return a valid `IUser` payload matching the Admin role.
+
+### 4. Added Firebase Auth Mock Bypass
+* **Affected File**: `frontend/src/lib/firebase.ts`
+* **Problem**: Standard login attempts failed when Firebase configuration credentials were dummy/placeholders.
+* **Fix**: Imported `env` from `@/config/env` and intercepted `loginWithEmail` so that when `env.enableMocks()` is true, it immediately returns a mock authentication credential containing the mock user and admin roles.
+
+### 5. Added Missing MSW handler for `/api/users/review-level`
+* **Affected File**: `frontend/src/mocks/handlers.js`
+* **Problem**: The dashboard components (`ExpertDashboard.tsx` and `ReviewLevelComponent.tsx`) make a GET request to `/api/users/review-level` and call `.map()` on the response. Because the endpoint was not mocked in MSW, the offline proxy returned a parsed non-array value, leading to the crash: `reviewLevel?.map is not a function`.
+* **Fix**: Added a mock handler for `/api/users/review-level` returning a structured array of `ReviewLevelCount` objects.
+
+### 6. Fixed Optional Chaining Loading Crash on `usersData`
+* **Affected Files**:
+  * `SelectedPannel.tsx`
+  * `BulkUploadAllocationModal.tsx`
+  * `AllocationQueueHeader.tsx`
+  * `AnswerItem.tsx`
+* **Problem**: When pages first mount, `usersData` is `undefined` because the query `useGetAllUsers()` is loading. The components attempted to evaluate `usersData?.users.filter(...)`, which threw `Cannot read properties of undefined (reading 'filter')` because `usersData?.users` resolves to `undefined` and optional chaining was not placed before the `.filter` call.
+* **Fix**: Changed all occurrences of `usersData?.users.filter(...)` to `(usersData?.users ?? []).filter(...)` or `usersData?.users?.filter(...)` to guarantee safe evaluation during loading states.
+
+### 7. Added Mock Handler for `/api/users/all`
+* **Affected File**: `frontend/src/mocks/handlers.js`
+* **Problem**: The user list dropdowns failed to populate because there was no mock API route for `/api/users/all`.
+* **Fix**: Added a GET handler for `/api/users/all` returning a mock `IUsersNameResponse` containing placeholder experts, admin, and moderator users.

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 allowBuilds:
   '@firebase/util': false
   '@tailwindcss/oxide': false
+  core-js: set this to true or false
   esbuild: false
   msw: false
   protobufjs: false

--- a/frontend/src/components/SelectedPannel.tsx
+++ b/frontend/src/components/SelectedPannel.tsx
@@ -44,7 +44,7 @@ export default function SelectedAnswerPanel({
     useGetReRouteAllocation();
 
   const experts =
-    usersData?.users.filter((user) => user.role === "expert") || [];
+    (usersData?.users ?? []).filter((user) => user.role === "expert");
 
   const filteredExperts = experts.filter(
     (expert) =>

--- a/frontend/src/features/question-table-page/BulkUploadAllocationModal.tsx
+++ b/frontend/src/features/question-table-page/BulkUploadAllocationModal.tsx
@@ -58,7 +58,7 @@ export function BulkUploadAllocationModal({
   }, [open, paeOnly]);
 
   const paeExperts =
-    usersData?.users.filter((u) => u.role === "pae_expert") ?? [];
+    (usersData?.users ?? []).filter((u) => u.role === "pae_expert");
 
   const filteredPaeExperts = paeExperts.filter(
     (e) =>

--- a/frontend/src/features/question_details/components/AllocationQueueHeader.tsx
+++ b/frontend/src/features/question_details/components/AllocationQueueHeader.tsx
@@ -51,9 +51,9 @@ export const AllocationQueueHeader = ({
 
   const expertsIdsInQueue = new Set(queue.map((expert) => expert._id));
   const experts =
-    usersData?.users.filter(
+    (usersData?.users ?? []).filter(
       (user) => user.role === "expert" && !expertsIdsInQueue.has(user._id)
-    ) || [];
+    );
   // let experts = [];
 
   /*   if (question.source === "AJRASAKHA") {

--- a/frontend/src/features/question_details/components/AnswerItem.tsx
+++ b/frontend/src/features/question_details/components/AnswerItem.tsx
@@ -321,7 +321,7 @@ export const AnswerItem = forwardRef((props: AnswerItemProps, ref) => {
     : null;
 
   const experts =
-    usersData?.users.filter((user) => user.role === "expert") || [];
+    (usersData?.users ?? []).filter((user) => user.role === "expert");
 
   const filteredExperts = experts.filter(
     (expert) =>

--- a/frontend/src/hooks/api/api-fetch.ts
+++ b/frontend/src/hooks/api/api-fetch.ts
@@ -1,6 +1,7 @@
 import { auth } from "@/config/firebase";
 import { useAuthStore } from "@/stores/auth-store";
 import { getIdToken, type User } from "firebase/auth";
+import { env } from "@/config/env";
 
 export const getCurrentUser = (): Promise<User | null> => {
   return new Promise((resolve) => {
@@ -14,9 +15,10 @@ export const apiFetch = async <T>(
   url: string,
   options: RequestInit = {}
 ): Promise<T | null> => {
-  const firebaseUser = await getCurrentUser();
+  const isMock = env.enableMocks();
+  const firebaseUser = isMock ? null : await getCurrentUser();
 
-  let token: string | null = null;
+  let token: string | null = isMock ? "mock-id-token" : null;
   if (firebaseUser) {
     try {
       token = await getIdToken(firebaseUser);

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -17,6 +17,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { UserService } from "@/hooks/services/userService";
 import { AuthService } from "@/hooks/services/authService";
 import { isDevelopment } from "@/shared/app";
+import { env } from "@/config/env";
 const authService = new AuthService();
 
 
@@ -26,6 +27,29 @@ export const auth = getAuth(app);
 export const provider = new GoogleAuthProvider();
 const userService = new UserService()
 export const loginWithEmail = async (email: string, password: string) => {
+  if (env.enableMocks()) {
+    return {
+      user: {
+        uid: "firebase-uid-123456",
+        email: email,
+        displayName: "Mock User",
+        photoURL: "",
+        emailVerified: true,
+        getIdToken: async () => "mock-id-token",
+      },
+      appUser: {
+        _id: "60d5ec49b3f1c8e4a8f8b8d1",
+        firebaseUID: "firebase-uid-123456",
+        email: email,
+        firstName: "Mock",
+        lastName: "User",
+        role: "admin",
+        isCallAgentActive: true,
+        status: "active",
+      }
+    } as any;
+  }
+
   try {
     const user = await userService.Getuser(email)
     // Moderators and Experts are gated by activity status (isBlocked is their check-in/

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -321,6 +321,118 @@ export const handlers = [
       ],
     );
   }),
+  http.get(`${baseURL}/api/users/me`, async () => {
+    return HttpResponse.json({
+      _id: "60d5ec49b3f1c8e4a8f8b8d1",
+      firebaseUID: "firebase-uid-123456",
+      email: "admin@example.com",
+      firstName: "Mock",
+      lastName: "Admin",
+      role: "admin",
+      isCallAgentActive: true,
+      status: "active",
+    }, { status: 200 });
+  }),
+  http.get(`${baseURL}/api/users/details/:email`, async ({ params }) => {
+    return HttpResponse.json({
+      _id: "60d5ec49b3f1c8e4a8f8b8d1",
+      firebaseUID: "firebase-uid-123456",
+      email: decodeURIComponent(params.email),
+      firstName: "Mock",
+      lastName: "Admin",
+      role: "admin",
+      isCallAgentActive: true,
+      status: "active",
+    }, { status: 200 });
+  }),
+  http.get(`${baseURL}/api/users/all`, async () => {
+    const mockUsers = {
+      myPreference: {
+        state: "Karnataka",
+        crop: "Rice",
+        domain: "Pest Management"
+      },
+      users: [
+        {
+          _id: "60d5ec49b3f1c8e4a8f8b8d1",
+          userName: "Mock Admin",
+          email: "admin@example.com",
+          role: "admin",
+          preference: { state: "Karnataka", crop: "Rice", domain: "Pest Management" },
+          isBlocked: false,
+          status: "active"
+        },
+        {
+          _id: "60d5ec49b3f1c8e4a8f8b8d2",
+          userName: "Expert Rajesh",
+          email: "rajesh@example.com",
+          role: "expert",
+          preference: { state: "Karnataka", crop: "Rice", domain: "Pest Management" },
+          isBlocked: false,
+          status: "active"
+        },
+        {
+          _id: "60d5ec49b3f1c8e4a8f8b8d3",
+          userName: "PAE Expert Kumar",
+          email: "kumar@example.com",
+          role: "pae_expert",
+          preference: { state: "Karnataka", crop: "Rice", domain: "Pest Management" },
+          isBlocked: false,
+          status: "active"
+        },
+        {
+          _id: "60d5ec49b3f1c8e4a8f8b8d4",
+          userName: "Moderator Priya",
+          email: "priya@example.com",
+          role: "moderator",
+          preference: { state: "Karnataka", crop: "Rice", domain: "Pest Management" },
+          isBlocked: false,
+          status: "active"
+        }
+      ],
+      totalUsers: 4,
+      totalPages: 1
+    };
+    return HttpResponse.json(mockUsers, { status: 200 });
+  }),
+  http.get(`${baseURL}/api/users/review-level`, async () => {
+    const mockReviewLevels = [
+      {
+        Review_level: 'Author',
+        pendingcount: 10,
+        completedcount: 5,
+        approvedCount: 3,
+        rejectedCount: 1,
+        modifiedCount: 1,
+        inReviewQuestions: 2,
+        delayedQuestion: 0,
+        count: 5
+      },
+      {
+        Review_level: 'Level 1',
+        pendingcount: 4,
+        completedcount: 12,
+        approvedCount: 8,
+        rejectedCount: 2,
+        modifiedCount: 2,
+        inReviewQuestions: 1,
+        delayedQuestion: 1,
+        count: 12
+      },
+      {
+        Review_level: 'Level 2',
+        pendingcount: 0,
+        completedcount: 20,
+        approvedCount: 15,
+        rejectedCount: 3,
+        modifiedCount: 2,
+        inReviewQuestions: 0,
+        delayedQuestion: 0,
+        count: 20
+      }
+    ];
+    return HttpResponse.json(mockReviewLevels, { status: 200 });
+  }),
   http.get(`${baseURL}/api/users/:userId`, async () => {
     const resultArray = [
       [getUserControllerGetUserById200Response(), { status: 200 }],

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,6 +1,7 @@
 import { auth, googleProvider } from "@/config/firebase";
 import { queryClient } from "@/routes/__root";
 import type { AuthUser, ExtendedUserCredential } from "@/types";
+import { env } from "@/config/env";
 import {
   // getIdToken,
   onAuthStateChanged,
@@ -100,6 +101,13 @@ export const useAuthStore = create<AuthStore>()(
 
         initAuthListener: () => {
           set({ loading: true });
+          if (env.enableMocks()) {
+            set((state) => ({
+              loading: false,
+              isAuthenticated: !!state.user,
+            }));
+            return;
+          }
           onAuthStateChanged(auth, async (firebaseUser) => {
             if (firebaseUser) {
               const authUser: AuthUser = {


### PR DESCRIPTION
# Pull Request Description

## Overview
This PR adds support for a fully working local **Mock Mode** (`VITE_ENABLE_MOCKS=true`) in the frontend, enabling developers to run and test the application dashboard and playground interface without requiring live Firebase instances, MongoDB databases, or upstream Plivo APIs.

---

## Changes and Bug Fixes

### 1. Fixed Mock Session Reset in Auth Store
* **Affected File**: `frontend/src/stores/auth-store.ts`
* **Problem**: In mock mode, the custom email login bypasses Google Firebase. However, the Firebase SDK's active listener `onAuthStateChanged` still executes on startup and immediately triggers with `null` (since no actual session exists in the Firebase backend). This cleared the Zustand store's mock user object, redirecting the user back to the `/auth` login screen.
* **Fix**: Updated `initAuthListener` to check `env.enableMocks()`. If active, it skips the Firebase `onAuthStateChanged` subscription and honors the persisted Zustand store state instead.

### 2. Fixed Firebase Token Method Crash in apiFetch
* **Affected File**: `frontend/src/hooks/api/api-fetch.ts`
* **Problem**: The `apiFetch` helper called `getCurrentUser()` on each API call, which checks Firebase state and attempts to run `getIdToken()` on the mock user. Since the mock user is a plain object and lacks Firebase SDK prototype methods, this caused the app to throw runtime crashes.
* **Fix**: Added a check for `env.enableMocks()` inside `apiFetch`. When active, it skips the Firebase user retrieval and returns a static mock string `"mock-id-token"`.

### 3. Added Missing MSW User Handlers
* **Affected File**: `frontend/src/mocks/handlers.js`
* **Problem**: The `/api/users/me` and `/api/users/details/:email` endpoints were missing from MSW mock routes. Queries for loading user profile data failed with HTTP 404/network errors.
* **Fix**: Added mock GET handlers for `/api/users/me` and `/api/users/details/:email` that return a valid `IUser` payload matching the Admin role.

### 4. Added Firebase Auth Mock Bypass
* **Affected File**: `frontend/src/lib/firebase.ts`
* **Problem**: Standard login attempts failed when Firebase configuration credentials were dummy/placeholders.
* **Fix**: Imported `env` from `@/config/env` and intercepted `loginWithEmail` so that when `env.enableMocks()` is true, it immediately returns a mock authentication credential containing the mock user and admin roles.

### 5. Added Missing MSW handler for `/api/users/review-level`
* **Affected File**: `frontend/src/mocks/handlers.js`
* **Problem**: The dashboard components (`ExpertDashboard.tsx` and `ReviewLevelComponent.tsx`) make a GET request to `/api/users/review-level` and call `.map()` on the response. Because the endpoint was not mocked in MSW, the offline proxy returned a parsed non-array value, leading to the crash: `reviewLevel?.map is not a function`.
* **Fix**: Added a mock handler for `/api/users/review-level` returning a structured array of `ReviewLevelCount` objects.

### 6. Fixed Optional Chaining Loading Crash on `usersData`
* **Affected Files**:
  * `SelectedPannel.tsx`
  * `BulkUploadAllocationModal.tsx`
  * `AllocationQueueHeader.tsx`
  * `AnswerItem.tsx`
* **Problem**: When pages first mount, `usersData` is `undefined` because the query `useGetAllUsers()` is loading. The components attempted to evaluate `usersData?.users.filter(...)`, which threw `Cannot read properties of undefined (reading 'filter')` because `usersData?.users` resolves to `undefined` and optional chaining was not placed before the `.filter` call.
* **Fix**: Changed all occurrences of `usersData?.users.filter(...)` to `(usersData?.users ?? []).filter(...)` or `usersData?.users?.filter(...)` to guarantee safe evaluation during loading states.

### 7. Added Mock Handler for `/api/users/all`
* **Affected File**: `frontend/src/mocks/handlers.js`
* **Problem**: The user list dropdowns failed to populate because there was no mock API route for `/api/users/all`.
* **Fix**: Added a GET handler for `/api/users/all` returning a mock `IUsersNameResponse` containing placeholder experts, admin, and moderator users.