### PR TITLE
test: add ACC automated test coverage

### DIFF
--- a/backend/src/modules/plivo/tests/README.md
+++ b/backend/src/modules/plivo/tests/README.md
@@ -1,0 +1,126 @@
+# ACC Automated Tests
+
+This directory contains the first-pass automated contract and orchestration tests
+for the Agricultural Call Center (ACC).
+
+The tests verify ACC-owned behavior only. Plivo, Sarvam AI, WebSocket connections,
+MongoDB repositories, and other external integrations are mocked. No test in this
+directory calls a real phone number, external API, or production database.
+
+## Test files
+
+### `agent-availability-management.test.ts`
+
+Verifies that:
+
+- the first online call agent receives `agent_1`;
+- the next online call agent receives the next available number;
+- taking an agent offline resets availability and call state;
+- routing selects the lowest-numbered free agent;
+- busy agents are skipped;
+- no available agent returns `null`;
+- assignment marks an agent busy and records the call UUID;
+- call completion makes the agent available again; and
+- non-call-agent users cannot register as available.
+
+Heartbeat cleanup remains an explicit `it.todo`. The architecture describes a
+cleanup job, but no testable heartbeat-cleanup implementation entry point was
+found in the current source tree.
+
+### `sarvam-speech-contract.test.ts`
+
+Verifies that:
+
+- one call opens four Sarvam sockets: inbound/outbound transcribe and translate;
+- speech sockets use `/speech-to-text/ws`;
+- the model is `saaras:v3`;
+- the modes are `transcribe` and `translate`;
+- sample rate and codec parameters are correct;
+- no speech socket uses the text-translation model `mayura:v1`;
+- audio is sent as the expected base64 JSON payload;
+- transcript, translation, detected-language, API-error, and socket-error events
+  are handled safely; and
+- call completion flushes and closes every Sarvam socket.
+
+### `call-routing.test.ts`
+
+Verifies that:
+
+- an incoming Plivo call uses atomic agent reservation;
+- the selected agent and call UUID are mapped in `PlivoService`;
+- the XML streams both audio tracks before dialing the browser endpoint;
+- no-agent routing speaks the busy message and hangs up without dialing;
+- the call UUID can be read from Plivo's query string; and
+- an agent reserved before a routing failure is released.
+
+### `call-wrap-up.test.ts`
+
+Verifies that:
+
+- Plivo call metadata, both participant transcripts, translations, detected
+  languages, and the agent mapping are persisted;
+- an existing call record is updated instead of duplicated;
+- captured transcripts are still saved if Plivo metadata cannot be fetched;
+- repository failure is handled without crashing wrap-up; and
+- cleanup removes transcripts, translations, detected language, and agent
+  mapping from in-memory call state.
+
+### `concurrent-multi-agent.test.ts`
+
+Verifies the service contract for concurrent routing:
+
+- simultaneous calls receive different free agents;
+- each assignment records its own call UUID;
+- excess calls receive no assignment when all agents are busy;
+- completing one call does not release another call's agent; and
+- only the released agent is reused for the next call.
+
+These are mocked first-pass concurrency tests. They exercise the atomic repository
+boundary used by `AgentAssignmentService`; they are not a real MongoDB concurrency
+or load test.
+
+### `complete-agent-session-lifecycle.test.ts`
+
+Provides a mocked end-to-end ACC orchestration test covering:
+
+- the Plivo answer webhook atomically reserving an agent;
+- generation of the agent connection XML;
+- creation of the backend media-stream session;
+- forwarding inbound farmer and outbound agent audio;
+- broadcasting mocked Sarvam transcript and translation events to the dashboard;
+- processing remaining audio when Plivo sends the stop event;
+- broadcasting the final dual-participant transcript;
+- saving call details before in-memory cleanup;
+- releasing the assigned agent after cleanup; and
+- preventing a later socket-close event from running wrap-up twice.
+
+This is an end-to-end orchestration test within the backend process. External
+services and the database remain mocked, so it is deterministic and safe for CI.
+
+## Run the tests
+
+From `backend`:
+
+```powershell
+pnpm vitest run src/modules/plivo/tests/agent-availability-management.test.ts
+pnpm vitest run src/modules/plivo/tests/sarvam-speech-contract.test.ts
+pnpm vitest run src/modules/plivo/tests/call-routing.test.ts
+pnpm vitest run src/modules/plivo/tests/call-wrap-up.test.ts
+pnpm vitest run src/modules/plivo/tests/concurrent-multi-agent.test.ts
+pnpm vitest run src/modules/plivo/tests/complete-agent-session-lifecycle.test.ts
+```
+
+Run all ACC tests together:
+
+```powershell
+pnpm vitest run src/modules/plivo/tests
+```
+
+## Scope and safety
+
+- Production and source implementation files were not modified.
+- Real MongoDB, Firebase, Plivo, and Sarvam services are not used.
+- Speech recognition and translation quality are intentionally not tested.
+- Plivo's internal audio behavior and real phone-call quality are out of scope.
+- Performance thresholds and load tests should be added only after expected
+  production concurrency and latency targets are confirmed.

