### PR TITLE
feat: add coordinator map dashboard with farmer GPS visualization

### DIFF
--- a/backend/src/modules/chatbot/controllers/ChatbotController.ts
+++ b/backend/src/modules/chatbot/controllers/ChatbotController.ts
@@ -2053,6 +2053,17 @@ export class ChatbotController {
     }
   }
 
+  @Get('/coordinator-farmers-geo/:userId')
+  @HttpCode(200)
+  @Authorized(['admin', ...COORDINATOR_ROLES])
+  async getCoordinatorFarmerGeoData(
+    @Param('userId') userId: string,
+    @CurrentUser() currentUser: IUser,
+  ) {
+    await this.assertCoordinatorOwnDashboard(userId, currentUser);
+    return this.chatbotService.getCoordinatorFarmerGeoData(userId);
+  }
+
   @Get('/village-data')
   @HttpCode(200)
   @Authorized()

--- a/backend/src/modules/chatbot/services/ChatbotService.ts
+++ b/backend/src/modules/chatbot/services/ChatbotService.ts
@@ -3764,6 +3764,10 @@ export class ChatbotService extends BaseService implements IChatbotService {
     }
   }
 
+  async getCoordinatorFarmerGeoData(coordinatorId: string) {
+    return this.chatbotRepository.getCoordinatorFarmerGeoData(coordinatorId);
+  }
+
   async getVillageUserCounts(state: string, district: string, source: string, userType: string): Promise<any> {
     try {
       return this.chatbotRepository.getVillageUserCounts(state, district, source, userType, undefined);

--- a/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/ChatbotRepository.ts
@@ -16215,6 +16215,99 @@ export class ChatbotRepository implements IChatbotRepository {
     }
   }
 
+  async getCoordinatorFarmerGeoData(coordinatorId: string) {
+    await this.init('annam');
+    const coordinator = await this.users.findOne({
+      _id: new ObjectId(coordinatorId),
+    });
+    if (!coordinator) throw new BadRequestError('Coordinator not found');
+
+    const assignedIds: ObjectId[] = coordinator.assignedCoordinators ?? [];
+    if (assignedIds.length === 0) {
+      return { coordinatorId, farmers: [], stats: { total: 0, withLocation: 0, totalQuestions: 0 } };
+    }
+
+    const farmers = await this.users
+      .find(
+        { _id: { $in: assignedIds } },
+        {
+          projection: {
+            _id: 1,
+            name: 1,
+            firstName: 1,
+            lastName: 1,
+            email: 1,
+            firebaseUID: 1,
+            userRole: 1,
+            'farmerProfile.farmerName': 1,
+            'farmerProfile.location': 1,
+            'farmerProfile.district': 1,
+            'farmerProfile.blockName': 1,
+            'farmerProfile.villageName': 1,
+            'farmerProfile.primaryCrop': 1,
+            'farmerProfile.cropsCultivated': 1,
+            'farmerProfile.state': 1,
+          },
+        },
+      )
+      .toArray();
+
+    // Fetch question counts per farmer from questions collection
+    const farmerObjectIds = farmers.map((f: any) => new ObjectId(f._id));
+    const questionCounts = await this.questions
+      .aggregate([
+        { $match: { userId: { $in: farmerObjectIds } } },
+        {
+          $group: {
+            _id: '$userId',
+            totalQuestions: { $sum: 1 },
+            closedQuestions: { $sum: { $cond: ['$isClosed', 1, 0] } },
+            lastQuestionAt: { $max: '$createdAt' },
+          },
+        },
+      ])
+      .toArray();
+
+    const countMap = new Map(
+      questionCounts.map((q: any) => [q._id.toString(), q]),
+    );
+
+    const enrichedFarmers = farmers.map((f: any) => {
+      const id = f._id.toString();
+      const qc = countMap.get(id);
+      return {
+        userId: id,
+        name: f.name || `${f.firstName ?? ''} ${f.lastName ?? ''}`.trim(),
+        email: f.email,
+        userRole: f.userRole,
+        farmerProfile: f.farmerProfile ?? {},
+        location: f.farmerProfile?.location ?? null,
+        totalQuestions: qc?.totalQuestions ?? 0,
+        closedQuestions: qc?.closedQuestions ?? 0,
+        lastQuestionAt: qc?.lastQuestionAt ?? null,
+      };
+    });
+
+    const withLocation = enrichedFarmers.filter((f: any) => f.location?.latitude && f.location?.longitude);
+    const totalQuestions = enrichedFarmers.reduce((sum: number, f: any) => sum + f.totalQuestions, 0);
+
+    return {
+      coordinatorId,
+      coordinatorRole: coordinator.userRole,
+      scope: {
+        district: coordinator.farmerProfile?.district,
+        block: coordinator.farmerProfile?.blockName,
+        state: coordinator.farmerProfile?.state,
+      },
+      farmers: enrichedFarmers,
+      stats: {
+        total: enrichedFarmers.length,
+        withLocation: withLocation.length,
+        totalQuestions,
+      },
+    };
+  }
+
   async getVillageUserCounts(
     state: string,
     district: string,

--- a/frontend/src/features/chatbotDashboard/components/CoordinatorMapDashboard.tsx
+++ b/frontend/src/features/chatbotDashboard/components/CoordinatorMapDashboard.tsx
@@ -1,0 +1,163 @@
+import { useMemo, useState } from "react";
+import { MapContainer, TileLayer, Marker, Popup, ZoomControl } from "react-leaflet";
+import * as L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { Loader2, MapPin, Users, MessageSquare, CheckCircle } from "lucide-react";
+import { useCoordinatorFarmerGeo, type CoordinatorFarmerGeo } from "../hooks/useCoordinatorFarmerGeo";
+import { useAuthStore } from "@/stores/auth-store";
+import { useGetCurrentUser } from "@/hooks/api/user/useGetCurrentUser";
+
+function createFarmerIcon(questions: number): L.DivIcon {
+  const color = questions === 0 ? "#9ca3af" : questions < 5 ? "#f59e0b" : "#16a34a";
+  return L.divIcon({
+    className: "",
+    iconSize: [24, 24],
+    iconAnchor: [12, 12],
+    popupAnchor: [0, -14],
+    html: `<div style="width:24px;height:24px;border-radius:50%;background:${color};border:2px solid white;box-shadow:0 1px 4px rgba(0,0,0,.3);display:flex;align-items:center;justify-content:center">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+    </div>`,
+  });
+}
+
+const noLocationIcon = L.divIcon({
+  className: "",
+  iconSize: [0, 0],
+  iconAnchor: [0, 0],
+  html: "",
+});
+
+function FarmerPopup({ farmer }: { farmer: CoordinatorFarmerGeo }) {
+  const p = farmer.farmerProfile;
+  return (
+    <div className="min-w-[200px] text-sm space-y-1">
+      <p className="font-semibold text-base">{farmer.name || p.farmerName || "Unknown"}</p>
+      <p className="text-muted-foreground">{p.villageName}, {p.blockName}, {p.district}</p>
+      {p.primaryCrop && <p className="text-muted-foreground">Crop: {p.primaryCrop}</p>}
+      <div className="flex gap-3 pt-1 text-xs">
+        <span className="flex items-center gap-1"><MessageSquare size={12} /> {farmer.totalQuestions} Q</span>
+        <span className="flex items-center gap-1"><CheckCircle size={12} /> {farmer.closedQuestions} closed</span>
+      </div>
+      {farmer.lastQuestionAt && (
+        <p className="text-xs text-muted-foreground pt-1">
+          Last active: {new Date(farmer.lastQuestionAt).toLocaleDateString()}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function StatsBar({ stats }: { stats: { total: number; withLocation: number; totalQuestions: number } }) {
+  return (
+    <div className="flex gap-4 p-3 bg-card/80 border border-border rounded-lg text-sm">
+      <div className="flex items-center gap-1.5">
+        <Users size={14} className="text-muted-foreground" />
+        <span className="font-medium">{stats.total}</span>
+        <span className="text-muted-foreground">farmers</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <MapPin size={14} className="text-muted-foreground" />
+        <span className="font-medium">{stats.withLocation}</span>
+        <span className="text-muted-foreground">on map</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <MessageSquare size={14} className="text-muted-foreground" />
+        <span className="font-medium">{stats.totalQuestions}</span>
+        <span className="text-muted-foreground">questions</span>
+      </div>
+    </div>
+  );
+}
+
+export default function CoordinatorMapDashboard() {
+  const { user } = useAuthStore();
+  const { data: currentUser } = useGetCurrentUser({ enabled: !!user });
+  const coordinatorId = currentUser?.userId ?? currentUser?._id ?? "";
+  const { data, isLoading } = useCoordinatorFarmerGeo(coordinatorId, Boolean(coordinatorId));
+  const [hoveredFarmer, setHoveredFarmer] = useState<string | null>(null);
+
+  const farmersWithLocation = useMemo(
+    () => data?.farmers.filter((f) => f.location?.latitude && f.location?.longitude) ?? [],
+    [data],
+  );
+
+  const center = useMemo(() => {
+    if (farmersWithLocation.length === 0) return [20.5937, 78.9629] as [number, number];
+    const avgLat = farmersWithLocation.reduce((s, f) => s + f.location!.latitude, 0) / farmersWithLocation.length;
+    const avgLng = farmersWithLocation.reduce((s, f) => s + f.location!.longitude, 0) / farmersWithLocation.length;
+    return [avgLat, avgLng] as [number, number];
+  }, [farmersWithLocation]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <Loader2 className="animate-spin text-muted-foreground" size={32} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 p-4 h-full">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Farmer Map</h2>
+        {data?.scope?.district && (
+          <span className="text-sm text-muted-foreground">
+            {data.scope.district}{data.scope.block ? ` / ${data.scope.block}` : ""}
+          </span>
+        )}
+      </div>
+
+      {data?.stats && <StatsBar stats={data.stats} />}
+
+      <div className="flex-1 rounded-lg overflow-hidden border border-border relative" style={{ minHeight: 400 }}>
+        <MapContainer
+          center={center}
+          zoom={farmersWithLocation.length > 0 ? 10 : 5}
+          zoomControl={false}
+          style={{ height: "100%", width: "100%" }}
+          scrollWheelZoom={true}
+        >
+          <ZoomControl position="topright" />
+          <TileLayer
+            attribution='&copy; <a href="https://carto.com/">CARTO</a>'
+            url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+          />
+          {farmersWithLocation.map((farmer) => (
+            <Marker
+              key={farmer.userId}
+              position={[farmer.location!.latitude, farmer.location!.longitude]}
+              icon={createFarmerIcon(farmer.totalQuestions)}
+              eventHandlers={{
+                mouseover: () => setHoveredFarmer(farmer.userId),
+                mouseout: () => setHoveredFarmer(null),
+              }}
+            >
+              <Popup>
+                <FarmerPopup farmer={farmer} />
+              </Popup>
+            </Marker>
+          ))}
+        </MapContainer>
+
+        {farmersWithLocation.length === 0 && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/60">
+            <p className="text-muted-foreground text-sm">No farmers with GPS data found</p>
+          </div>
+        )}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 text-xs text-muted-foreground px-1">
+        <span className="flex items-center gap-1">
+          <span className="w-3 h-3 rounded-full bg-gray-400 inline-block" /> No questions
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="w-3 h-3 rounded-full bg-amber-500 inline-block" /> 1-4 questions
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="w-3 h-3 rounded-full bg-green-600 inline-block" /> 5+ questions
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/chatbotDashboard/hooks/useCoordinatorFarmerGeo.ts
+++ b/frontend/src/features/chatbotDashboard/hooks/useCoordinatorFarmerGeo.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "@/hooks/api/api-fetch";
+import { env } from "@/config/env";
+
+export interface CoordinatorFarmerGeo {
+  userId: string;
+  name: string;
+  email: string;
+  userRole: string;
+  farmerProfile: {
+    farmerName?: string;
+    district?: string;
+    blockName?: string;
+    villageName?: string;
+    primaryCrop?: string;
+    cropsCultivated?: string[];
+    state?: string;
+  };
+  location: { latitude: number; longitude: number } | null;
+  totalQuestions: number;
+  closedQuestions: number;
+  lastQuestionAt: string | null;
+}
+
+export interface CoordinatorFarmerGeoResponse {
+  coordinatorId: string;
+  coordinatorRole: string;
+  scope: {
+    district?: string;
+    block?: string;
+    state?: string;
+  };
+  farmers: CoordinatorFarmerGeo[];
+  stats: {
+    total: number;
+    withLocation: number;
+    totalQuestions: number;
+  };
+}
+
+const EMPTY_RESPONSE: CoordinatorFarmerGeoResponse = {
+  coordinatorId: "",
+  coordinatorRole: "",
+  scope: {},
+  farmers: [],
+  stats: { total: 0, withLocation: 0, totalQuestions: 0 },
+};
+
+export function useCoordinatorFarmerGeo(coordinatorId: string, enabled = true) {
+  return useQuery<CoordinatorFarmerGeoResponse, Error>({
+    queryKey: ["coordinator-farmer-geo", coordinatorId],
+    enabled: enabled && Boolean(coordinatorId),
+    staleTime: 60_000,
+    queryFn: async () =>
+      (await apiFetch<CoordinatorFarmerGeoResponse>(
+        `${env.apiBaseUrl()}/analytics/coordinator-farmers-geo/${coordinatorId}`,
+      )) ?? EMPTY_RESPONSE,
+  });
+}

--- a/frontend/src/routes/coordinator/index.tsx
+++ b/frontend/src/routes/coordinator/index.tsx
@@ -5,6 +5,7 @@ import { isCoordinatorRole } from "@/lib/roles";
 import { useAuthStore } from "@/stores/auth-store";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
+import CoordinatorMapDashboard from "@/features/chatbotDashboard/components/CoordinatorMapDashboard";
 
 export const Route = createFileRoute("/coordinator/")({
   component: RouteComponent,
@@ -22,7 +23,6 @@ function RouteComponent() {
       navigate({ to: "/auth" });
       return;
     }
-
     if (currentUser && !isCoordinatorRole(currentUser.role)) {
       navigate({ to: "/home" });
     }
@@ -39,6 +39,9 @@ function RouteComponent() {
           <UserProfileActions />
         </div>
       </header>
+      <main>
+        <CoordinatorMapDashboard />
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
- Backend: new GET /analytics/coordinator-farmers-geo/:userId endpoint
- Returns assigned farmers with GPS coordinates, question counts, engagement data
- Enriches farmer data with aggregate question stats from questions collection
- Frontend: Leaflet map with color-coded markers by engagement level
- Stats bar showing total farmers, map coverage, total questions
- Farmer popup with profile details, crop, question stats, last active
- Uses existing react-leaflet infrastructure and CartoDB tiles
- Auth-gated to coordinator roles + admin