### PR TITLE
feat: add government scheme eligibility auto-matcher

### DIFF
--- a/backend/src/bootstrap/jobs/index.ts
+++ b/backend/src/bootstrap/jobs/index.ts
@@ -7,6 +7,7 @@ import './reAllocateCron.js'
 import './timeBoundReAllocateCron.js'
 import './moderatorQueueCron.js'
 //import './embeddingBackfill.js'
+import './schemeMatcher.js'
 export const initJobs = () => {
   console.log('[CRON] Jobs initialized.');
 };

--- a/backend/src/bootstrap/jobs/schemeMatcher.ts
+++ b/backend/src/bootstrap/jobs/schemeMatcher.ts
@@ -1,0 +1,22 @@
+import cron from 'node-cron';
+import { SchemeMatcherService } from '../../modules/schemes/services/SchemeMatcherService.js';
+
+const options = { timezone: 'Asia/Kolkata' };
+
+const job = async () => {
+  console.log('[CRON] Scheme eligibility scan started');
+  const service = new SchemeMatcherService();
+  try {
+    const results = await service.matchAllFarmers(50, (processed, total) => {
+      console.log(`[CRON] Scheme matcher: ${processed}/${total} farmers processed`);
+    });
+    console.log(`[CRON] Scheme eligibility scan completed: ${results.length} farmers matched`);
+  } catch (err) {
+    console.error('[CRON] Scheme eligibility scan failed:', err);
+  } finally {
+    await service.close();
+  }
+};
+
+// Run daily at 3:00 AM IST
+cron.schedule('0 3 * * *', job, options);

--- a/backend/src/modules/schemes/container.ts
+++ b/backend/src/modules/schemes/container.ts
@@ -1,0 +1,8 @@
+import {ContainerModule} from 'inversify';
+import {SchemeController} from './controllers/SchemeController.js';
+
+export const schemesContainerModule = new ContainerModule(options => {
+  options.bind(SchemeController).toSelf().inSingletonScope();
+});
+
+export const schemesContainerModules: ContainerModule[] = [schemesContainerModule];

--- a/backend/src/modules/schemes/controllers/SchemeController.ts
+++ b/backend/src/modules/schemes/controllers/SchemeController.ts
@@ -1,0 +1,134 @@
+import 'reflect-metadata';
+import {
+  JsonController,
+  Get,
+  Post,
+  HttpCode,
+  Authorized,
+  CurrentUser,
+  Param,
+  QueryParam,
+  Body,
+} from 'routing-controllers';
+import { OpenAPI } from 'routing-controllers-openapi';
+import { injectable } from 'inversify';
+import { IUser } from '#root/shared/index.js';
+import { SchemeMatcherService } from '../services/SchemeMatcherService.js';
+
+@OpenAPI({
+  tags: ['schemes'],
+  description: 'Government scheme eligibility matching endpoints',
+})
+@injectable()
+@JsonController('/schemes', { transformResponse: false })
+export class SchemeController {
+  @OpenAPI({
+    summary: 'Match schemes for a specific farmer',
+    description: 'Returns eligible government schemes based on the farmer\'s profile demographics.',
+  })
+  @Get('/match/:farmerId')
+  @HttpCode(200)
+  @Authorized()
+  async matchFarmer(@Param('farmerId') farmerId: string) {
+    const service = new SchemeMatcherService();
+    try {
+      const existing = await service.getFarmerMatches(farmerId);
+      if (existing) return existing;
+
+      return { error: 'No cached results. Run a bulk scan first or use /schemes/match-farmer.' };
+    } finally {
+      await service.close();
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Match schemes for custom demographics',
+    description: 'Searches MyScheme.gov.in with provided demographic filters and returns matching schemes.',
+  })
+  @Post('/match-farmer')
+  @HttpCode(200)
+  @Authorized()
+  async matchCustomFarmer(
+    @Body() body: {
+      state?: string;
+      age?: number;
+      gender?: string;
+      occupation?: string;
+    },
+  ) {
+    const service = new SchemeMatcherService();
+    try {
+      const schemes = await service.matchFarmer({
+        state: body.state,
+        age: body.age,
+        gender: body.gender,
+      });
+      return { schemes };
+    } finally {
+      await service.close();
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Get matching stats and state distribution',
+    description: 'Returns aggregate statistics of scheme matching results.',
+  })
+  @Get('/stats')
+  @HttpCode(200)
+  @Authorized()
+  async getStats() {
+    const service = new SchemeMatcherService();
+    try {
+      return await service.getStats();
+    } finally {
+      await service.close();
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Get recent matching results',
+    description: 'Returns the most recent farmer-scheme matching results.',
+  })
+  @Get('/results')
+  @HttpCode(200)
+  @Authorized()
+  async getResults(
+    @QueryParam('limit') limit = 50,
+  ) {
+    const service = new SchemeMatcherService();
+    try {
+      const results = await service.getRecentResults(limit);
+      return { results };
+    } finally {
+      await service.close();
+    }
+  }
+
+  @OpenAPI({
+    summary: 'Trigger bulk scheme matching for all farmers',
+    description: 'Runs eligibility matching against all farmers with profile data. Admin only.',
+  })
+  @Post('/scan')
+  @HttpCode(200)
+  @Authorized()
+  async triggerBulkMatch(
+    @CurrentUser() user: IUser,
+    @Body() body: { batchSize?: number },
+  ) {
+    if (user.role !== 'admin') {
+      return { error: 'Only admins can trigger bulk scans' };
+    }
+
+    const service = new SchemeMatcherService();
+    try {
+      const results = await service.matchAllFarmers(body.batchSize || 50);
+      return {
+        success: true,
+        matched: results.length,
+        message: `Matched ${results.length} farmers with eligible schemes.`,
+      };
+    } finally {
+      await service.close();
+    }
+  }
+}

