### PR TITLE
fix(question): release gate keeper/auditor atomically on status change

### DIFF
--- a/backend/src/modules/question/services/QuestionService.ts
+++ b/backend/src/modules/question/services/QuestionService.ts
@@ -2321,15 +2321,28 @@ export class QuestionService extends BaseService implements IQuestionService {
           updates.isClosed = true;
           if (!updates.closedAt) updates.closedAt = new Date();
         }
-        return this.questionRepo.updateQuestion(questionId, updates, session);
+        const updateResult = await this.questionRepo.updateQuestion(
+          questionId,
+          updates,
+          session,
+        );
+
+        // In-transaction: if the status changed, free any gate keeper / auditor whose
+        // handling scope the question has now left (pass / push-to-auditor / close, etc.)
+        // so the status change and the release commit atomically — a failure here rolls
+        // back the whole update, preventing a stuck assignee. (The queue cron still
+        // reconciles as a backstop for any release missed by other paths.)
+        if (!threadUpdate && updates.status) {
+          await this.freeRoleAssigneeOnStatusChange(
+            questionId,
+            updates.status,
+            session,
+          );
+        }
+
+        return updateResult;
       });
 
-      // After commit: if the status changed, free any gate keeper / auditor whose
-      // handling scope the question has now left (pass / push-to-auditor / close, etc.)
-      // so the role queue cron can hand them another question.
-      if (!threadUpdate && updates.status) {
-        await this.freeRoleAssigneeOnStatusChange(questionId, updates.status);
-      }
       return result;
     } catch (error) {
       throw new InternalServerError(`Failed to update question: ${error}`);
@@ -7013,15 +7026,56 @@ export class QuestionService extends BaseService implements IQuestionService {
    * auditor). Clears the assignee field on the question and removes it from the
    * user's assigned list so the cron can hand them another. Best-effort; never throws.
    */
+  /**
+   * The exact time a role (gate keeper / auditor) finished with a question — taken from the
+   * audit trail (the createdAt of the latest action logged by an actor of that role) rather
+   * than fabricated with new Date().
+   *
+   * When called inside the update transaction (session present), the audit entry for the
+   * current action hasn't been written yet AND an older same-role entry could mislead — so
+   * there we use the action instant (now), which is exact. Post-commit / reconciliation
+   * (no session) reads the real historical time from the audit trail.
+   */
+  private async resolveRoleFinishTime(
+    questionId: string,
+    role: 'gate_keeper' | 'auditor',
+    session?: ClientSession,
+  ): Promise<Date> {
+    if (session) return new Date();
+    try {
+      const {data} = await this.auditTrailsService.getAuditTrailsByQuestionId(
+        questionId,
+        1,
+        25,
+        null,
+        'desc',
+      );
+      const entry = data.find(
+        a => (a as any)?.actor?.role === role && (a as any)?.createdAt,
+      );
+      if (entry?.createdAt) return new Date(entry.createdAt as any);
+    } catch (err: any) {
+      console.error(
+        `[RoleAssignee] audit-time lookup failed for ${questionId} (${role}):`,
+        err?.message,
+      );
+    }
+    return new Date();
+  }
+
   async freeRoleAssigneeOnStatusChange(
     questionId: string,
     newStatus?: QuestionStatus,
+    session?: ClientSession,
   ): Promise<void> {
-    try {
-      const question = await this.questionRepo.getById(questionId);
+    // When a session is supplied, the caller wants this to run inside their transaction —
+    // let failures propagate so the status change and the release roll back together.
+    // Without a session it stays best-effort (post-commit / other callers) and never throws.
+    const run = async () => {
+      const question = await this.questionRepo.getById(questionId, session);
       if (!question) return;
-      // Fall back to the question's current (already-committed) status when the caller
-      // doesn't pass one — e.g. after an answer approval/close.
+      // Fall back to the question's current status when the caller doesn't pass one —
+      // e.g. after an answer approval/close.
       const status = newStatus ?? question.status;
 
       // When the question leaves the role's handling statuses, the assignee has acted:
@@ -7030,30 +7084,38 @@ export class QuestionService extends BaseService implements IQuestionService {
       // change doesn't overwrite the original finish time.
       const gkId = (question as any).gateKeeperId?.toString();
       if (gkId && !QuestionService.GATE_KEEPER_STATUSES.includes(status)) {
-        // Always pull the question from the gate keeper's assigned list so they're
-        // freed (e.g. on cancel duplicate → open). Only stamp finishedAt once so a
-        // later status change doesn't overwrite the original finish time.
-        await this.userRepo.removeAssignedQuestion(gkId, questionId);
+        await this.userRepo.removeAssignedQuestion(gkId, questionId, session);
         if (!(question as any).gateKeeperFinishedAt) {
           await this.questionRepo.markRoleFinished(
             questionId,
             'gateKeeperFinishedAt',
-            new Date(),
+            await this.resolveRoleFinishTime(questionId, 'gate_keeper', session),
+            session,
           );
         }
       }
 
       const audId = (question as any).auditorId?.toString();
       if (audId && !QuestionService.AUDITOR_STATUSES.includes(status)) {
-        await this.userRepo.removeAssignedQuestion(audId, questionId);
+        await this.userRepo.removeAssignedQuestion(audId, questionId, session);
         if (!(question as any).auditorFinishedAt) {
           await this.questionRepo.markRoleFinished(
             questionId,
             'auditorFinishedAt',
-            new Date(),
+            await this.resolveRoleFinishTime(questionId, 'auditor', session),
+            session,
           );
         }
       }
+    };
+
+    if (session) {
+      await run();
+      return;
+    }
+
+    try {
+      await run();
     } catch (err: any) {
       console.error(
         `[RoleAssignee] Failed to free assignee for ${questionId}:`,

--- a/backend/src/shared/database/interfaces/IQuestionRepository.ts
+++ b/backend/src/shared/database/interfaces/IQuestionRepository.ts
@@ -606,5 +606,6 @@ export interface IQuestionRepository {
     questionId: string,
     finishedAtField: 'gateKeeperFinishedAt' | 'auditorFinishedAt',
     finishedAt: Date,
+    session?: ClientSession,
   ): Promise<void>;
 }

--- a/backend/src/shared/database/interfaces/IUserRepository.ts
+++ b/backend/src/shared/database/interfaces/IUserRepository.ts
@@ -353,7 +353,7 @@ export interface IUserRepository {
   findAvailableStfModeratorsForSources(sources: QuestionSource[]): Promise<IUser[]>;
   findAvailableUsersByRole(role: UserRole): Promise<IUser[]>;
   addAssignedQuestion(moderatorId: string, questionId: string, status: QuestionStatus, source?: QuestionSource, session?: ClientSession): Promise<void>;
-  removeAssignedQuestion(moderatorId: string, questionId: string): Promise<void>;
+  removeAssignedQuestion(moderatorId: string, questionId: string, session?: ClientSession): Promise<void>;
   removeAssignedQuestionFromAllModerators(questionId: string, session?: ClientSession): Promise<void>;
 
    /**

--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -7560,11 +7560,13 @@ export class QuestionRepository implements IQuestionRepository {
     questionId: string,
     finishedAtField: 'gateKeeperFinishedAt' | 'auditorFinishedAt',
     finishedAt: Date,
+    session?: ClientSession,
   ): Promise<void> {
     await this.init();
     await this.QuestionCollection.updateOne(
       { _id: new ObjectId(questionId) },
       { $set: { [finishedAtField]: finishedAt, updatedAt: new Date() } },
+      { session },
     );
   }
   /** One page (skip/limit) + exact total for a Queue-Details question section.

--- a/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/UserRepository.ts
@@ -1035,7 +1035,11 @@ export class UserRepository implements IUserRepository {
   /** Removes a single question's entry from a moderator's assigned-questions array.
    *  Called when the moderator acts on the question (answers/closes), or when the
    *  question is manually removed/reassigned. */
-  async removeAssignedQuestion(moderatorId: string, questionId: string): Promise<void> {
+  async removeAssignedQuestion(
+    moderatorId: string,
+    questionId: string,
+    session?: ClientSession,
+  ): Promise<void> {
     await this.init();
     await this.usersCollection.updateOne(
       { _id: new ObjectId(moderatorId) },
@@ -1043,6 +1047,7 @@ export class UserRepository implements IUserRepository {
         $pull: { assignedQuestionIds: { questionId: new ObjectId(questionId) } },
         $set: { updatedAt: new Date() },
       },
+      { session },
     );
   }
 


### PR DESCRIPTION
The gate keeper / auditor release (pull from assignedQuestionIds + stamp finishedAt) ran as a best-effort step AFTER the update transaction committed, so a transient failure left the status changed but the assignee stuck — still holding the question with a stale status and gateKeeperFinishedAt/auditorFinishedAt never set.

- Thread an optional ClientSession through removeAssignedQuestion and markRoleFinished (+ interfaces).
- freeRoleAssigneeOnStatusChange now accepts a session: inside a transaction it lets failures propagate (rolls back the whole update); without one it stays best-effort.
- updateQuestion runs the release INSIDE the update transaction, so the status change and the release commit or roll back together.
- Finish timestamps come from the audit-trail action time (resolveRoleFinishTime) instead of a fabricated new Date(); the in-transaction action uses the exact action instant.