### PR TITLE
Fix/change question status of duplicate question on assigning experts manually

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2811,6 +2811,18 @@ export class QuestionService extends BaseService implements IQuestionService {
         }
 
         //6. Allocate experts
+        // If the question is a duplicate and auto-allocate is OFF, it means the
+        // moderator intentionally toggled off auto-allocate and is now manually
+        // picking an expert. Reopen the question so the selected expert can see
+        // it in their dashboard (only open/delayed questions are visible there).
+        if (question.status === 'duplicate' && question.isAutoAllocate === false) {
+          await this.questionRepo.updateQuestion(
+            questionId,
+            { status: 'open' },
+            session,
+          );
+        }
+
         const expertIds = experts.map(e => new ObjectId(e));
 
         // if the last expert is  reviewing other question  (if status is not reviewed or not submitted an answer)

--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2818,7 +2818,7 @@ export class QuestionService extends BaseService implements IQuestionService {
         const updateData:any = {
           firstAllocationAt: new Date(),
         };
-        if (question.status === 'duplicate' && question.isAutoAllocate === false) {
+        if (question.status === 'duplicate') {
           updateData.status = 'open';
         }
 

--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2815,13 +2815,14 @@ export class QuestionService extends BaseService implements IQuestionService {
         // moderator intentionally toggled off auto-allocate and is now manually
         // picking an expert. Reopen the question so the selected expert can see
         // it in their dashboard (only open/delayed questions are visible there).
+        const updateData:any = {
+          firstAllocationAt: new Date(),
+        };
         if (question.status === 'duplicate' && question.isAutoAllocate === false) {
-          await this.questionRepo.updateQuestion(
-            questionId,
-            { status: 'open' },
-            session,
-          );
+          updateData.status = 'open';
         }
+
+        await this.questionRepo.updateQuestion(questionId,updateData,session,);
 
         const expertIds = experts.map(e => new ObjectId(e));
 

--- a/frontend/src/features/question_details/components/AllocationQueueHeader.tsx
+++ b/frontend/src/features/question_details/components/AllocationQueueHeader.tsx
@@ -141,7 +141,12 @@ export const AllocationQueueHeader = ({
   // The auto-allocate toggle is shown to moderators/admins regardless of status (so
   // they can turn allocation on/off ahead of time). The "Select Experts" action only
   // shows when the question is actually in a normal expert-answering status — never for
-  // triage statuses (dynamic / duplicate / queue_duplicate / auditor_review / non_agri).
+  // triage statuses (dynamic / queue_duplicate / auditor_review / non_agri).
+  //
+  // Exception — duplicate questions: when the moderator explicitly turns auto-allocate
+  // OFF on a duplicate question, "Select Experts" must appear so they can manually pick
+  // an expert. The backend will reopen the question to 'open' on allocation so the
+  // expert can see it in their dashboard.
   // Gate keepers and auditors manage expert allocation alongside moderators/admins.
   const canManageAllocation = currentUser.role !== "expert";
   const isExpertStatus =
@@ -149,7 +154,9 @@ export const AllocationQueueHeader = ({
     question.status !== "queue_duplicate" &&
     question.status !== "auditor_review" &&
     question.status !== "dynamic" &&
-    question.status !== "duplicate";
+    // For duplicate questions: allow "Select Experts" only when auto-allocate is OFF
+    // (moderator has consciously decided to assign manually).
+    (question.status !== "duplicate" || !autoAllocate);
 
   return (
     <div className="flex flex-col gap-4 pb-6 border-b border-border">


### PR DESCRIPTION
Whenever there's a duplicate question and moderators or admin assign that question to expert then the should be open for experts to answer or reviewed that question, and can be visible in the expert's dashboard since we are only showing open or delayed questions in the expert dashboard.

<img width="1512" height="421" alt="image" src="https://github.com/user-attachments/assets/48a7c474-81cc-47c2-a59f-95a5544c83a0" />
