### PR TITLE
Preserve language for clarification replies

### DIFF
--- a/ai/ajrasakha/agents/planner.py
+++ b/ai/ajrasakha/agents/planner.py
@@ -42,6 +42,7 @@ from ajrasakha.agents.domains import (
 from ajrasakha.agents.language import _llm_detect_language, detect_script_language, resolve_planner_language_pair
 from ajrasakha.agents.translation_catalog import (
     OFFICIAL_LANGUAGES,
+    get_catalog,
     get_crop_follow_up,
     get_state_follow_up,
     language_pair_from_plan,
@@ -747,6 +748,12 @@ async def planner_node(
     state_resolved = _resolve_state_deterministic(messages, location, prev_entities)
     crop_resolved = resolve_crop_for_turn(messages)
     clarification_query = merge_clarification_reply_into_query(prev_plan, user_text)
+    previous_vocal_language = (prev_plan.get("vocal_language") or "").strip()
+    previous_script_language = (prev_plan.get("script_language") or "").strip()
+    preserve_clarification_language = bool(
+        clarification_query
+        and (previous_script_language, previous_vocal_language) in get_catalog()
+    )
 
     llm_messages: list[BaseMessage] = [SystemMessage(content=PLANNER_SYSTEM_PROMPT)]
     conv_block = format_conversation_for_planner(messages) or user_text
@@ -911,6 +918,9 @@ async def planner_node(
             ):
                 if key in prev_plan:
                     plan[key] = prev_plan[key]
+            if preserve_clarification_language:
+                plan["vocal_language"] = previous_vocal_language
+                plan["script_language"] = previous_script_language
             trace_event(
                 "planner_clarification_query_assembled",
                 previous_query=(
@@ -923,22 +933,33 @@ async def planner_node(
                 llm_rephrased_query=plan.get("rephrased_query"),
             )
 
-        # Use Unicode-based script detection first (before LLM detection)
-        detected_script = detect_script_language(user_text)
-
-        # Use LLM-based language detection for vocal_language with script context
-        # to avoid incorrect inference from state/crop names
-        detected_vocal = _llm_detect_language(user_text, script_context=detected_script)
-        vocal = _coerce_official_language(detected_vocal) or "English"
-
-        if vocal != plan.get("vocal_language"):
-            logger.info(
-                "Planner vocal_language corrected via LLM detection: prev_vocal=%s -> detected_vocal=%s",
-                plan.get("vocal_language"),
-                vocal,
+        if preserve_clarification_language:
+            # A short answer to our location/crop question is data, not a new
+            # language preference. The preceding block restores the prior pair;
+            # do not immediately replace it by detecting the short reply alone.
+            trace_event(
+                "planner_clarification_language_preserved",
+                vocal_language=plan.get("vocal_language"),
+                script_language=plan.get("script_language"),
+                clarification_reply=user_text,
             )
-        plan["vocal_language"] = vocal
-        plan["script_language"] = detected_script
+        else:
+            # Use Unicode-based script detection first (before LLM detection).
+            detected_script = detect_script_language(user_text)
+
+            # Use LLM-based language detection for vocal_language with script context
+            # to avoid incorrect inference from state/crop names.
+            detected_vocal = _llm_detect_language(user_text, script_context=detected_script)
+            vocal = _coerce_official_language(detected_vocal) or "English"
+
+            if vocal != plan.get("vocal_language"):
+                logger.info(
+                    "Planner vocal_language corrected via LLM detection: prev_vocal=%s -> detected_vocal=%s",
+                    plan.get("vocal_language"),
+                    vocal,
+                )
+            plan["vocal_language"] = vocal
+            plan["script_language"] = detected_script
 
         if not plan.get("rephrased_query"):
             plan["rephrased_query"] = user_text

--- a/ai/ajrasakha/agents/tests/test_state_turn_scope.py
+++ b/ai/ajrasakha/agents/tests/test_state_turn_scope.py
@@ -1,5 +1,7 @@
 """Regression: state/district must not leak from unrelated old thread messages."""
 
+from unittest.mock import Mock, patch
+
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
@@ -12,6 +14,21 @@ from ajrasakha.agents.planner import _resolve_state_deterministic
 from ajrasakha.agents.planner_rules import apply_planner_completeness_rules
 
 from ajrasakha.agents.state import AjraSakhaState
+
+
+class _StaticPlannerModel:
+    """Small structured-output stand-in for planner-node regression tests."""
+
+    def __init__(self, output):
+        self.output = output
+
+    def with_structured_output(self, _schema):
+        return self
+
+    async def ainvoke(self, _messages, config=None):
+        return self.output
+
+
 def test_state_not_leaked_from_old_karnataka_message():
     messages = [
         HumanMessage(content="Wheat disease control in Karnataka"),
@@ -157,4 +174,102 @@ async def test_state_carries_forward_during_clarify_loop():
     new_plan = res["plan"]
     assert new_plan["entities"].get("state") == "Karnataka"
     assert new_plan["entities"].get("crop") == "Onion"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("script_language", "vocal_language", "should_preserve"),
+    [
+        ("Gurmukhi", "Punjabi", True),
+        ("English", "Punjabi", True),
+        ("Devanagari", "Hindi", True),
+        ("Unknown", "Punjabi", False),
+    ],
+)
+async def test_location_clarification_preserves_catalog_language_pair(
+    script_language, vocal_language, should_preserve
+):
+    """Preserve supported pairs; safely re-detect invalid legacy pairs."""
+    from ajrasakha.agents.planner import PlannerOutput, planner_node
+    from langchain_core.runnables import RunnableConfig
+
+    state: AjraSakhaState = {
+        "messages": [
+            HumanMessage(content="ਗੰਨੇ ਵਿੱਚ ਗੋਭ ਦੀ ਸੁੰਡੀ ਦਾ ਇਲਾਜ ਕੀ ਹੈ?"),
+            AIMessage(content="ਕਿਰਪਾ ਕਰਕੇ ਆਪਣਾ ਜ਼ਿਲ੍ਹਾ ਦੱਸੋ।"),
+            HumanMessage(content="rupnagar"),
+        ],
+        "location": None,
+        "plan": {
+            "domain": "Weather",
+            "domains": ["Weather"],
+            "is_complete": False,
+            "missing_info": ["location"],
+            "entities": {"crop": "all"},
+            "rephrased_query": "How can I control early shoot borer in sugarcane?",
+            "original_query_en": "How can I control early shoot borer in sugarcane?",
+            "vocal_language": vocal_language,
+            "script_language": script_language,
+        },
+    }
+    detected_language = Mock(return_value="English")
+    model = _StaticPlannerModel(
+        PlannerOutput(
+            domains=["Weather"],
+            rephrased_query="Rupnagar",
+            original_query_en="Rupnagar",
+            vocal_language="English",
+            script_language="English",
+        )
+    )
+
+    with (
+        patch("ajrasakha.agents.planner.get_minimax_chat_model", return_value=model),
+        patch("ajrasakha.agents.planner._llm_detect_language", detected_language),
+    ):
+        result = await planner_node(state, RunnableConfig())
+
+    if should_preserve:
+        assert result["plan"]["vocal_language"] == vocal_language
+        assert result["plan"]["script_language"] == script_language
+        detected_language.assert_not_called()
+    else:
+        assert result["plan"]["vocal_language"] == "English"
+        assert result["plan"]["script_language"] == "English"
+        detected_language.assert_called_once_with("rupnagar", script_context="English")
+
+
+@pytest.mark.asyncio
+async def test_new_question_still_detects_language():
+    """Language detection remains enabled when the message is not a clarification reply."""
+    from ajrasakha.agents.planner import PlannerOutput, planner_node
+    from langchain_core.runnables import RunnableConfig
+
+    state: AjraSakhaState = {
+        "messages": [HumanMessage(content="Mera fasal kaise bachayein?")],
+        "location": None,
+        "plan": {},
+    }
+    detected_language = Mock(return_value="Hindi")
+    model = _StaticPlannerModel(
+        PlannerOutput(
+            domains=["Weather"],
+            rephrased_query="How can I protect my crop?",
+            original_query_en="How can I protect my crop?",
+            vocal_language="English",
+            script_language="English",
+        )
+    )
+
+    with (
+        patch("ajrasakha.agents.planner.get_minimax_chat_model", return_value=model),
+        patch("ajrasakha.agents.planner._llm_detect_language", detected_language),
+    ):
+        result = await planner_node(state, RunnableConfig())
+
+    assert result["plan"]["vocal_language"] == "Hindi"
+    assert result["plan"]["script_language"] == "English"
+    detected_language.assert_called_once_with(
+        "Mera fasal kaise bachayein?", script_context="English"
+    )
 


### PR DESCRIPTION
Fixed a bug where we were re-detecting the vocal and script language for clarification replies.