--- a/backend/src/modules/plivo/tests/agent-availability-management.test.ts
+++ b/backend/src/modules/plivo/tests/agent-availability-management.test.ts
@@ -1,0 +1,282 @@
+import 'reflect-metadata';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {BadRequestError} from 'routing-controllers';
+import {UserService} from '#root/modules/user/services/UserService.js';
+import {IUser} from '#root/shared/interfaces/models.js';
+
+vi.mock('#root/modules/notification/services/NotificationService.js', () => ({
+  NotificationService: class NotificationService {},
+}));
+
+describe('Agent Availability Management', () => {
+  const session = {
+    startTransaction: vi.fn(),
+    commitTransaction: vi.fn(),
+    abortTransaction: vi.fn().mockResolvedValue(undefined),
+    endSession: vi.fn(),
+    inTransaction: vi.fn(() => true),
+  };
+
+  const userRepo = {
+    findById: vi.fn(),
+    findCallAgents: vi.fn(),
+    edit: vi.fn(),
+    findAndMarkAvailableAgent: vi.fn(),
+  };
+
+  const mongoDatabase = {
+    getClient: vi.fn().mockResolvedValue({
+      startSession: vi.fn(() => session),
+    }),
+  };
+
+  let service: UserService;
+
+  const callAgent = (overrides: Partial<IUser> = {}): IUser =>
+    ({
+      _id: 'agent-user-1',
+      role: 'call_agent',
+      agent: 'not_available',
+      isCallAgentActive: false,
+      isBusy: false,
+      currentCallUuid: null,
+      ...overrides,
+    }) as IUser;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    session.inTransaction.mockReturnValue(true);
+    mongoDatabase.getClient.mockResolvedValue({
+      startSession: vi.fn(() => session),
+    });
+    service = new UserService(
+      userRepo as any,
+      {} as any,
+      mongoDatabase as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+  });
+
+  it('registers the first agent as available', async () => {
+    // Arrange
+    const registeredAgent = callAgent({
+      agent: 'agent_1',
+      isCallAgentActive: true,
+    });
+    userRepo.findById.mockResolvedValue(callAgent());
+    userRepo.findCallAgents.mockResolvedValue([]);
+    userRepo.edit.mockResolvedValue(registeredAgent);
+
+    // Act
+    const result = await service.setAgentOnline('agent-user-1');
+
+    // Assert
+    expect(userRepo.edit).toHaveBeenCalledWith(
+      'agent-user-1',
+      {
+        agent: 'agent_1',
+        isCallAgentActive: true,
+        isBusy: false,
+        currentCallUuid: null,
+      },
+      session,
+    );
+    expect(result).toEqual(registeredAgent);
+  });
+
+  it('registers a second agent in the next available position', async () => {
+    // Arrange
+    const registeredAgent = callAgent({
+      _id: 'agent-user-2',
+      agent: 'agent_2',
+      isCallAgentActive: true,
+    });
+    userRepo.findById.mockResolvedValue(callAgent({_id: 'agent-user-2'}));
+    userRepo.findCallAgents.mockResolvedValue([
+      callAgent({agent: 'agent_1', isCallAgentActive: true}),
+    ]);
+    userRepo.edit.mockResolvedValue(registeredAgent);
+
+    // Act
+    const result = await service.setAgentOnline('agent-user-2');
+
+    // Assert
+    expect(userRepo.edit).toHaveBeenCalledWith(
+      'agent-user-2',
+      expect.objectContaining({
+        agent: 'agent_2',
+        isCallAgentActive: true,
+        isBusy: false,
+        currentCallUuid: null,
+      }),
+      session,
+    );
+    expect(result).toEqual(registeredAgent);
+  });
+
+  it('takes an agent offline and releases their position', async () => {
+    // Arrange
+    const offlineAgent = callAgent();
+    userRepo.findById.mockResolvedValue(
+      callAgent({
+        agent: 'agent_1',
+        isCallAgentActive: true,
+        isBusy: true,
+        currentCallUuid: 'call-1',
+      }),
+    );
+    userRepo.edit.mockResolvedValue(offlineAgent);
+
+    // Act
+    const result = await service.setAgentOffline('agent-user-1');
+
+    // Assert
+    expect(userRepo.edit).toHaveBeenCalledWith(
+      'agent-user-1',
+      {
+        agent: 'not_available',
+        isCallAgentActive: false,
+        isBusy: false,
+        currentCallUuid: null,
+      },
+      session,
+    );
+    expect(result).toEqual(offlineAgent);
+  });
+
+  it('selects the lowest numbered free agent', async () => {
+    // Arrange
+    const agentOne = callAgent({
+      agent: 'agent_1',
+      isCallAgentActive: true,
+    });
+    userRepo.findCallAgents.mockResolvedValue([
+      callAgent({_id: 'agent-user-3', agent: 'agent_3', isCallAgentActive: true}),
+      agentOne,
+      callAgent({_id: 'agent-user-2', agent: 'agent_2', isCallAgentActive: true}),
+    ]);
+
+    // Act
+    const result = await service.findAvailableAgent();
+
+    // Assert
+    expect(result).toEqual(agentOne);
+  });
+
+  it('skips a busy agent when routing a call', async () => {
+    // Arrange
+    const freeAgent = callAgent({
+      _id: 'agent-user-2',
+      agent: 'agent_2',
+      isCallAgentActive: true,
+    });
+    userRepo.findCallAgents.mockResolvedValue([
+      callAgent({
+        agent: 'agent_1',
+        isCallAgentActive: true,
+        isBusy: true,
+        currentCallUuid: 'active-call',
+      }),
+      freeAgent,
+    ]);
+
+    // Act
+    const result = await service.findAvailableAgent();
+
+    // Assert
+    expect(result).toEqual(freeAgent);
+  });
+
+  it('reports no agent when nobody is available', async () => {
+    // Arrange
+    userRepo.findCallAgents.mockResolvedValue([
+      callAgent({agent: 'agent_1', isCallAgentActive: false}),
+      callAgent({
+        _id: 'agent-user-2',
+        agent: 'agent_2',
+        isCallAgentActive: true,
+        isBusy: true,
+      }),
+    ]);
+
+    // Act
+    const result = await service.findAvailableAgent();
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it('marks an assigned agent as busy for the call', async () => {
+    // Arrange
+    const busyAgent = callAgent({
+      agent: 'agent_1',
+      isCallAgentActive: true,
+      isBusy: true,
+      currentCallUuid: 'call-123',
+    });
+    userRepo.findById.mockResolvedValue(
+      callAgent({agent: 'agent_1', isCallAgentActive: true}),
+    );
+    userRepo.edit.mockResolvedValue(busyAgent);
+
+    // Act
+    const result = await service.markAgentAsBusy('agent-user-1', 'call-123');
+
+    // Assert
+    expect(userRepo.edit).toHaveBeenCalledWith(
+      'agent-user-1',
+      {isBusy: true, currentCallUuid: 'call-123'},
+      session,
+    );
+    expect(result).toEqual(busyAgent);
+  });
+
+  it('returns an agent to available after the call ends', async () => {
+    // Arrange
+    const availableAgent = callAgent({
+      agent: 'agent_1',
+      isCallAgentActive: true,
+    });
+    userRepo.findById.mockResolvedValue(
+      callAgent({
+        agent: 'agent_1',
+        isCallAgentActive: true,
+        isBusy: true,
+        currentCallUuid: 'call-123',
+      }),
+    );
+    userRepo.edit.mockResolvedValue(availableAgent);
+
+    // Act
+    const result = await service.markAgentAsAvailable('agent-user-1');
+
+    // Assert
+    expect(userRepo.edit).toHaveBeenCalledWith(
+      'agent-user-1',
+      {isBusy: false, currentCallUuid: null},
+      session,
+    );
+    expect(result).toEqual(availableAgent);
+  });
+
+  it('rejects online registration for a non-call-agent', async () => {
+    // Arrange
+    userRepo.findById.mockResolvedValue({
+      _id: 'farmer-user-1',
+      role: 'farmer',
+    });
+
+    // Act
+    const action = service.setAgentOnline('farmer-user-1');
+
+    // Assert
+    await expect(action).rejects.toBeInstanceOf(BadRequestError);
+    expect(userRepo.edit).not.toHaveBeenCalled();
+  });
+
+  it.todo(
+    'marks an agent offline when heartbeat cleanup detects an expired heartbeat',
+  );
+});

--- a/backend/src/modules/plivo/tests/call-routing.test.ts
+++ b/backend/src/modules/plivo/tests/call-routing.test.ts
@@ -1,0 +1,182 @@
+import 'reflect-metadata';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {PlivoController} from '#root/modules/plivo/controllers/PlivoController.js';
+
+const mocks = vi.hoisted(() => ({
+  plivoClient: {
+    calls: {
+      list: vi.fn(),
+    },
+  },
+  plivoClientConstructor: vi.fn(),
+  getAgentCredentials: vi.fn((agentNumber: string) => ({
+    username: `${agentNumber}-endpoint`,
+  })),
+}));
+
+vi.mock('plivo', () => ({
+  default: {
+    Client: mocks.plivoClientConstructor.mockImplementation(
+      () => mocks.plivoClient,
+    ),
+  },
+}));
+
+vi.mock('#root/config/app.js', () => ({
+  appConfig: {
+    plivo: {
+      streamUrl: 'wss://acc.example.test/audio',
+      plivo_number: '+911234567890',
+      getAgentCredentials: mocks.getAgentCredentials,
+    },
+  },
+}));
+
+describe('ACC Call Routing', () => {
+  const callDetailsRepository = {};
+  const userService = {
+    findAndMarkAvailableAgent: vi.fn(),
+    markAgentAsAvailable: vi.fn(),
+  };
+  const plivoService = {
+    setCallAgent: vi.fn(),
+  };
+
+  let controller: PlivoController;
+  let response: {
+    set: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+    status: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    response = {
+      set: vi.fn(),
+      send: vi.fn(),
+      status: vi.fn(),
+    };
+    response.status.mockReturnValue(response);
+    controller = new PlivoController(
+      callDetailsRepository as any,
+      userService as any,
+      plivoService as any,
+    );
+  });
+
+  it('routes an incoming call to the atomically reserved agent', async () => {
+    // Arrange
+    userService.findAndMarkAvailableAgent.mockResolvedValue({
+      _id: 'agent-user-1',
+      role: 'call_agent',
+      agent: 'agent_1',
+      isCallAgentActive: true,
+      isBusy: true,
+      currentCallUuid: 'call-123',
+    });
+    const request = {
+      body: {CallUUID: 'call-123'},
+      query: {},
+    };
+
+    // Act
+    await controller.answer(request as any, response as any);
+
+    // Assert
+    expect(userService.findAndMarkAvailableAgent)
+      .toHaveBeenCalledWith('call-123');
+    expect(mocks.getAgentCredentials).toHaveBeenCalledWith('agent_1');
+    expect(plivoService.setCallAgent)
+      .toHaveBeenCalledWith('call-123', 'agent-user-1');
+    expect(response.set).toHaveBeenCalledWith('Content-Type', 'text/xml');
+    expect(response.send).toHaveBeenCalledWith(
+      expect.stringContaining('<User>agent_1-endpoint</User>'),
+    );
+  });
+
+  it('streams both call tracks before connecting the agent', async () => {
+    // Arrange
+    userService.findAndMarkAvailableAgent.mockResolvedValue({
+      _id: 'agent-user-2',
+      role: 'call_agent',
+      agent: 'agent_2',
+    });
+
+    // Act
+    await controller.answer(
+      {body: {CallUUID: 'call-456'}, query: {}} as any,
+      response as any,
+    );
+
+    // Assert
+    const xml = response.send.mock.calls[0][0] as string;
+    expect(xml).toContain(
+      '<Stream contentType="audio/x-l16;rate=16000"',
+    );
+    expect(xml).toContain('audioTrack="both"');
+    expect(xml).toContain('wss://acc.example.test/audio</Stream>');
+    expect(xml.indexOf('<Stream')).toBeLessThan(xml.indexOf('<Dial'));
+  });
+
+  it('returns a busy response without dialing when no agent is available', async () => {
+    // Arrange
+    userService.findAndMarkAvailableAgent.mockResolvedValue(null);
+
+    // Act
+    await controller.answer(
+      {body: {CallUUID: 'call-789'}, query: {}} as any,
+      response as any,
+    );
+
+    // Assert
+    const xml = response.send.mock.calls[0][0] as string;
+    expect(xml).toContain('All agents are busy. Please call back later.');
+    expect(xml).toContain('<Hangup />');
+    expect(xml).not.toContain('<Dial');
+    expect(plivoService.setCallAgent).not.toHaveBeenCalled();
+  });
+
+  it('accepts the Plivo call UUID from the query string', async () => {
+    // Arrange
+    userService.findAndMarkAvailableAgent.mockResolvedValue(null);
+
+    // Act
+    await controller.answer(
+      {body: {}, query: {CallUUID: 'query-call-123'}} as any,
+      response as any,
+    );
+
+    // Assert
+    expect(userService.findAndMarkAvailableAgent)
+      .toHaveBeenCalledWith('query-call-123');
+  });
+
+  it('releases a reserved agent if response construction fails', async () => {
+    // Arrange
+    userService.findAndMarkAvailableAgent.mockResolvedValue({
+      _id: 'agent-user-1',
+      role: 'call_agent',
+      agent: 'agent_1',
+    });
+    mocks.getAgentCredentials.mockImplementationOnce(() => {
+      throw new Error('missing endpoint credentials');
+    });
+    userService.markAgentAsAvailable.mockResolvedValue({});
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    // Act
+    await controller.answer(
+      {body: {CallUUID: 'call-error'}, query: {}} as any,
+      response as any,
+    );
+
+    // Assert
+    expect(userService.markAgentAsAvailable)
+      .toHaveBeenCalledWith('agent-user-1');
+    expect(response.status).toHaveBeenCalledWith(500);
+    expect(response.send).toHaveBeenCalledWith('Internal Server Error');
+    consoleError.mockRestore();
+  });
+});

