### PR TITLE
Improve multilingual language detection test coverage

### DIFF
--- a/ai/ajrasakha/agents/tests/test_expert_queue_reply.py
+++ b/ai/ajrasakha/agents/tests/test_expert_queue_reply.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
@@ -20,6 +22,15 @@ from ajrasakha.agents.translation_catalog import (
     get_two_hour_disclaimer,
 )
 from ajrasakha.agents.state import AjraSakhaState
+
+# IST 14:00 — inside the default 2-hour disclaimer window (not 22-23 or 0-5 IST)
+_IST = timezone(timedelta(hours=5, minutes=30))
+
+
+class _FixedDatetime:
+    @classmethod
+    def now(cls, tz: object = None) -> datetime:
+        return datetime(2026, 1, 1, 14, 0, tzinfo=tz or _IST)
 
 
 def _gdb_json(**overrides) -> str:
@@ -108,11 +119,12 @@ async def test_translate_answer_empty_gdb_path_content():
     state = _state_after_sanitizer_filter()
     placeholder = await empty_gdb_reply_node(state)
     merged = {**state, **placeholder}
-    result = await translate_answer_node(merged, {})
+    with mock.patch("ajrasakha.agents.answer_footers.datetime", _FixedDatetime):
+        result = await translate_answer_node(merged, {})
+        expected = build_expert_queue_content("English", "English")
     text = result["messages"][0].content
     assert EXPERT_QUEUE_REPLY_MARKER in text
     assert "Thank You." in text