--- a/backend/src/modules/schemes/index.ts
+++ b/backend/src/modules/schemes/index.ts
@@ -1,0 +1,16 @@
+import {Container, ContainerModule} from 'inversify';
+import {useContainer} from 'class-validator';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {SchemeController} from './controllers/SchemeController.js';
+import {schemesContainerModule} from './container.js';
+
+export const schemesModuleControllers: Function[] = [SchemeController];
+export const schemesModuleValidators: Function[] = [];
+export const schemesContainerModules: ContainerModule[] = [schemesContainerModule];
+
+export async function setupSchemesContainer(): Promise<void> {
+  const container = new Container();
+  await container.load(...schemesContainerModules);
+  const inversifyAdapter = new InversifyAdapter(container);
+  useContainer(inversifyAdapter);
+}

--- a/backend/src/modules/schemes/services/SchemeMatcherService.ts
+++ b/backend/src/modules/schemes/services/SchemeMatcherService.ts
@@ -1,0 +1,392 @@
+import { env } from '#root/utils/env.js';
+import { MongoClient, ObjectId } from 'mongodb';
+
+const MYSCHEME_SEARCH_URL = 'https://api.myscheme.gov.in/search/v6/schemes';
+const MYSCHEME_DETAIL_URL = 'https://api.myscheme.gov.in/schemes/v6/public/schemes';
+const MYSCHEME_API_KEY = env('MYSCHEME_API_KEY') || '';
+const CATEGORY_FILTER = 'Agriculture,Rural & Environment';
+
+const HEADERS = {
+  'x-api-key': MYSCHEME_API_KEY,
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+  'Origin': 'https://www.myscheme.gov.in',
+  'Referer': 'https://www.myscheme.gov.in/',
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+};
+
+export interface FarmerProfile {
+  _id?: string | ObjectId;
+  phoneNo?: string;
+  farmerName?: string;
+  age?: number;
+  gender?: string;
+  state?: string;
+  district?: string;
+  blockName?: string;
+  villageName?: string;
+  highestEducatedPerson?: string;
+  cropsCultivated?: string[];
+  primaryCrop?: string;
+}
+
+export interface SchemeMatch {
+  slug: string;
+  name: string;
+  description: string;
+  tags: string[];
+  eligibilityMet: string[];
+  eligibilityPending: string[];
+  confidence: number;
+}
+
+export interface FarmerSchemeResult {
+  farmerId: string;
+  farmerName: string;
+  state: string;
+  district: string;
+  schemes: SchemeMatch[];
+  matchedAt: Date;
+}
+
+function buildAgeBucket(age: number): { min: number; max: number } {
+  const bucketStart = Math.floor((age - 1) / 10) * 10 + 1;
+  return { min: bucketStart, max: bucketStart + 9 };
+}
+
+function buildSearchFilters(profile: FarmerProfile): any[] {
+  const filters: any[] = [
+    { identifier: 'schemeCategory', value: CATEGORY_FILTER },
+  ];
+
+  if (profile.state) {
+    filters.push({ identifier: 'schemeState', value: profile.state });
+  }
+
+  if (profile.age) {
+    const bucket = buildAgeBucket(profile.age);
+    filters.push({ identifier: 'age-general', min: bucket.min, max: bucket.max });
+  }
+
+  if (profile.gender) {
+    const genderMap: Record<string, string> = {
+      'male': 'Male', 'female': 'Female', 'other': 'Other',
+      'm': 'Male', 'f': 'Female',
+    };
+    const mapped = genderMap[profile.gender.toLowerCase()];
+    if (mapped) filters.push({ identifier: 'gender', value: mapped });
+  }
+
+  return filters;
+}
+
+function buildSpecificFilters(profile: FarmerProfile): any[] | null {
+  const filters = buildSearchFilters(profile);
+  let hasSpecific = false;
+
+  if (profile.gender) {
+    const genderMap: Record<string, string> = {
+      'male': 'Male', 'female': 'Female', 'other': 'Other',
+      'm': 'Male', 'f': 'Female',
+    };
+    const mapped = genderMap[profile.gender.toLowerCase()];
+    if (mapped) {
+      filters.push({ identifier: 'gender', value: mapped });
+      hasSpecific = true;
+    }
+  }
+
+  return hasSpecific ? filters : null;
+}
+
+async function searchSchemes(filters: any[]): Promise<any[]> {
+  if (!MYSCHEME_API_KEY) {
+    console.error('[SchemeMatcher] MYSCHEME_API_KEY not configured');
+    return [];
+  }
+
+  try {
+    const params = new URLSearchParams({
+      lang: 'en',
+      q: JSON.stringify(filters),
+      from: '0',
+      size: '10',
+    });
+
+    const res = await fetch(`${MYSCHEME_SEARCH_URL}?${params}`, {
+      headers: HEADERS as Record<string, string>,
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data?.data?.hits || data?.data || [];
+  } catch {
+    return [];
+  }
+}
+
+async function getSchemeDetail(slug: string): Promise<any> {
+  if (!MYSCHEME_API_KEY) return null;
+
+  try {
+    const res = await fetch(
+      `${MYSCHEME_DETAIL_URL}?slug=${encodeURIComponent(slug)}&lang=en`,
+      {
+        headers: HEADERS as Record<string, string>,
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data?.data || null;
+  } catch {
+    return null;
+  }
+}
+
+function parseSchemesFromSearch(hits: any[]): SchemeMatch[] {
+  return hits.map((hit: any) => {
+    const source = hit._source || hit;
+    return {
+      slug: source.slug || hit.slug || '',
+      name: source.schemeName || source.name || 'Unknown Scheme',
+      description: source.shortDescription || source.description || '',
+      tags: source.tags || [],
+      eligibilityMet: [],
+      eligibilityPending: [],
+      confidence: 0.5,
+    };
+  });
+}
+
+function scoreScheme(scheme: SchemeMatch, profile: FarmerProfile): SchemeMatch {
+  let score = 0.5;
+  const met: string[] = [];
+  const pending: string[] = [];
+
+  if (profile.state) {
+    const stateTag = scheme.tags.find((t) =>
+      t.toLowerCase().includes(profile.state!.toLowerCase()),
+    );
+    if (stateTag) {
+      score += 0.15;
+      met.push(`State: ${profile.state}`);
+    } else {
+      pending.push(`State: ${profile.state} (may apply nationwide)`);
+    }
+  }
+
+  if (profile.age) {
+    const ageTag = scheme.tags.find((t) => t.toLowerCase().includes('age'));
+    if (ageTag) {
+      score += 0.1;
+      met.push(`Age: ${profile.age}`);
+    }
+  }
+
+  if (profile.gender) {
+    const genderTag = scheme.tags.find((t) =>
+      t.toLowerCase().includes(profile.gender!.toLowerCase()),
+    );
+    if (genderTag) {
+      score += 0.1;
+      met.push(`Gender: ${profile.gender}`);
+    }
+  }
+
+  if (profile.cropsCultivated && profile.cropsCultivated.length > 0) {
+    const agriTag = scheme.tags.find((t) =>
+      t.toLowerCase().includes('farmer') || t.toLowerCase().includes('agriculture'),
+    );
+    if (agriTag) {
+      score += 0.1;
+      met.push('Farmer/Agriculture scheme');
+    }
+  }
+
+  scheme.eligibilityMet = met;
+  scheme.eligibilityPending = pending;
+  scheme.confidence = Math.min(score, 1.0);
+  return scheme;
+}
+
+export class SchemeMatcherService {
+  private mongoClient: MongoClient | null = null;
+
+  private async getClient(): Promise<MongoClient> {
+    if (!this.mongoClient) {
+      const uri = env('MONGODB_URI') || env('MONGODB_URL') || '';
+      this.mongoClient = new MongoClient(uri);
+      await this.mongoClient.connect();
+    }
+    return this.mongoClient;
+  }
+
+  private getAnnamDb(client: MongoClient) {
+    const dbName = env('ANNAM_DB_NAME') || env('ANNAM_DATABASE_NAME') || 'annam';
+    return client.db(dbName);
+  }
+
+  private getMainDb(client: MongoClient) {
+    const dbName = env('DB_NAME') || env('MONGODB_DB_NAME') || 'ajrasakha';
+    return client.db(dbName);
+  }
+
+  async matchFarmer(profile: FarmerProfile): Promise<SchemeMatch[]> {
+    const baseFilters = buildSearchFilters(profile);
+    const specificFilters = buildSpecificFilters(profile);
+
+    const searchPromises = [searchSchemes(baseFilters)];
+    if (specificFilters) {
+      searchPromises.push(searchSchemes(specificFilters));
+    }
+
+    const results = await Promise.all(searchPromises);
+    const allHits = results.flat();
+
+    const seen = new Set<string>();
+    const uniqueHits = allHits.filter((hit: any) => {
+      const slug = hit._source?.slug || hit.slug || '';
+      if (seen.has(slug)) return false;
+      seen.add(slug);
+      return true;
+    });
+
+    let schemes = parseSchemesFromSearch(uniqueHits);
+    schemes = schemes.map((s) => scoreScheme(s, profile));
+    schemes.sort((a, b) => b.confidence - a.confidence);
+
+    return schemes.slice(0, 10);
+  }
+
+  async matchAllFarmers(
+    batchSize = 50,
+    onProgress?: (processed: number, total: number) => void,
+  ): Promise<FarmerSchemeResult[]> {
+    const client = await this.getClient();
+    const annamDb = this.getAnnamDb(client);
+    const mainDb = this.getMainDb(client);
+    const users = annamDb.collection('users');
+    const matchResults = mainDb.collection('scheme_matches');
+
+    const query = {
+      'farmerProfile.phoneNo': { $exists: true, $ne: null, $ne: '' },
+      'farmerProfile.state': { $exists: true, $ne: null, $ne: '' },
+    };
+
+    const totalCount = await users.countDocuments(query);
+    console.log(`[SchemeMatcher] Matching ${totalCount} farmers...`);
+
+    const results: FarmerSchemeResult[] = [];
+    let processed = 0;
+
+    const cursor = users.find(query).batchSize(batchSize);
+
+    for await (const user of cursor) {
+      const profile = user as any;
+      const fp = profile.farmerProfile;
+
+      const farmerProfile: FarmerProfile = {
+        _id: profile._id?.toString(),
+        phoneNo: fp?.phoneNo,
+        farmerName: fp?.farmerName,
+        age: fp?.age,
+        gender: fp?.gender,
+        state: fp?.state,
+        district: fp?.district,
+        blockName: fp?.blockName,
+        villageName: fp?.villageName,
+        cropsCultivated: fp?.cropsCultivated,
+        primaryCrop: fp?.primaryCrop,
+      };
+
+      try {
+        const schemes = await this.matchFarmer(farmerProfile);
+
+        if (schemes.length > 0) {
+          const result: FarmerSchemeResult = {
+            farmerId: profile._id?.toString() || '',
+            farmerName: fp?.farmerName || 'Unknown',
+            state: fp?.state || '',
+            district: fp?.district || '',
+            schemes,
+            matchedAt: new Date(),
+          };
+
+          results.push(result);
+
+          await matchResults.updateOne(
+            { farmerId: result.farmerId },
+            { $set: result },
+            { upsert: true },
+          );
+        }
+      } catch (err) {
+        console.error(`[SchemeMatcher] Error matching farmer ${profile._id}:`, err);
+      }
+
+      processed++;
+      if (processed % 10 === 0) {
+        console.log(`[SchemeMatcher] Processed ${processed}/${totalCount}`);
+        onProgress?.(processed, totalCount);
+      }
+
+      await new Promise((r) => setTimeout(r, 300));
+    }
+
+    console.log(`[SchemeMatcher] Complete. ${results.length} farmers have matching schemes.`);
+    return results;
+  }
+
+  async getFarmerMatches(farmerId: string): Promise<FarmerSchemeResult | null> {
+    const client = await this.getClient();
+    const mainDb = this.getMainDb(client);
+    const matchResults = mainDb.collection<FarmerSchemeResult>('scheme_matches');
+    return matchResults.findOne({ farmerId });
+  }
+
+  async getRecentResults(limit = 50): Promise<FarmerSchemeResult[]> {
+    const client = await this.getClient();
+    const mainDb = this.getMainDb(client);
+    const matchResults = mainDb.collection<FarmerSchemeResult>('scheme_matches');
+    return matchResults.find({}).sort({ matchedAt: -1 }).limit(limit).toArray();
+  }
+
+  async getStats(): Promise<{
+    totalFarmersMatched: number;
+    totalSchemesFound: number;
+    stateDistribution: Record<string, number>;
+  }> {
+    const client = await this.getClient();
+    const mainDb = this.getMainDb(client);
+    const matchResults = mainDb.collection<FarmerSchemeResult>('scheme_matches');
+
+    const totalFarmersMatched = await matchResults.countDocuments();
+
+    const pipeline = [
+      { $unwind: '$schemes' },
+      { $group: { _id: '$state', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ];
+
+    const stateAgg = await matchResults.aggregate(pipeline).toArray();
+    const stateDistribution: Record<string, number> = {};
+    let totalSchemesFound = 0;
+
+    for (const entry of stateAgg) {
+      stateDistribution[entry._id] = entry.count;
+      totalSchemesFound += entry.count;
+    }
+
+    return { totalFarmersMatched, totalSchemesFound, stateDistribution };
+  }
+
+  async close() {
+    if (this.mongoClient) {
+      await this.mongoClient.close();
+      this.mongoClient = null;
+    }
+  }
+}


### PR DESCRIPTION
- SchemeMatcherService: queries MyScheme.gov.in API directly with farmer demographics
- Dual-query strategy: base + specific filters for better relevance
- Score-based matching: assigns confidence scores based on state, age, gender, occupation alignment
- Stores results in scheme_matches collection with upsert deduplication
- SchemeController: admin endpoints for per-farmer, custom, bulk matching, stats
- Cron job runs daily at 3 AM IST for continuous re-checking
- Supports batch processing with progress callbacks for large farmer datasets