--- a/backend/src/modules/plivo/tests/call-wrap-up.test.ts
+++ b/backend/src/modules/plivo/tests/call-wrap-up.test.ts
@@ -1,0 +1,189 @@
+import 'reflect-metadata';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {PlivoService} from '#root/modules/plivo/services/PlivoService.js';
+
+const mocks = vi.hoisted(() => {
+  class MockWebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+  }
+
+  return {
+    MockWebSocket,
+    plivoCallsGet: vi.fn(),
+    plivoClientConstructor: vi.fn(),
+  };
+});
+
+vi.mock('ws', () => ({
+  WebSocket: mocks.MockWebSocket,
+}));
+
+vi.mock('plivo', () => ({
+  default: {
+    Client: mocks.plivoClientConstructor.mockImplementation(() => ({
+      calls: {
+        get: mocks.plivoCallsGet,
+      },
+    })),
+  },
+}));
+
+vi.mock('../../../config/app.js', () => ({
+  appConfig: {
+    sarvamAPI: 'test-sarvam-api-key',
+  },
+}));
+
+describe('ACC Call Wrap-Up', () => {
+  const callUuid = 'call-wrap-up-123';
+  const agentUserId = '507f1f77bcf86cd799439011';
+  const callDetailsRepository = {
+    getByCallUuid: vi.fn(),
+    create: vi.fn(),
+    updateCallDetails: vi.fn(),
+  };
+
+  let service: PlivoService;
+
+  const arrangeCapturedConversation = (): void => {
+    vi.spyOn(service, 'getTranscript').mockImplementation((_callId, track) =>
+      track === 'inbound' ? 'मुझे गेहूं की जानकारी चाहिए' : 'I can help',
+    );
+    vi.spyOn(service, 'getTranslation').mockImplementation((_callId, track) =>
+      track === 'inbound' ? 'I need information about wheat' : 'I can help',
+    );
+    vi.spyOn(service, 'getDetectedLanguage')
+      .mockImplementation((_callId, track) =>
+        track === 'inbound' ? 'hi-IN' : 'en-IN',
+      );
+    service.setCallAgent(callUuid, agentUserId);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new PlivoService(callDetailsRepository as any);
+    mocks.plivoCallsGet.mockResolvedValue({
+      fromNumber: '+919900000001',
+      toNumber: '+911234567890',
+      callDuration: 125,
+      callState: 'completed',
+      callDirection: 'inbound',
+    });
+    callDetailsRepository.getByCallUuid.mockResolvedValue(null);
+    callDetailsRepository.create.mockResolvedValue('saved-call-id');
+    callDetailsRepository.updateCallDetails.mockResolvedValue(undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('saves completed call metadata, both transcripts, and the agent mapping', async () => {
+    // Arrange
+    arrangeCapturedConversation();
+
+    // Act
+    await service.saveCallDetails(callUuid);
+
+    // Assert
+    expect(mocks.plivoCallsGet).toHaveBeenCalledWith(callUuid);
+    expect(callDetailsRepository.create).toHaveBeenCalledOnce();
+    const saved = callDetailsRepository.create.mock.calls[0][0];
+    expect(saved).toMatchObject({
+      callUuid,
+      from: '+919900000001',
+      to: '+911234567890',
+      duration: 125,
+      status: 'completed',
+      direction: 'inbound',
+      caller: {
+        transcript: 'मुझे गेहूं की जानकारी चाहिए',
+        translation: 'I need information about wheat',
+        detectedLanguage: 'hi-IN',
+      },
+      agent: {
+        transcript: 'I can help',
+        translation: 'I can help',
+        detectedLanguage: 'en-IN',
+      },
+    });
+    expect(saved.agent.userid.toString()).toBe(agentUserId);
+  });
+
+  it('updates the existing call record instead of creating a duplicate', async () => {
+    // Arrange
+    arrangeCapturedConversation();
+    callDetailsRepository.getByCallUuid.mockResolvedValue({
+      callUuid,
+      caller: {
+        transcript: '',
+        translation: '',
+        detectedLanguage: 'unknown',
+      },
+      agent: {
+        transcript: '',
+        translation: '',
+        detectedLanguage: 'unknown',
+      },
+    });
+
+    // Act
+    await service.saveCallDetails(callUuid);
+
+    // Assert
+    expect(callDetailsRepository.updateCallDetails)
+      .toHaveBeenCalledWith(
+        callUuid,
+        expect.objectContaining({callUuid, status: 'completed'}),
+      );
+    expect(callDetailsRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('preserves captured transcripts when Plivo metadata is unavailable', async () => {
+    // Arrange
+    arrangeCapturedConversation();
+    mocks.plivoCallsGet.mockRejectedValue(new Error('Plivo unavailable'));
+
+    // Act
+    await service.saveCallDetails(callUuid);
+
+    // Assert
+    expect(callDetailsRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callUuid,
+        caller: expect.objectContaining({
+          transcript: 'मुझे गेहूं की जानकारी चाहिए',
+        }),
+        agent: expect.objectContaining({
+          transcript: 'I can help',
+        }),
+      }),
+    );
+  });
+
+  it('handles call-detail persistence failure without crashing wrap-up', async () => {
+    // Arrange
+    arrangeCapturedConversation();
+    callDetailsRepository.create.mockRejectedValue(
+      new Error('database unavailable'),
+    );
+
+    // Act / Assert
+    await expect(service.saveCallDetails(callUuid)).resolves.toBeUndefined();
+  });
+
+  it('clears the call-to-agent mapping after wrap-up cleanup', () => {
+    // Arrange
+    service.setCallAgent(callUuid, agentUserId);
+    expect(service.getCallAgent(callUuid)).toBe(agentUserId);
+
+    // Act
+    service.clearTranscript(callUuid);
+
+    // Assert
+    expect(service.getCallAgent(callUuid)).toBeUndefined();
+    expect(service.getTranscript(callUuid, 'inbound')).toBe('');
+    expect(service.getTranslation(callUuid, 'outbound')).toBe('');
+    expect(service.getDetectedLanguage(callUuid, 'inbound')).toBe('unknown');
+  });
+});

--- a/backend/src/modules/plivo/tests/complete-agent-session-lifecycle.test.ts
+++ b/backend/src/modules/plivo/tests/complete-agent-session-lifecycle.test.ts
@@ -1,0 +1,334 @@
+import 'reflect-metadata';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {PlivoController} from '#root/modules/plivo/controllers/PlivoController.js';
+import {initWebSocket} from '#root/bootstrap/websocket.js';
+
+const mocks = vi.hoisted(() => {
+  type Handler = (...args: any[]) => any;
+
+  class MockSocket {
+    readyState = 1;
+    send = vi.fn();
+    private handlers = new Map<string, Handler[]>();
+
+    on(event: string, handler: Handler): this {
+      const handlers = this.handlers.get(event) ?? [];
+      handlers.push(handler);
+      this.handlers.set(event, handlers);
+      return this;
+    }
+
+    async emit(event: string, ...args: any[]): Promise<void> {
+      for (const handler of this.handlers.get(event) ?? []) {
+        await handler(...args);
+      }
+    }
+  }
+
+  class MockWebSocketServer {
+    static instances: MockWebSocketServer[] = [];
+
+    clients = new Set<MockSocket>();
+    options: unknown;
+    private handlers = new Map<string, Handler>();
+
+    constructor(options: unknown) {
+      this.options = options;
+      MockWebSocketServer.instances.push(this);
+    }
+
+    on(event: string, handler: Handler): this {
+      this.handlers.set(event, handler);
+      return this;
+    }
+
+    async connect(socket: MockSocket): Promise<void> {
+      this.clients.add(socket);
+      await this.handlers.get('connection')?.(socket, {});
+    }
+  }
+
+  const agentMappings = new Map<string, string>();
+  const transcriptCallbacks = new Map<string, Handler>();
+
+  const plivoService = {
+    setCallAgent: vi.fn((callId: string, agentId: string) => {
+      agentMappings.set(callId, agentId);
+    }),
+    getCallAgent: vi.fn((callId: string) => agentMappings.get(callId)),
+    initializeStreams: vi.fn((callId: string, callback: Handler) => {
+      transcriptCallbacks.set(callId, callback);
+    }),
+    transcribeAudio: vi.fn().mockResolvedValue({
+      originalText: '',
+      translatedText: '',
+    }),
+    processRemainingAudio: vi.fn().mockResolvedValue({
+      inbound: {originalText: '', translatedText: ''},
+      outbound: {originalText: '', translatedText: ''},
+    }),
+    getTranscript: vi.fn((_callId: string, track: string) =>
+      track === 'inbound' ? 'मुझे गेहूं की जानकारी चाहिए' : 'I can help',
+    ),
+    getTranslation: vi.fn((_callId: string, track: string) =>
+      track === 'inbound' ? 'I need information about wheat' : 'I can help',
+    ),
+    getDetectedLanguage: vi.fn((_callId: string, track: string) =>
+      track === 'inbound' ? 'hi-IN' : 'en-IN',
+    ),
+    saveCallDetails: vi.fn().mockResolvedValue(undefined),
+    clearTranscript: vi.fn((callId: string) => {
+      agentMappings.delete(callId);
+    }),
+  };
+
+  const userService = {
+    findAndMarkAvailableAgent: vi.fn(),
+    markAgentAsAvailable: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const container = {
+    get: vi.fn((token: symbol) =>
+      String(token).includes('PlivoService') ? plivoService : userService,
+    ),
+  };
+
+  return {
+    MockSocket,
+    MockWebSocketServer,
+    agentMappings,
+    transcriptCallbacks,
+    plivoService,
+    userService,
+    container,
+    getContainer: vi.fn(() => container),
+    getAgentCredentials: vi.fn(() => ({
+      username: 'agent_1-endpoint',
+    })),
+    plivoClientConstructor: vi.fn(),
+  };
+});
+
+vi.mock('ws', () => ({
+  WebSocket: class WebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+  },
+  WebSocketServer: mocks.MockWebSocketServer,
+}));
+
+vi.mock('plivo', () => ({
+  default: {
+    Client: mocks.plivoClientConstructor.mockImplementation(() => ({
+      calls: {list: vi.fn()},
+    })),
+  },
+}));
+
+vi.mock('#root/config/app.js', () => ({
+  appConfig: {
+    plivo: {
+      streamUrl: 'wss://acc.example.test/audio',
+      plivo_number: '+911234567890',
+      getAgentCredentials: mocks.getAgentCredentials,
+    },
+  },
+}));
+
+vi.mock('../../../bootstrap/loadModules.js', () => ({
+  getContainer: mocks.getContainer,
+}));
+
+describe('Complete ACC Agent Session Lifecycle', () => {
+  const callId = 'complete-call-123';
+  const agentUserId = 'agent-user-1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.MockWebSocketServer.instances.length = 0;
+    mocks.agentMappings.clear();
+    mocks.transcriptCallbacks.clear();
+    mocks.userService.findAndMarkAvailableAgent.mockResolvedValue({
+      _id: agentUserId,
+      role: 'call_agent',
+      agent: 'agent_1',
+      isCallAgentActive: true,
+      isBusy: true,
+      currentCallUuid: callId,
+    });
+    mocks.userService.markAgentAsAvailable.mockResolvedValue(undefined);
+    mocks.plivoService.processRemainingAudio.mockResolvedValue({
+      inbound: {originalText: '', translatedText: ''},
+      outbound: {originalText: '', translatedText: ''},
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('completes answer, streaming, transcription, persistence, cleanup, and release', async () => {
+    // Arrange: Plivo answer webhook reserves and connects the agent.
+    const controller = new PlivoController(
+      {} as any,
+      mocks.userService as any,
+      mocks.plivoService as any,
+    );
+    const response = {
+      set: vi.fn(),
+      send: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+    };
+
+    // Act: answer the incoming call.
+    await controller.answer(
+      {body: {CallUUID: callId}, query: {}} as any,
+      response as any,
+    );
+
+    // Assert: routing reserved the agent and returned connection XML.
+    expect(mocks.userService.findAndMarkAvailableAgent)
+      .toHaveBeenCalledWith(callId);
+    expect(mocks.plivoService.setCallAgent)
+      .toHaveBeenCalledWith(callId, agentUserId);
+    expect(response.send).toHaveBeenCalledWith(
+      expect.stringContaining('<User>agent_1-endpoint</User>'),
+    );
+
+    // Arrange: create the mocked backend stream and dashboard client.
+    initWebSocket({} as any);
+    const server = mocks.MockWebSocketServer.instances[0];
+    const callSocket = new mocks.MockSocket();
+    const dashboardSocket = new mocks.MockSocket();
+    server.clients.add(dashboardSocket);
+    await server.connect(callSocket);
+
+    // Act: Plivo starts streaming both participant tracks.
+    await callSocket.emit(
+      'message',
+      Buffer.from(JSON.stringify({
+        event: 'start',
+        start: {callId},
+      })),
+    );
+    const inboundAudio = Buffer.from('farmer audio');
+    const outboundAudio = Buffer.from('agent audio');
+    await callSocket.emit(
+      'message',
+      Buffer.from(JSON.stringify({
+        event: 'media',
+        media: {
+          track: 'inbound',
+          payload: inboundAudio.toString('base64'),
+        },
+      })),
+    );
+    await callSocket.emit(
+      'message',
+      Buffer.from(JSON.stringify({
+        event: 'media',
+        media: {
+          track: 'outbound',
+          payload: outboundAudio.toString('base64'),
+        },
+      })),
+    );
+
+    // Assert: ACC initialized Sarvam and forwarded both audio tracks.
+    expect(mocks.plivoService.initializeStreams)
+      .toHaveBeenCalledWith(callId, expect.any(Function));
+    expect(mocks.plivoService.transcribeAudio).toHaveBeenNthCalledWith(
+      1,
+      inboundAudio,
+      callId,
+      'inbound',
+    );
+    expect(mocks.plivoService.transcribeAudio).toHaveBeenNthCalledWith(
+      2,
+      outboundAudio,
+      callId,
+      'outbound',
+    );
+
+    // Act: mocked Sarvam emits live farmer and agent results.
+    const transcriptCallback = mocks.transcriptCallbacks.get(callId);
+    transcriptCallback?.({
+      track: 'inbound',
+      originalText: 'मुझे गेहूं की जानकारी चाहिए',
+      translatedText: 'I need information about wheat',
+      detectedLanguage: 'hi-IN',
+    });
+    transcriptCallback?.({
+      track: 'outbound',
+      originalText: 'I can help',
+      translatedText: 'I can help',
+      detectedLanguage: 'en-IN',
+    });
+
+    // Assert: the dashboard receives both live transcript events.
+    const liveMessages = dashboardSocket.send.mock.calls
+      .map(([payload]) => JSON.parse(payload))
+      .filter(message => message.type === 'transcript');
+    expect(liveMessages).toEqual([
+      expect.objectContaining({
+        callId,
+        track: 'inbound',
+        detectedLanguage: 'hi-IN',
+      }),
+      expect.objectContaining({
+        callId,
+        track: 'outbound',
+        detectedLanguage: 'en-IN',
+      }),
+    ]);
+
+    // Act: Plivo ends the call.
+    await callSocket.emit(
+      'message',
+      Buffer.from(JSON.stringify({event: 'stop'})),
+    );
+
+    // Assert: finalization happens before persistence, cleanup, and release.
+    expect(mocks.plivoService.processRemainingAudio)
+      .toHaveBeenCalledWith(callId);
+    expect(mocks.plivoService.saveCallDetails).toHaveBeenCalledWith(callId);
+    expect(mocks.plivoService.clearTranscript).toHaveBeenCalledWith(callId);
+    expect(mocks.userService.markAgentAsAvailable)
+      .toHaveBeenCalledWith(agentUserId);
+    expect(mocks.plivoService.processRemainingAudio.mock.invocationCallOrder[0])
+      .toBeLessThan(
+        mocks.plivoService.saveCallDetails.mock.invocationCallOrder[0],
+      );
+    expect(mocks.plivoService.saveCallDetails.mock.invocationCallOrder[0])
+      .toBeLessThan(
+        mocks.plivoService.clearTranscript.mock.invocationCallOrder[0],
+      );
+    expect(mocks.plivoService.clearTranscript.mock.invocationCallOrder[0])
+      .toBeLessThan(
+        mocks.userService.markAgentAsAvailable.mock.invocationCallOrder[0],
+      );
+    expect(mocks.agentMappings.has(callId)).toBe(false);
+
+    const callEndMessage = dashboardSocket.send.mock.calls
+      .map(([payload]) => JSON.parse(payload))
+      .find(message => message.type === 'call_end');
+    expect(callEndMessage).toEqual(
+      expect.objectContaining({
+        callId,
+        caller: expect.objectContaining({
+          transcript: 'मुझे गेहूं की जानकारी चाहिए',
+          translation: 'I need information about wheat',
+        }),
+        agent: expect.objectContaining({
+          transcript: 'I can help',
+          translation: 'I can help',
+        }),
+      }),
+    );
+
+    // Act: a later socket close must not repeat call wrap-up.
+    await callSocket.emit('close');
+
+    // Assert
+    expect(mocks.plivoService.saveCallDetails).toHaveBeenCalledOnce();
+    expect(mocks.userService.markAgentAsAvailable).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/src/modules/plivo/tests/concurrent-multi-agent.test.ts
+++ b/backend/src/modules/plivo/tests/concurrent-multi-agent.test.ts
@@ -1,0 +1,165 @@
+import 'reflect-metadata';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {AgentAssignmentService} from '#root/modules/plivo/services/AgentAssignmentService.js';
+import {IUser} from '#root/shared/interfaces/models.js';
+
+describe('Concurrent ACC Agent Assignment', () => {
+  const availableAgents = [
+    {
+      _id: 'agent-user-1',
+      role: 'call_agent',
+      agent: 'agent_1',
+      isCallAgentActive: true,
+      isBusy: false,
+      currentCallUuid: null,
+    },
+    {
+      _id: 'agent-user-2',
+      role: 'call_agent',
+      agent: 'agent_2',
+      isCallAgentActive: true,
+      isBusy: false,
+      currentCallUuid: null,
+    },
+  ] as IUser[];
+
+  const userRepository = {
+    findAndMarkAvailableAgent: vi.fn(),
+    edit: vi.fn(),
+  };
+
+  let service: AgentAssignmentService;
+  let agents: IUser[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agents = availableAgents.map(agent => ({...agent}));
+
+    userRepository.findAndMarkAvailableAgent.mockImplementation(
+      async (callUuid: string) => {
+        await Promise.resolve();
+        const agent = agents.find(
+          candidate =>
+            candidate.isCallAgentActive === true &&
+            candidate.isBusy === false &&
+            candidate.agent !== 'not_available',
+        );
+
+        if (!agent) {
+          return null;
+        }
+
+        agent.isBusy = true;
+        agent.currentCallUuid = callUuid;
+        return {...agent};
+      },
+    );
+
+    userRepository.edit.mockImplementation(
+      async (userId: string, update: Partial<IUser>) => {
+        const agent = agents.find(candidate => candidate._id === userId);
+        if (agent) {
+          Object.assign(agent, update);
+        }
+        return agent;
+      },
+    );
+
+    service = new AgentAssignmentService(userRepository as any);
+  });
+
+  it('assigns simultaneous calls to different available agents', async () => {
+    // Arrange / Act
+    const [firstAssignment, secondAssignment] = await Promise.all([
+      service.findAndMarkAvailableAgent('call-1'),
+      service.findAndMarkAvailableAgent('call-2'),
+    ]);
+
+    // Assert
+    expect(firstAssignment?._id).toBe('agent-user-1');
+    expect(secondAssignment?._id).toBe('agent-user-2');
+    expect(firstAssignment?._id).not.toBe(secondAssignment?._id);
+  });
+
+  it('records the correct call UUID on each simultaneous assignment', async () => {
+    // Arrange / Act
+    const assignments = await Promise.all([
+      service.findAndMarkAvailableAgent('call-alpha'),
+      service.findAndMarkAvailableAgent('call-beta'),
+    ]);
+
+    // Assert
+    expect(assignments).toEqual([
+      expect.objectContaining({
+        isBusy: true,
+        currentCallUuid: 'call-alpha',
+      }),
+      expect.objectContaining({
+        isBusy: true,
+        currentCallUuid: 'call-beta',
+      }),
+    ]);
+    expect(userRepository.findAndMarkAvailableAgent)
+      .toHaveBeenCalledTimes(2);
+  });
+
+  it('returns no assignment when simultaneous calls exceed free agents', async () => {
+    // Arrange / Act
+    const assignments = await Promise.all([
+      service.findAndMarkAvailableAgent('call-1'),
+      service.findAndMarkAvailableAgent('call-2'),
+      service.findAndMarkAvailableAgent('call-3'),
+    ]);
+
+    // Assert
+    expect(assignments.filter(Boolean)).toHaveLength(2);
+    expect(assignments.filter(assignment => assignment === null)).toHaveLength(1);
+  });
+
+  it('keeps other agents busy when one completed call releases its agent', async () => {
+    // Arrange
+    await Promise.all([
+      service.findAndMarkAvailableAgent('call-1'),
+      service.findAndMarkAvailableAgent('call-2'),
+    ]);
+
+    // Act
+    await service.markAgentAsAvailable('agent-user-1');
+
+    // Assert
+    expect(userRepository.edit).toHaveBeenCalledWith(
+      'agent-user-1',
+      {isBusy: false, currentCallUuid: null},
+      undefined,
+    );
+    expect(agents[0]).toEqual(
+      expect.objectContaining({isBusy: false, currentCallUuid: null}),
+    );
+    expect(agents[1]).toEqual(
+      expect.objectContaining({isBusy: true, currentCallUuid: 'call-2'}),
+    );
+  });
+
+  it('reuses only the agent released by the completed call', async () => {
+    // Arrange
+    await Promise.all([
+      service.findAndMarkAvailableAgent('call-1'),
+      service.findAndMarkAvailableAgent('call-2'),
+    ]);
+    await service.markAgentAsAvailable('agent-user-1');
+
+    // Act
+    const nextAssignment =
+      await service.findAndMarkAvailableAgent('call-3');
+
+    // Assert
+    expect(nextAssignment).toEqual(
+      expect.objectContaining({
+        _id: 'agent-user-1',
+        isBusy: true,
+        currentCallUuid: 'call-3',
+      }),
+    );
+    expect(agents[1].currentCallUuid).toBe('call-2');
+  });
+});

--- a/backend/src/modules/plivo/tests/sarvam-speech-contract.test.ts
+++ b/backend/src/modules/plivo/tests/sarvam-speech-contract.test.ts
@@ -1,0 +1,292 @@
+import 'reflect-metadata';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {PlivoService} from '#root/modules/plivo/services/PlivoService.js';
+
+const mocks = vi.hoisted(() => {
+  type Handler = (...args: any[]) => void;
+
+  class MockWebSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+
+    url: string;
+    options: unknown;
+    readyState = MockWebSocket.OPEN;
+    send = vi.fn();
+    close = vi.fn(() => {
+      this.readyState = MockWebSocket.CLOSED;
+    });
+    private handlers = new Map<string, Handler[]>();
+
+    constructor(url: string, options: unknown) {
+      this.url = url;
+      this.options = options;
+      mocks.sockets.push(this);
+    }
+
+    on(event: string, handler: Handler): this {
+      const eventHandlers = this.handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      this.handlers.set(event, eventHandlers);
+      return this;
+    }
+
+    emit(event: string, ...args: any[]): void {
+      for (const handler of this.handlers.get(event) ?? []) {
+        handler(...args);
+      }
+    }
+  }
+
+  return {
+    sockets: [] as MockWebSocket[],
+    MockWebSocket,
+    plivoClient: {},
+    plivoClientConstructor: vi.fn(),
+  };
+});
+
+vi.mock('ws', () => ({
+  WebSocket: mocks.MockWebSocket,
+}));
+
+vi.mock('plivo', () => ({
+  default: {
+    Client: mocks.plivoClientConstructor.mockImplementation(
+      () => mocks.plivoClient,
+    ),
+  },
+}));
+
+vi.mock('../../../config/app.js', () => ({
+  appConfig: {
+    sarvamAPI: 'test-sarvam-api-key',
+  },
+}));
+
+describe('Sarvam Speech Contract', () => {
+  const callId = 'call-123';
+  const callDetailsRepository = {
+    create: vi.fn(),
+    edit: vi.fn(),
+  };
+
+  let service: PlivoService;
+  let onTranscript: ReturnType<typeof vi.fn>;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  let consoleLog: ReturnType<typeof vi.spyOn>;
+
+  const initializeCall = (): void => {
+    service.initializeStreams(callId, onTranscript);
+  };
+
+  const emitMessage = (
+    socketIndex: number,
+    message: Record<string, unknown>,
+  ): void => {
+    mocks.sockets[socketIndex].emit(
+      'message',
+      Buffer.from(JSON.stringify(message)),
+    );
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.sockets.length = 0;
+    onTranscript = vi.fn();
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    service = new PlivoService(callDetailsRepository as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    consoleError.mockRestore();
+    consoleLog.mockRestore();
+  });
+
+  it('opens four speech sockets for one call', () => {
+    // Arrange / Act
+    initializeCall();
+
+    // Assert
+    expect(mocks.sockets).toHaveLength(4);
+  });
+
+  it('opens transcribe sockets with the required speech contract', () => {
+    // Arrange / Act
+    initializeCall();
+    const transcribeSockets = [mocks.sockets[0], mocks.sockets[2]];
+
+    // Assert
+    for (const socket of transcribeSockets) {
+      const url = new URL(socket.url);
+      expect(url.pathname).toBe('/speech-to-text/ws');
+      expect(url.searchParams.get('model')).toBe('saaras:v3');
+      expect(url.searchParams.get('mode')).toBe('transcribe');
+      expect(url.searchParams.get('sample_rate')).toBe('16000');
+      expect(url.searchParams.get('input_audio_codec')).toBe('pcm_l16');
+    }
+  });
+
+  it('opens translate sockets with the required speech contract', () => {
+    // Arrange / Act
+    initializeCall();
+    const translateSockets = [mocks.sockets[1], mocks.sockets[3]];
+
+    // Assert
+    for (const socket of translateSockets) {
+      const url = new URL(socket.url);
+      expect(url.pathname).toBe('/speech-to-text/ws');
+      expect(url.searchParams.get('model')).toBe('saaras:v3');
+      expect(url.searchParams.get('mode')).toBe('translate');
+      expect(url.searchParams.get('sample_rate')).toBe('16000');
+      expect(url.searchParams.get('input_audio_codec')).toBe('pcm_l16');
+    }
+  });
+
+  it('never uses the text translation model for speech sockets', () => {
+    // Arrange / Act
+    initializeCall();
+
+    // Assert
+    expect(mocks.sockets.every(socket => !socket.url.includes('mayura:v1')))
+      .toBe(true);
+  });
+
+  it('sends audio to Sarvam in the expected payload format', async () => {
+    // Arrange
+    initializeCall();
+    mocks.sockets[0].emit('open');
+    mocks.sockets[1].emit('open');
+    const audio = Buffer.from([1, 2, 3, 4]);
+
+    // Act
+    await service.transcribeAudio(audio, callId, 'inbound');
+
+    // Assert
+    const expectedPayload = {
+      audio: {
+        data: audio.toString('base64'),
+        sample_rate: '16000',
+        encoding: 'audio/wav',
+      },
+    };
+    expect(JSON.parse(mocks.sockets[0].send.mock.calls[0][0]))
+      .toEqual(expectedPayload);
+    expect(JSON.parse(mocks.sockets[1].send.mock.calls[0][0]))
+      .toEqual(expectedPayload);
+  });
+
+  it('handles transcript responses with the detected language', async () => {
+    // Arrange
+    initializeCall();
+
+    // Act
+    emitMessage(0, {
+      type: 'data',
+      data: {transcript: 'नमस्ते', language_code: 'hi-IN'},
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Assert
+    expect(onTranscript).toHaveBeenCalledWith({
+      track: 'inbound',
+      originalText: 'नमस्ते',
+      translatedText: '',
+      detectedLanguage: 'hi-IN',
+    });
+    expect(service.getTranscript(callId, 'inbound')).toBe('नमस्ते');
+    expect(service.getDetectedLanguage(callId, 'inbound')).toBe('hi-IN');
+  });
+
+  it('handles translated speech responses', async () => {
+    // Arrange
+    initializeCall();
+
+    // Act
+    emitMessage(1, {
+      type: 'data',
+      data: {transcript: 'Hello'},
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Assert
+    expect(onTranscript).toHaveBeenCalledWith({
+      track: 'inbound',
+      originalText: '',
+      translatedText: 'Hello',
+      detectedLanguage: 'unknown',
+    });
+    expect(service.getTranslation(callId, 'inbound')).toBe('Hello');
+  });
+
+  it('handles Sarvam error responses without producing transcript data', () => {
+    // Arrange
+    initializeCall();
+
+    // Act / Assert
+    expect(() => {
+      emitMessage(0, {
+        type: 'error',
+        data: {message: 'bad audio'},
+      });
+    }).not.toThrow();
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(service.getTranscript(callId, 'inbound')).toBe('');
+  });
+
+  it('handles WebSocket errors without crashing', () => {
+    // Arrange
+    initializeCall();
+
+    // Act / Assert
+    expect(() => {
+      mocks.sockets[0].emit('error', new Error('socket failed'));
+      mocks.sockets[1].emit('error', new Error('socket failed'));
+    }).not.toThrow();
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it('flushes every Sarvam socket when the call ends', async () => {
+    // Arrange
+    initializeCall();
+    for (const socket of mocks.sockets) {
+      socket.emit('open');
+    }
+
+    // Act
+    const completion = service.processRemainingAudio(callId);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await completion;
+
+    // Assert
+    for (const socket of mocks.sockets) {
+      expect(socket.send).toHaveBeenCalledWith(
+        JSON.stringify({type: 'flush'}),
+      );
+    }
+  });
+
+  it('closes every Sarvam socket when the call ends', async () => {
+    // Arrange
+    initializeCall();
+    for (const socket of mocks.sockets) {
+      socket.emit('open');
+    }
+
+    // Act
+    const completion = service.processRemainingAudio(callId);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await completion;
+
+    // Assert
+    for (const socket of mocks.sockets) {
+      expect(socket.close).toHaveBeenCalledOnce();
+    }
+  });
+});


### PR DESCRIPTION
## Test coverage

- Agent availability management
  - Online/offline registration
  - Agent numbering
  - Busy/available state transitions
  - Lowest-numbered agent selection
  - No-agent handling

- Sarvam speech contract
  - Four WebSocket streams per call
  - `saaras:v3` speech model validation
  - Protection against accidental `mayura:v1` usage
  - Audio payload validation
  - Transcript, translation, error, flush, and close handling

- Call routing
  - Atomic agent reservation
  - Plivo connection XML
  - Busy response when no agent is available
  - Agent release after routing failure

- Call wrap-up
  - Transcript and call metadata persistence
  - Existing-call updates
  - Cleanup of in-memory call state
  - Safe handling of Plivo and repository failures

- Concurrent agent assignment
  - Different agents for simultaneous calls
  - Correct call UUID mapping
  - No assignment when all agents are busy
  - Safe release and reuse of agents

- Complete mocked ACC lifecycle
  - Answer webhook
  - Media streaming
  - Live transcript events
  - Call finalization
  - Persistence and cleanup
  - Agent release
  - Duplicate wrap-up prevention