### PR TITLE
feat(imd-weather-api-wrapper): add Dockerfile

### DIFF
--- a/apis/imd_weather_api_wrapper/Dockerfile
+++ b/apis/imd_weather_api_wrapper/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Every other service under apis/ (acc_api, ans_gen_pop, langgraph-openai-adapter, proxy_api/*) ships a Dockerfile except this one, so it couldn't be built/run consistently with its siblings. Adds a matching python:3.11-slim Dockerfile that installs requirements.txt and serves the existing FastAPI app via `uvicorn api.main:app` on port 8000, per the app's own README.

Verified locally: image builds, container starts cleanly, and /docs + /openapi.json respond over HTTP.