### PR TITLE
Add saved-answers feature: repository, controller, DI wiring, and fro…

### DIFF
--- a/backend/src/container.ts
+++ b/backend/src/container.ts
@@ -6,6 +6,7 @@ import {
   AnalyticsMongoDatabase,
   AnnamDatabase
 } from '#shared/index.js';
+import {SavedAnswerRepository} from '#shared/database/providers/mongo/repositories/SavedAnswerRepository.js';
 import {GLOBAL_TYPES} from './types.js';
 import {dbConfig} from './config/db.js';
 import {analyticsDbConfig} from './config/analyticsDbConfig.js';
@@ -25,6 +26,8 @@ export const sharedContainerModule = new ContainerModule(options => {
   // Database
   options.bind(GLOBAL_TYPES.Database).to(MongoDatabase).inSingletonScope();
 
+  // Saved Answers
+  options.bind(GLOBAL_TYPES.SavedAnswerRepository).to(SavedAnswerRepository).inSingletonScope();
 
   // Other
   options.bind(HttpErrorHandler).toSelf().inSingletonScope(); 
@@ -36,5 +39,4 @@ export const sharedContainerModule = new ContainerModule(options => {
   options.bind(GLOBAL_TYPES.annamanalyticsUri).toConstantValue(analyticsDbConfig.annamUrl);
   options.bind(GLOBAL_TYPES.annamanalyticsDbName).toConstantValue(analyticsDbConfig.annamDbName);
   options.bind(GLOBAL_TYPES.annamanalyticsDatabase).to(AnnamDatabase).inSingletonScope();
-}); 
-
+});

--- a/backend/src/modules/answer/controllers/SavedAnswerController.ts
+++ b/backend/src/modules/answer/controllers/SavedAnswerController.ts
@@ -1,0 +1,42 @@
+import 'reflect-metadata';
+import {
+  JsonController, Post, Get, Delete, Body, Param, HttpCode,
+  CurrentUser, Authorized, BadRequestError,
+} from 'routing-controllers';
+import { OpenAPI } from 'routing-controllers-openapi';
+import { inject } from 'inversify';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { IUser } from '#root/shared/interfaces/models.js';
+import { ISavedAnswerRepository } from '#root/shared/database/interfaces/ISavedAnswerRepository.js';
+
+@OpenAPI({ tags: ['SavedAnswers'], description: 'Bookmarking answers for quick reuse' })
+@JsonController('/saved-answers')
+export class SavedAnswerController {
+  constructor(
+    @inject(GLOBAL_TYPES.SavedAnswerRepository)
+    private readonly savedAnswerRepo: ISavedAnswerRepository,
+  ) {}
+
+  @OpenAPI({ summary: 'Bookmark an answer for later reuse' })
+  @Post('/')
+  @HttpCode(201)
+  @Authorized()
+  async save(@Body() body: { answerId: string; note?: string }, @CurrentUser() user: IUser) {
+    if (!body?.answerId) throw new BadRequestError('answerId is required');
+    return this.savedAnswerRepo.saveAnswer(user._id!.toString(), body.answerId, body.note);
+  }
+
+  @OpenAPI({ summary: "List the current user's saved answers" })
+  @Get('/')
+  @Authorized()
+  async list(@CurrentUser() user: IUser) {
+    return this.savedAnswerRepo.getSavedAnswers(user._id!.toString());
+  }
+
+  @OpenAPI({ summary: 'Remove a saved answer' })
+  @Delete('/:id')
+  @Authorized()
+  async remove(@Param('id') id: string, @CurrentUser() user: IUser) {
+    return this.savedAnswerRepo.removeSavedAnswer(user._id!.toString(), id);
+  }
+}

