### PR TITLE
🌐 You spoke it once, you're stuck with it? Not anymore. — restore language change in Edit Farmer & Voice Recorder

### DIFF
--- a/frontend/src/components/voice-recorder-card.tsx
+++ b/frontend/src/components/voice-recorder-card.tsx
@@ -309,7 +309,6 @@ export const VoiceRecorderCard = ({}: VoiceRecorderCardProps) => {
                 </CardTitle>
                 <Select
                   value={language}
-                  disabled
                   onValueChange={(value) =>
                     setLanguage(value as SupportedLanguage)
                   }

--- a/frontend/src/features/chatbotDashboard/components/EditFarmerModal.tsx
+++ b/frontend/src/features/chatbotDashboard/components/EditFarmerModal.tsx
@@ -511,23 +511,25 @@ const DemographicDetails = ({
 
       {/* Fields go here */}
 
-      {/* <div>
+      <div>
         <label className="text-sm font-medium">Language</label>
 
-        <select
-          value={form.languagePreference}
-          onChange={(e) => handleChange("languagePreference", e.target.value)}
-          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+        <Select
+          value={form.languagePreference || undefined}
+          onValueChange={(val) => handleChange("languagePreference", val)}
         >
-          <option value="">Select Language</option>
-
-          {INDIAN_LANGUAGES.map((language) => (
-            <option key={language} value={language}>
-              {language}
-            </option>
-          ))}
-        </select>
-      </div> */}
+          <SelectTrigger className="h-10 w-full">
+            <SelectValue placeholder="Select Language" />
+          </SelectTrigger>
+          <SelectContent>
+            {INDIAN_LANGUAGES.map((language) => (
+              <SelectItem key={language} value={language}>
+                {language}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
       <div>
         <label className="text-sm font-medium">Farmer Name</label>


### PR DESCRIPTION
## You spoke it once, you're stuck with it? Not anymore.

### Summary
A farmer (or operator) who picked a language by mistake had **no way to switch it back**. This PR restores the language selector in **two** broken places.

### Root cause
Both UIs had working state + working backend contracts — only the **JSX affordance** had been removed/locked.

#### 1. Edit Farmer modal — Language dropdown was commented out
`frontend/src/features/chatbotDashboard/components/EditFarmerModal.tsx`

- `form.languagePreference` is still read (line 269) and still sent in the save payload (line 315)
- `INDIAN_LANGUAGES` is still imported
- But the `<select>` between `Demographic Details` header and `Farmer Name` was wrapped in `{/* ... */}` — invisible to operators, so a mis-keyed language could never be corrected through the UI

Fix: uncommented + upgraded to the same Radix `<Select>` already used by Gender/Crop in this modal, so behavior matches the rest of the form.

**Before**
```tsx
{/* <div>
  <label className="text-sm font-medium">Language</label>
  <select value={form.languagePreference} ...>
    <option value="">Select Language</option>
    {INDIAN_LANGUAGES.map(...)}
  </select>
</div> */}
```

**After**
```tsx
<div>
  <label className="text-sm font-medium">Language</label>
  <Select
    value={form.languagePreference || undefined}
    onValueChange={(val) => handleChange("languagePreference", val)}
  >
    <SelectTrigger className="h-10 w-full">
      <SelectValue placeholder="Select Language" />
    </SelectTrigger>
    <SelectContent>
      {INDIAN_LANGUAGES.map((language) => (
        <SelectItem key={language} value={language}>
          {language}
        </SelectItem>
      ))}
    </SelectContent>
  </Select>
</div>
```

#### 2. Voice Recorder — Language selector was hardcoded `disabled`
`frontend/src/components/voice-recorder-card.tsx`

```diff
- <Select value={language} disabled onValueChange={...}>
+ <Select value={language} onValueChange={...}>
```

The backend already accepts `lang` per chunk (`useSendAudioChunk` → `/api/.../audio-chunk`), so the `disabled` was purely UI-level. On noisy or code-mixed audio, forcing `auto` materially hurt transcription quality.

### Why this matters
- **Operational correctness**: a wrong `languagePreference` routes the user through the wrong Sarvam pipeline. Today the only fix is a DB edit.
- **Discoverability**: the field already existed in the data model — operators reasonably assumed they could change it. The wrong-language mistake was silent.
- **Zero infra cost**: no schema, API, or dependency change. Pure UI restoration.

### Files changed
| File | Lines | Purpose |
|---|---|---|
| `frontend/src/features/chatbotDashboard/components/EditFarmerModal.tsx` | +16 / −15 | Restore + upgrade Language field |
| `frontend/src/components/voice-recorder-card.tsx` | +0 / −1 | Remove `disabled` so Select is interactive |

### Risk
Low. Both edits reuse already-imported symbols (`INDIAN_LANGUAGES`, `Select`, `SelectTrigger`, `SelectContent`, `SelectItem`) and the existing `handleChange("languagePreference", ...)` path. No state shape, prop, or contract change. Backend untouched.

### Test plan
1. Open `Edit Farmer` for any existing user → confirm "Language" dropdown appears below "Demographic Details" and reflects current value.
2. Pick a different language → Save → reopen → value persists.
3. Open Voice Recorder → confirm the language picker is clickable and selection updates `language` state.
4. `pnpm lint && pnpm typecheck` in `frontend/`.
