### PR TITLE
fix: the issue in assigned user filter

### DIFF
--- a/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/QuestionRepository.ts
@@ -770,7 +770,6 @@ export class QuestionRepository implements IQuestionRepository {
             {
               $and: [
                 { history: { $size: 0 } },
-                { queue: { $size: 1 } },
                 { $or: [{ 'queue.0': userObjId }, { 'queue.0': userStr }] },
               ],
             },

--- a/backend/src/utils/buildQuestionFilter.ts
+++ b/backend/src/utils/buildQuestionFilter.ts
@@ -144,7 +144,6 @@ if (autoAllocateModeratorFilter && autoAllocateModeratorFilter !== 'all') {
           {
             $and: [
               { history: { $size: 0 } },
-              { queue: { $size: 1 } },
               { $or: [{ "queue.0": userObjId }, { "queue.0": userStr }] },
             ],
           },


### PR DESCRIPTION
removed the { queue: { $size: 1 } } condition restriction in both buildQuestionFilter.ts and QuestionRepository.ts.

Now, as long as history is empty (history.length == 0) and the user is at queue[0], the question will match regardless of how many total experts are in the queue (1, 2, 4, etc.).

Both questions will now show up properly when filtering by that user!