--- a/backend/src/shared/database/interfaces/ISavedAnswerRepository.ts
+++ b/backend/src/shared/database/interfaces/ISavedAnswerRepository.ts
@@ -1,0 +1,35 @@
+import { ClientSession, ObjectId } from 'mongodb';
+
+export interface ISavedAnswer {
+  _id?: string | ObjectId;
+  userId: string | ObjectId;
+  answerId: string | ObjectId;
+  note?: string;
+  createdAt?: Date;
+}
+
+export interface ISavedAnswerRepository {
+  saveAnswer(
+    userId: string,
+    answerId: string,
+    note?: string,
+    session?: ClientSession,
+  ): Promise<{ insertedId: string }>;
+
+  getSavedAnswers(
+    userId: string,
+    session?: ClientSession,
+  ): Promise<any[]>;
+
+  removeSavedAnswer(
+    userId: string,
+    savedAnswerId: string,
+    session?: ClientSession,
+  ): Promise<{ deletedCount: number }>;
+
+  isAlreadySaved(
+    userId: string,
+    answerId: string,
+    session?: ClientSession,
+  ): Promise<boolean>;
+}

--- a/backend/src/shared/database/providers/mongo/repositories/SavedAnswerRepository.ts
+++ b/backend/src/shared/database/providers/mongo/repositories/SavedAnswerRepository.ts
@@ -1,0 +1,145 @@
+import { inject } from 'inversify';
+import { ClientSession, Collection, ObjectId } from 'mongodb';
+import { MongoDatabase } from '../MongoDatabase.js';
+import { GLOBAL_TYPES } from '#root/types.js';
+import { isValidObjectId } from '#root/utils/isValidObjectId.js';
+import { BadRequestError, InternalServerError } from 'routing-controllers';
+import { ISavedAnswer, ISavedAnswerRepository } from '#root/shared/database/interfaces/ISavedAnswerRepository.js';
+
+export class SavedAnswerRepository implements ISavedAnswerRepository {
+  private SavedAnswerCollection: Collection<ISavedAnswer>;
+
+  constructor(
+    @inject(GLOBAL_TYPES.Database)
+    private db: MongoDatabase,
+  ) {}
+
+  private async init() {
+    this.SavedAnswerCollection = await this.db.getCollection<ISavedAnswer>('saved_answers');
+  }
+
+  async saveAnswer(
+    userId: string,
+    answerId: string,
+    note?: string,
+    session?: ClientSession,
+  ): Promise<{ insertedId: string }> {
+    try {
+      await this.init();
+
+      if (!userId || !isValidObjectId(userId)) {
+        throw new BadRequestError('Invalid or missing userId');
+      }
+      if (!answerId || !isValidObjectId(answerId)) {
+        throw new BadRequestError('Invalid or missing answerId');
+      }
+
+      // Avoid duplicate bookmarks of the same answer by the same user
+      const existing = await this.SavedAnswerCollection.findOne(
+        { userId: new ObjectId(userId), answerId: new ObjectId(answerId) },
+        { session },
+      );
+      if (existing) {
+        return { insertedId: existing._id!.toString() };
+      }
+
+      const doc: ISavedAnswer = {
+        userId: new ObjectId(userId),
+        answerId: new ObjectId(answerId),
+        note,
+        createdAt: new Date(),
+      };
+
+      const result = await this.SavedAnswerCollection.insertOne(doc as any, { session });
+      return { insertedId: result.insertedId.toString() };
+    } catch (error) {
+      throw new InternalServerError(`Error while saving answer, More/ ${error}`);
+    }
+  }
+
+  async getSavedAnswers(userId: string, session?: ClientSession): Promise<any[]> {
+    try {
+      await this.init();
+
+      if (!userId || !isValidObjectId(userId)) {
+        throw new BadRequestError('Invalid or missing userId');
+      }
+
+      const results = await this.SavedAnswerCollection.aggregate(
+        [
+          { $match: { userId: new ObjectId(userId) } },
+          {
+            $lookup: {
+              from: 'answers',
+              localField: 'answerId',
+              foreignField: '_id',
+              as: 'answer',
+            },
+          },
+          { $unwind: { path: '$answer', preserveNullAndEmptyArrays: true } },
+          {
+            $lookup: {
+              from: 'questions',
+              localField: 'answer.questionId',
+              foreignField: '_id',
+              as: 'question',
+            },
+          },
+          { $unwind: { path: '$question', preserveNullAndEmptyArrays: true } },
+          { $sort: { createdAt: -1 } },
+        ],
+        { session },
+      ).toArray();
+
+      return results.map(r => ({
+        _id: r._id?.toString(),
+        note: r.note,
+        createdAt: r.createdAt,
+        answer: r.answer
+          ? {
+              _id: r.answer._id?.toString(),
+              answer: r.answer.answer,
+              sources: r.answer.sources,
+              isFinalAnswer: r.answer.isFinalAnswer,
+            }
+          : null,
+        question: r.question
+          ? { _id: r.question._id?.toString(), text: r.question.question }
+          : null,
+      }));
+    } catch (error) {
+      throw new InternalServerError(`Failed to fetch saved answers, More/ ${error}`);
+    }
+  }
+
+  async removeSavedAnswer(
+    userId: string,
+    savedAnswerId: string,
+    session?: ClientSession,
+  ): Promise<{ deletedCount: number }> {
+    try {
+      await this.init();
+
+      if (!savedAnswerId || !isValidObjectId(savedAnswerId)) {
+        throw new BadRequestError('Invalid or missing savedAnswerId');
+      }
+
+      const result = await this.SavedAnswerCollection.deleteOne(
+        { _id: new ObjectId(savedAnswerId), userId: new ObjectId(userId) },
+        { session },
+      );
+      return { deletedCount: result.deletedCount };
+    } catch (error) {
+      throw new InternalServerError(`Error while removing saved answer, More/ ${error}`);
+    }
+  }
+
+  async isAlreadySaved(userId: string, answerId: string, session?: ClientSession): Promise<boolean> {
+    await this.init();
+    const existing = await this.SavedAnswerCollection.findOne(
+      { userId: new ObjectId(userId), answerId: new ObjectId(answerId) },
+      { session },
+    );
+    return !!existing;
+  }
+}

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -9,6 +9,8 @@ const TYPES = {
   RequestController: Symbol.for('RequestController'),
   ReRouteController:Symbol.for('ReRouteController'),
   ChemicalController: Symbol.for('ChemicalController'),
+  SavedAnswerController: Symbol.for('SavedAnswerController'),
+    
 
   // Services
   UserService: Symbol.for('UserService'),
@@ -38,6 +40,7 @@ const TYPES = {
   CropRepository: Symbol.for('CropRepository'),
   ChemicalRepository: Symbol.for('ChemicalRepository'),
   MongoDatabase: Symbol.for('MongoDatabase'),
+  SavedAnswerRepository: Symbol.for('SavedAnswerRepository'),
   CropService: Symbol.for('CropService'),
   ChemicalService: Symbol.for('ChemicalService'),
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -4,7 +4,8 @@ packages:
 allowBuilds:
   '@firebase/util': false
   '@tailwindcss/oxide': false
+  core-js: false
   esbuild: false
   msw: false
   protobufjs: false
-  wasm-pack: set this to true or false
+  wasm-pack: false

--- a/frontend/src/features/qa-interface-page/SavedAnswersPanel.tsx
+++ b/frontend/src/features/qa-interface-page/SavedAnswersPanel.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/atoms/card";
+import { Button } from "../../components/atoms/button";
+import { useSavedAnswers, useRemoveSavedAnswer } from "@/hooks/api/answer/useSavedAnswers";
+
+export const SavedAnswersPanel = ({ onUse }: { onUse: (answerText: string) => void }) => {
+  const { data: savedAnswers, isLoading } = useSavedAnswers();
+  const removeSaved = useRemoveSavedAnswer();
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">Loading saved answers…</p>;
+  if (!savedAnswers?.length) return <p className="text-sm text-muted-foreground">No saved answers yet.</p>;
+
+  return (
+    <Card>
+      <CardHeader><CardTitle>Saved Answers</CardTitle></CardHeader>
+      <CardContent className="space-y-3">
+        {savedAnswers.map((item) => (
+          <div key={item._id} className="border rounded-md p-3 space-y-2">
+            {item.question?.text && (
+              <p className="text-xs text-muted-foreground">{item.question.text}</p>
+            )}
+            <p className="text-sm line-clamp-3">{item.answer?.answer}</p>
+            <div className="flex gap-2">
+              <Button size="sm" onClick={() => item.answer && onUse(item.answer.answer)}>
+                Use this
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => removeSaved.mutate(item._id)}>
+                Remove
+              </Button>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/hooks/api/answer/useSavedAnswers.ts
+++ b/frontend/src/hooks/api/answer/useSavedAnswers.ts
@@ -1,0 +1,32 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { SavedAnswerService, type SavedAnswerItem } from "../../services/savedAnswerService";
+import { toast } from "sonner";
+
+const savedAnswerService = new SavedAnswerService();
+
+export const useSavedAnswers = () =>
+  useQuery<SavedAnswerItem[] | null>({
+    queryKey: ["saved-answers"],
+    queryFn: () => savedAnswerService.list(),
+  });
+
+export const useSaveAnswer = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ answerId, note }: { answerId: string; note?: string }) =>
+      savedAnswerService.save(answerId, note),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["saved-answers"] });
+      toast.success("Answer saved for reuse");
+    },
+    onError: (error: Error) => toast.error(error.message || "Failed to save answer"),
+  });
+};
+
+export const useRemoveSavedAnswer = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => savedAnswerService.remove(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["saved-answers"] }),
+  });
+};