-    expected = build_expert_queue_content("English", "English")
     assert text == expected
     assert text == (
         f"{get_two_hour_disclaimer('English', 'English')}\n\n"

--- a/ai/ajrasakha/agents/tests/test_script_detection.py
+++ b/ai/ajrasakha/agents/tests/test_script_detection.py
@@ -1,0 +1,107 @@
+"""Deterministic script/language detection tests (no LLM, no time dependency).
+
+Deliberately non-duplicative with test_planner_language_pair.py (which already
+covers native-Telugu and Romanized-Hinglish resolve_planner_language_pair).
+This file focuses on detect_script / detect_script_language (untested elsewhere)
+and resolve_planner_language_pair for languages not covered by the planner file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ajrasakha.agents.language import (
+    detect_script,
+    detect_script_language,
+    resolve_planner_language_pair,
+)
+
+# Native-script farmer queries, one per representative Indian language.
+_NATIVE = [
+    ("Hindi", "गेहूं की फसल में कीड़े कैसे नियंत्रित करें?"),
+    ("Marathi", "गहू पिकातील किडी कशी नियंत्रित करावी?"),
+    ("Telugu", "బార్లీ పంటలో ఆఫిడ్స్ ని ఎలా నియంత్రించాలి?"),
+    ("Tamil", "பார்லி பயிரில் அசுவினிகளை எவ்வாறு கட்டுப்படுத்துவது?"),
+    ("Kannada", "ಬಾರ್ಲಿ ಬೆಳೆಯಲ್ಲಿ ಗಿಡಹೇನುಗಳನ್ನು ಹೇಗೆ ನಿಯಂತ್ರಿಸುವುದು?"),
+    ("Malayalam", "ബാർലി വിളയിലെ മുഞ്ഞകളെ എങ്ങനെ നിയന്ത്രിക്കാം?"),
+    ("Bengali", "বার্লি ফসলে এফিড কীভাবে নিয়ন্ত্রণ করবেন?"),
+    ("Gujarati", "બાર્લી પાકમાં ઉકલિયાને કેવી રીતે નિયંત્રિત કરવું?"),
+]
+
+# (script, script_language) expected for each native sample.
+_NATIVE_SCRIPT_EXPECTED = {
+    "Hindi": ("Devanagari", "Devanagari"),
+    "Marathi": ("Devanagari", "Devanagari"),
+    "Telugu": ("Telugu", "Telugu"),
+    "Tamil": ("Tamil", "Tamil"),
+    "Kannada": ("Kannada", "Kannada"),
+    "Malayalam": ("Malayalam", "Malayalam"),
+    "Bengali": ("Bengali-Assamese", "Bengali-Assamese"),
+    "Gujarati": ("Gujarati", "Gujarati"),
+}
+
+# Romanized (Latin-script) Indian-language queries.
+_ROMANIZED = [
+    # Hinglish — Hindi words in Latin script
+    ("Mera gehu mein keede kaise control karein?", "Hindi"),
+    # Tanglish — Tamil in Latin script
+    ("Barli payiril asuvini yepdi control pandradhu?", "Tamil"),
+    # Tenglish — Telugu in Latin script
+    ("Barli pantalo aafids ni ela niyantrinchali?", "Telugu"),
+]
+
+
+@pytest.mark.parametrize(
+    "language,text,script,script_language",
+    [
+        (language, text, *_NATIVE_SCRIPT_EXPECTED[language])
+        for language, text in _NATIVE
+    ],
+    ids=[language for language, _ in _NATIVE],
+)
+def test_detect_native_script(language, text, script, script_language):
+    assert detect_script(text) == script
+    assert detect_script_language(text) == script_language
+
+
+@pytest.mark.parametrize(
+    "text,script,script_language",
+    [
+        ("How to control aphids in barley?", "Latin", "English"),
+        ("", "Latin", "English"),
+    ],
+    ids=["english", "empty"],
+)
+def test_detect_latin_script(text, script, script_language):
+    assert detect_script(text) == script
+    assert detect_script_language(text) == script_language
+
+
+@pytest.mark.parametrize(
+    "text,vocal_language",
+    _ROMANIZED,
+    ids=["hinglish", "tanglish", "tenglish"],
+)
+def test_detect_romanized_script_is_latin(text, vocal_language):
+    assert detect_script(text) == "Latin"
+    assert detect_script_language(text) == "English"
+
+
+@pytest.mark.parametrize(
+    "language,text",
+    [
+        (language, text)
+        for language, text in _NATIVE
+        if language != "Telugu"  # native-Telugu resolve covered in test_planner_language_pair.py
+    ],
+    ids=[language for language, _ in _NATIVE if language != "Telugu"],
+)
+def test_resolve_planner_language_pair_native(language, text):
+    vocal, script = resolve_planner_language_pair(text, language, language)
+    assert (vocal, script) == (language, language)
+
+
+def test_resolve_planner_language_pair_tanglish():
+    """Romanized Tamil — the only Romanized resolve case not in the planner file."""
+    text = "Barli payiril asuvini yepdi control pandradhu?"
+    assert resolve_planner_language_pair(text, "Tamil", "Tamil") == ("Tamil", "English")

--- a/ai/ajrasakha/agents/tests/test_translate_answer_paths.py
+++ b/ai/ajrasakha/agents/tests/test_translate_answer_paths.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
+from unittest import mock
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
@@ -11,6 +13,15 @@ from ajrasakha.agents.prompts import EXPERT_QUEUE_REPLY_MARKER
 from ajrasakha.agents.state import TRANSLATE_PATH_EMPTY_GDB
 from ajrasakha.agents.translate_answer import translate_answer_node
 from ajrasakha.agents.translation_catalog import get_testing_disclaimer
+
+# IST 14:00 — inside the default 2-hour disclaimer window (not 22-23 or 0-5 IST)
+_IST = timezone(timedelta(hours=5, minutes=30))
+
+
+class _FixedDatetime:
+    @classmethod
+    def now(cls, tz: object = None) -> datetime:
+        return datetime(2026, 1, 1, 14, 0, tzinfo=tz or _IST)
 
 
 def _gdb_with_answer() -> dict:
@@ -42,9 +53,10 @@ def test_empty_gdb_path_catalog_only():
     }
     import asyncio
 
-    result = asyncio.run(translate_answer_node(state, {}))
+    with mock.patch("ajrasakha.agents.answer_footers.datetime", _FixedDatetime):
+        result = asyncio.run(translate_answer_node(state, {}))
+        expected = build_expert_queue_content("English", "English")
     text = result["messages"][0].content
-    expected = build_expert_queue_content("English", "English")
     assert text == expected
     assert FOOTER_SEPARATOR in text
     assert EXPERT_QUEUE_REPLY_MARKER in text

--- a/ai/ajrasakha/agents/tests/test_translate_prompt.py
+++ b/ai/ajrasakha/agents/tests/test_translate_prompt.py
@@ -10,7 +10,7 @@ def test_native_script_prompt_requires_transliteration():
     assert "transliterate" in prompt
     assert "ज़िंक" in build_translate_system_prompt("Hindi", "Hindi")
     assert "पीबीडब्ल्यू" in build_translate_system_prompt("Hindi", "Hindi")
-    assert "do not omit" in prompt or "do not omit lines" in prompt
+    assert "do not drop or shorten" in prompt
     assert "preserve chemical names exactly" not in prompt
     assert "do not leave a–z" in prompt or "do not leave a-z" in prompt
 
@@ -25,8 +25,8 @@ def test_english_script_prompt_allows_latin_codes():
 def test_shared_rules_preserve_urls_and_content():
     for script, vocal in [("Hindi", "Hindi"), ("English", "English")]:
         prompt = build_translate_system_prompt(script, vocal).lower()
-        assert "preserve urls" in prompt
-        assert "keep every fact" in prompt
+        assert "preserve numbers, urls" in prompt
+        assert "preserve line breaks" in prompt
 
 
 def test_punjabi_native_script_uses_transliteration_branch():


### PR DESCRIPTION
## Summary

Improves the multilingual language detection test suite for the translation agent and fixes stale/flaky tests.

### Changes
- **Add** \i/ajrasakha/agents/tests/test_script_detection.py\ (21 deterministic tests) covering:
  - \detect_script\ and \detect_script_language\ for all 8 native-script languages and Latin (Romanized) input.
  - \esolve_planner_language_pair\ native script resolution for 7 languages and Tanglish.
  - This raises \language.py\ coverage from 28% to 43% (deterministic core; LLM/API paths untouched).
- **Fix stale assertions** in \	est_translate_prompt.py\ to match current prompt wording (URL/number preservation rules).
- **Fix time-dependent flake** in \	est_translate_answer_paths.py\ and \	est_expert_queue_reply.py\ by freezing the clock to a time inside the two-hour expert-queue window (previously the test failed when run late at night / early morning IST).

### Verification
- Full translation suite: 54 passed / 0 failed.
- PR contains only the four AI test files (no production or unrelated changes).