--- a/frontend/src/hooks/services/savedAnswerService.ts
+++ b/frontend/src/hooks/services/savedAnswerService.ts
@@ -1,0 +1,29 @@
+import { apiFetch } from "../api/api-fetch";
+import { env } from "@/config/env";
+
+const API_BASE_URL = env.apiBaseUrl();
+
+export interface SavedAnswerItem {
+  _id: string;
+  note?: string;
+  createdAt: string;
+  answer: { _id: string; answer: string; sources: any[] } | null;
+  question: { _id: string; text: string } | null;
+}
+
+export class SavedAnswerService {
+  private _baseUrl = `${API_BASE_URL}/saved-answers`;
+
+  async save(answerId: string, note?: string) {
+    return apiFetch(this._baseUrl, {
+      method: "POST",
+      body: JSON.stringify({ answerId, note }),
+    });
+  }
+  async list(): Promise<SavedAnswerItem[] | null> {
+    return apiFetch<SavedAnswerItem[]>(this._baseUrl);
+  }
+  async remove(id: string) {
+    return apiFetch(`${this._baseUrl}/${id}`, { method: "DELETE" });
+  }
+}


### PR DESCRIPTION
## What this does
Adds a "Saved Reference Answers" feature for experts/moderators reviewing farmer questions.
While answering a question in the QA interface, an expert can bookmark a relevant
past answer (e.g. a Golden FAQ) and quickly reuse it later when answering similar questions.

## Changes
**Backend**
- `SavedAnswerRepository` — new MongoDB repository (`saved_answers` collection) with
  save / list / remove operations, following the existing `AnswerRepository` pattern
- `SavedAnswerController` — new REST endpoints:
  - `POST /saved-answers` — bookmark an answer
  - `GET /saved-answers` — list the current user's saved answers
  - `DELETE /saved-answers/:id` — remove a saved answer
- Registered `SavedAnswerRepository` in the DI container (`types.ts`, `container.ts`)

**Frontend**
- `savedAnswerService.ts` — API client for the new endpoints
- `useSavedAnswers`, `useSaveAnswer`, `useRemoveSavedAnswer` — React Query hooks
- `SavedAnswersPanel.tsx` — UI panel to browse and reuse saved answers

## Testing
- Backend and frontend both build cleanly (`pnpm run build`)
- Not yet tested against a live database — happy to pair on live testing if useful

## Notes for reviewers
This is my individual contribution for the Summership Phase 2 project submission.