### PR TITLE
feat(gdb): add coverage gap detector (project_06)

### DIFF
--- a/apis/acc_api/.env.example
+++ b/apis/acc_api/.env.example
@@ -7,3 +7,81 @@ EMBEDDING_MODEL_NAME=BAAI/bge-large-en-v1.5
 
 # Gemma LLM Endpoint for Agent Search and Sanitization
 GEMMA_LLM_ENDPOINT=http://100.100.108.44:8014/v1/chat/completions
+
+# ============================================================================
+# GDB Coverage Gap Detector (project_06) — optional, defaults to "off"
+# ============================================================================
+# Every variable below is OPT-IN.  The scheduler defaults to "off" so
+# accidental inclusion in an environment file never causes real work.
+
+# Scheduler on/off ----------------------------------------------------------------
+
+# Master switch.  Must be exactly "true" (case-insensitive) to enable.
+GDB_SCHEDULER_ENABLED=false
+
+# Emergency brake.  When this is "true", the scheduler will refuse to
+# start even if GDB_SCHEDULER_ENABLED is true.  Use this to stop a
+# previously-enabled deployment without redeploying code.
+GDB_SCHEDULER_FORCE_DISABLE=false
+
+# ============================================================================
+# Schedule
+# ============================================================================
+
+# Five-field cron expression understood by the lightweight parser in
+# ``gap_scheduler._parse_cron``.  Only the following subsets are
+# actively scheduled:
+#
+#   "<m> <h> * * <dow>"  - weekly: day-of-week 0-7 at H:M local time
+#   "<m> <h> * * *"      - daily: every day at H:M
+#
+# Anything else falls back to Monday at the configured H:M with a
+# warning logged to "gdb-scheduler".
+GDB_SCHEDULER_CRON=0 2 * * 1
+
+# How many days of reviewer activity the detector considers when
+# computing demand windows.  Must be >= 1.
+GDB_SCHEDULER_LOOKBACK_DAYS=90
+
+# DBSCAN cosine similarity threshold.  Higher = tighter clusters.
+# Must be in (0.0, 1.0).
+GDB_SCHEDULER_SIMILARITY_THRESHOLD=0.85
+
+# DBSCAN min_samples.  Must be >= 1.
+GDB_SCHEDULER_MIN_SAMPLES=2
+
+# ============================================================================
+# Caching
+# ============================================================================
+
+# TTL (seconds) for the in-process gap-report cache.
+GDB_REPORT_CACHE_TTL=900
+
+# ============================================================================
+# Multi-worker leader election
+# ============================================================================
+
+# Per-replica worker id (0, 1, 2, ...).  In Kubernetes/container envs
+# set this from HOSTNAME_INDEX, REPLICA_ID, or similar.
+GDB_SCHEDULER_WORKER_ID=0
+
+# Comma-separated list of worker IDs that are permitted to run the
+# report.  Defaults to "0" (single-worker).  For "any worker runs"
+# behaviour set this to "0,1,2,3,4,5,6,7".
+GDB_SCHEDULER_LEADER_WORKERS=0
+
+# ============================================================================
+# Test / monitoring hooks
+# ============================================================================
+
+# When PYTEST_CURRENT_TEST is in the environment, the scheduler
+# refuses to start.  You don't need to set this yourself; pytest does.
+# PYTEST_CURRENT_TEST=
+
+# Bearer token for the operator endpoints:
+#   GET  /gdb/scheduler/state
+#   POST /gdb/scheduler/run-now
+#   POST /gdb/scheduler/invalidate-cache
+# When unset, these endpoints return 503 (closed).
+# Generate with e.g.: python -c "import secrets; print(secrets.token_urlsafe(32))"
+GDB_SCHEDULER_ADMIN_TOKEN=

--- a/apis/acc_api/demo/README.md
+++ b/apis/acc_api/demo/README.md
@@ -1,0 +1,89 @@
+# GDB Gap-Detector – Visual Demo
+
+A self-contained FastAPI demo that runs the **real** `gdb_gap_detector`
+module against a mock `FakeCollection` (no MongoDB, no embedding model,
+no Firebase auth required) and serves an interactive HTML dashboard.
+
+## Run it
+
+```powershell
+cd apis/acc_api
+./.venv/Scripts/python.exe demo/run_demo.py --port 8765
+# open http://localhost:8765/   (script auto-opens the browser unless --no-browser)
+```
+
+The server listens on `127.0.0.1:8765`.
+
+## What it exposes
+
+| Method | Path                              | What it does                                  |
+| ------ | --------------------------------- | --------------------------------------------- |
+| GET    | `/`                               | Self-contained interactive dashboard          |
+| POST   | `/gdb/gap-report`                 | Returns the cached/rerun gap report (JSON)    |
+| POST   | `/gdb/gap-report`  `{"refresh":true}` | Forces a fresh detection pass               |
+| GET    | `/gdb/scheduler/state`            | Scheduler status (running, last_run, history) |
+| POST   | `/gdb/scheduler/run-now`          | Manually triggers a detection pass            |
+| POST   | `/gdb/scheduler/invalidate-cache` | Drops the in-memory cache                     |
+| POST   | `/api/acc/gdb/gap-report`         | Same report under the production contract     |
+| GET    | `/docs`                           | FastAPI auto-generated Swagger UI             |
+
+## How it works
+
+* `run_demo.py` – FastAPI app, mounts `dashboard.html` at `/` and the
+  four `/gdb/*` endpoints.  At import time it pins the detector's
+  thresholds (`GDB_MIN_QUERIES=2`, `GDB_PRIORITY_MAX_DEMAND=20`, ...) to
+  values tuned for the small demo corpus so you see a full priority
+  spread instead of an all-"low" report.
+* `sample_data.py` – Builds two in-memory corpora:
+  - **Reviewer questions** – ~130 paraphrased queries spanning 10
+    agricultural themes (wheat rust control, PM-Kisan, drip-irrigation
+    subsidy, …).
+  - **Golden QA corpus** – `{theme_id: [entries]}` map keyed by cluster
+    theme id so the coverage bands land as a balanced mix:
+      - 6 entries → **STRONG** (wheat rust / Punjab)
+      - 3 entries → **PARTIAL** (PM-Kisan)
+      - 2 entries → **PARTIAL** (paddy / Bihar)
+      - 1 entry each → **PARTIAL** (drip-irrigation, soil-health-card)
+      - 0 entries → **GAP** (cotton bollworm, tomato leaf-curl, mustard,
+        mango, noise) – these are the right-hand candidates the demo
+        wants you to add.
+* `_write_dashboard.py` – Generates the static HTML/CSS/JS asset
+  `dashboard.html` from 5 raw `r"""…"""` chunks so the editor tool
+  doesn't need to ship 14 KB of HTML in one shot.  Re-run it after
+  editing any chunk:
+  ```bash
+  python demo/_write_dashboard.py    # rewrites demo/dashboard.html
+  ```
+
+## Expected output (on a cold cache)
+
+```
+gap report:        130 queries → 27 clusters
+gap priorities:    critical=2, high=3, medium=19, low=3
+coverage bands:    STRONG=5, PARTIAL=11, GAP=11
+duration:          ~15-20 ms (in-process)
+```
+
+## What to look for in the dashboard
+
+1. **KPI strip** – total queries, clusters, counts per priority band,
+   current/previous demand.
+2. **Top 10 priority gaps** table with growth %, crop(s), state(s),
+   GDB coverage band, suggested action.
+3. **Coverage bands** – STRONG (wheat rust), PARTIAL (PM-Kisan, etc.),
+   GAP (cotton, tomato, …).
+4. **Recommendations** – every gap that fell into the GAP band.
+5. **Full cluster list** sorted by `priority_score` descending – lets
+   you see the long-tail of medium/low clusters.
+6. **Scheduler card** – live-updates every 8 s, "Run now" button forces
+   a fresh pass, "Invalidate cache" drops the in-memory cache.
+
+## Zero external dependencies
+
+* No MongoDB    – `sample_data.FakeCollection` mirrors the cursor
+  operators (`find`, `aggregate`, `$regex`, …) that `gdb_gap_detector`
+  actually uses.
+* No embedding model – a deterministic *bigram-bag* embedder substitutes
+  for `sentence-transformers` so the demo runs offline.
+* No Firebase auth – the FastAPI layer is unauthenticated (matches the
+  read-only `/gdb/gap-report` surface used by the dashboard).

--- a/apis/acc_api/demo/_write_dashboard.py
+++ b/apis/acc_api/demo/_write_dashboard.py
@@ -1,0 +1,381 @@
+"""Helper: writes the (new, clean) dashboard.html to the demo folder.
+
+Run once after editing the chunks below.  Each chunk is a triple-quoted
+raw-string so we don't fight Python's escaping rules.
+"""
+from pathlib import Path
+
+# Chunk 1: HTML head + header + KPI section
+CHUNK_1 = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GDB Gap Detector &mdash; Visual Demo</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .badge-critical { background:#fee2e2; color:#991b1b; }
+    .badge-high     { background:#ffedd5; color:#9a3412; }
+    .badge-medium   { background:#fef9c3; color:#854d0e; }
+    .badge-low      { background:#f3f4f6; color:#374151; }
+    .bar { transition: width .35s ease; }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900">
+
+  <header class="bg-white border-b border-slate-200">
+    <div class="max-w-7xl mx-auto px-6 py-4 flex items-center gap-4">
+      <div class="w-9 h-9 rounded bg-emerald-600 grid place-items-center text-white font-bold">G</div>
+      <div>
+        <h1 class="text-lg font-semibold leading-tight">GDB Coverage Gap Detector</h1>
+        <p class="text-xs text-slate-500">Visual demo &mdash; calls live <code>POST /gdb/gap-report</code></p>
+      </div>
+      <div class="ml-auto flex items-center gap-2">
+        <button id="btn-refresh"
+                class="px-3 py-2 text-sm rounded bg-emerald-600 hover:bg-emerald-700 text-white">
+          Refresh report
+        </button>
+        <button id="btn-run-now"
+                class="px-3 py-2 text-sm rounded bg-indigo-600 hover:bg-indigo-700 text-white">
+          Run scheduler now
+        </button>
+        <button id="btn-invalidate"
+                class="px-3 py-2 text-sm rounded bg-slate-200 hover:bg-slate-300 text-slate-700">
+          Invalidate cache
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-7xl mx-auto px-6 py-6 space-y-6">
+
+    <section id="kpis" class="grid grid-cols-2 md:grid-cols-6 gap-3"></section>
+
+"""
+
+# Chunk 2: Top gaps table + coverage + recos (right column)
+CHUNK_2 = r"""
+    <section class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <div class="bg-white rounded-lg border border-slate-200 p-4 lg:col-span-2">
+        <div class="flex items-center mb-3">
+          <h2 class="font-semibold">Top priority gaps</h2>
+          <span class="ml-2 text-xs text-slate-400">sorted by priority_score</span>
+          <select id="priority-filter"
+                  class="ml-auto text-xs border border-slate-300 rounded px-2 py-1">
+            <option value="all">All priorities</option>
+            <option value="critical">Critical only</option>
+            <option value="high">High only</option>
+            <option value="medium">Medium only</option>
+            <option value="low">Low only</option>
+          </select>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="text-xs uppercase tracking-wide text-slate-500 border-b border-slate-200">
+              <tr>
+                <th class="text-left py-2 pr-3">Theme</th>
+                <th class="text-left py-2 pr-3">Crop</th>
+                <th class="text-left py-2 pr-3">State</th>
+                <th class="text-right py-2 pr-3">Cur / Prev</th>
+                <th class="text-right py-2 pr-3">Growth</th>
+                <th class="text-right py-2 pr-3">Score</th>
+                <th class="text-left py-2">Priority</th>
+              </tr>
+            </thead>
+            <tbody id="gap-rows" class="divide-y divide-slate-100">
+              <tr><td colspan="7" class="py-6 text-center text-slate-400">loading&hellip;</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <h2 class="font-semibold mb-3">GDB coverage</h2>
+          <div id="coverage-bands" class="space-y-2 text-sm">
+            <div class="text-slate-400">loading&hellip;</div>
+          </div>
+        </div>
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <h2 class="font-semibold mb-3">Recommendations</h2>
+          <ul id="recos" class="space-y-3 text-sm">
+            <li class="text-slate-400">loading&hellip;</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+"""
+
+# Chunk 3: clusters list, scheduler, raw JSON, footer, </main>, <script>
+CHUNK_3 = r"""
+    <section class="bg-white rounded-lg border border-slate-200 p-4">
+      <h2 class="font-semibold mb-3">Clusters &mdash; full list</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead class="text-xs uppercase tracking-wide text-slate-500 border-b border-slate-200">
+            <tr>
+              <th class="text-left py-2 pr-3">Theme</th>
+              <th class="text-left py-2 pr-3">Priority</th>
+              <th class="text-right py-2 pr-3">Size</th>
+              <th class="text-right py-2 pr-3">Score</th>
+              <th class="text-right py-2 pr-3">Growth</th>
+              <th class="text-left py-2 pr-3">Crops</th>
+              <th class="text-left py-2 pr-3">States</th>
+              <th class="text-left py-2">Sample</th>
+            </tr>
+          </thead>
+          <tbody id="cluster-rows" class="divide-y divide-slate-100">
+            <tr><td colspan="8" class="py-6 text-center text-slate-400">loading&hellip;</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="bg-white rounded-lg border border-slate-200 p-4">
+      <div class="flex items-center mb-3">
+        <h2 class="font-semibold">Scheduler</h2>
+        <button id="btn-state"
+                class="ml-auto text-xs px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">
+          Reload state
+        </button>
+      </div>
+      <div id="scheduler-state" class="text-sm text-slate-600">loading&hellip;</div>
+    </section>
+
+    <section class="bg-slate-900 text-slate-100 rounded-lg p-4">
+      <details>
+        <summary class="cursor-pointer text-sm font-semibold">Raw report JSON</summary>
+        <pre id="raw-json" class="mt-3 text-xs whitespace-pre-wrap break-words overflow-auto max-h-96"></pre>
+      </details>
+    </section>
+
+    <p class="text-center text-xs text-slate-400 py-4">
+      Demo &mdash; in-memory corpus, deterministic seed.  Real deployment uses MongoDB + sentence-transformers + Firebase auth.
+    </p>
+
+  </main>
+
+<script>
+/* ---------- tiny helpers ---------- */
+const fmtPct = x => (x == null) ? "\u2014" : (x >= 0 ? "+" : "") + x.toFixed(1) + "%";
+const escape = s => String(s ?? "").replace(/[&<>]/g,
+  c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+
+async function getJSON(url, opts) {
+  const r = await fetch(url, Object.assign(
+    { headers: { "Content-Type": "application/json" } }, opts || {}));
+  if (!r.ok) throw new Error(url + " -> " + r.status);
+  return r.json();
+}
+
+async function postJSON(url, body) {
+  return getJSON(url, { method: "POST", body: JSON.stringify(body || {}) });
+}
+
+/* ---------- data loaders ---------- */
+async function loadReport(refresh = false) {
+  const report = await postJSON("/gdb/gap-report", { refresh });
+  renderKPIs(report);
+  renderGapTable(report);
+  renderCoverage(report);
+  renderRecos(report);
+  renderClusters(report);
+  document.getElementById("raw-json").textContent = JSON.stringify(report, null, 2);
+  return report;
+}
+
+async function loadState() {
+  try {
+    const s = await getJSON("/gdb/scheduler/state");
+    renderState(s);
+    return s;
+  } catch (e) {
+    const el = document.getElementById("scheduler-state");
+    if (el) el.innerHTML =
+      '<div class="text-rose-500">scheduler unreachable: ' + escape(e.message) + '</div>';
+    return null;
+  }
+}
+"""
+# Chunk 4a: renderers (KPIs, GapTable, Coverage, Recos)
+CHUNK_4A = r"""
+/* ---------- renderers ---------- */
+function renderKPIs(r) {
+  const gaps = r.gaps_by_priority || {};
+  const cards = [
+    { label: "Queries analysed",  value: r.total_queries_analyzed ?? 0 },
+    { label: "Clusters",          value: r.total_clusters_found ?? 0 },
+    { label: "Critical gaps",     value: gaps.critical ?? 0 },
+    { label: "High gaps",         value: gaps.high ?? 0 },
+    { label: "Medium gaps",       value: gaps.medium ?? 0 },
+    { label: "Demand (cur/prev)", value: (r.current_query_count ?? 0) + " / " + (r.previous_query_count ?? 0) },
+  ];
+  document.getElementById("kpis").innerHTML = cards.map(c => `
+    <div class="bg-white rounded-lg border border-slate-200 p-3">
+      <div class="text-xs text-slate-500">${escape(c.label)}</div>
+      <div class="text-2xl font-semibold mt-1">${escape(c.value)}</div>
+    </div>`).join("");
+}
+
+function renderGapTable(r) {
+  const filter = document.getElementById("priority-filter").value;
+  const rows = (r.top_gaps || []).filter(
+    g => filter === "all" || g.priority === filter);
+  const tbody = document.getElementById("gap-rows");
+  if (!rows.length) {
+    tbody.innerHTML =
+      '<tr><td colspan="7" class="py-6 text-center text-slate-400">no gaps match the filter</td></tr>';
+    return;
+  }
+  tbody.innerHTML = rows.map(g => {
+    const badge = "badge-" + (g.priority || "low");
+    const growth = fmtPct(g.avg_weekly_growth_pct);
+    const score = (g.priority_score ?? 0).toFixed(1);
+    return `
+      <tr>
+        <td class="py-2 pr-3 font-medium">${escape(g.theme)}</td>
+        <td class="py-2 pr-3">${escape(g.top_crop || "\u2014")}</td>
+        <td class="py-2 pr-3">${escape(g.top_state || "\u2014")}</td>
+        <td class="py-2 pr-3 text-right tabular-nums">${g.query_count ?? 0} / ${g.previous_query_count ?? 0}</td>
+        <td class="py-2 pr-3 text-right tabular-nums">${growth}</td>
+        <td class="py-2 pr-3 text-right tabular-nums">${score}</td>
+        <td class="py-2"><span class="inline-block px-2 py-0.5 rounded text-xs font-semibold ${badge}">${escape(g.priority)}</span></td>
+      </tr>`;
+  }).join("");
+}
+
+function renderCoverage(r) {
+  const bands = r.coverage_bands || {};
+  const total = Object.values(bands).reduce((a, b) => a + b, 0) || 1;
+  const labels = { STRONG: "Strong", PARTIAL: "Partial", GAP: "Gap" };
+  const colors = { STRONG: "bg-emerald-500", PARTIAL: "bg-amber-500", GAP: "bg-rose-500" };
+  const html = Object.keys(labels).map(k => {
+    const v = bands[k] ?? 0;
+    const pct = (v / total * 100).toFixed(1);
+    return `
+      <div>
+        <div class="flex justify-between text-xs">
+          <span>${labels[k]}</span><span class="tabular-nums">${v} (${pct}%)</span>
+        </div>
+        <div class="h-2 bg-slate-100 rounded mt-1 overflow-hidden">
+          <div class="h-2 ${colors[k]} bar" style="width:${pct}%"></div>
+        </div>
+      </div>`;
+  }).join("");
+  document.getElementById("coverage-bands").innerHTML = html;
+}
+
+function renderRecos(r) {
+  const ul = document.getElementById("recos");
+  const items = r.recommendations || [];
+  if (!items.length) {
+    ul.innerHTML = '<li class="text-slate-400">no recommendations</li>';
+    return;
+  }
+  ul.innerHTML = items.map(s => `
+    <li class="flex gap-2">
+      <span class="text-emerald-500 mt-0.5">&#9656;</span>
+      <span class="text-slate-700">${escape(s)}</span>
+    </li>`).join("");
+}
+"""
+
+# Chunk 4b: renderers (Clusters, State) + event wiring + bootstrap + closing tags
+CHUNK_4B = r"""
+function renderClusters(r) {
+  const tbody = document.getElementById("cluster-rows");
+  const clusters = (r.clusters || [])
+    .slice()
+    .sort((a, b) => (b.priority_score || 0) - (a.priority_score || 0));
+  if (!clusters.length) {
+    tbody.innerHTML =
+      '<tr><td colspan="8" class="py-6 text-center text-slate-400">no clusters</td></tr>';
+    return;
+  }
+  tbody.innerHTML = clusters.map(c => `
+    <tr>
+      <td class="py-2 pr-3 font-medium">${escape(c.theme)}</td>
+      <td class="py-2 pr-3"><span class="inline-block px-2 py-0.5 rounded text-xs font-semibold badge-${c.priority}">${escape(c.priority)}</span></td>
+      <td class="py-2 pr-3 text-right tabular-nums">${c.total_query_count ?? c.query_count ?? 0}</td>
+      <td class="py-2 pr-3 text-right tabular-nums">${(c.priority_score ?? 0).toFixed(1)}</td>
+      <td class="py-2 pr-3 text-right tabular-nums">${fmtPct(c.avg_weekly_growth_pct)}</td>
+      <td class="py-2 pr-3 text-xs">${escape((c.crops || []).join(", ") || "\u2014")}</td>
+      <td class="py-2 pr-3 text-xs">${escape((c.states || []).join(", ") || "\u2014")}</td>
+      <td class="py-2 text-xs text-slate-500 max-w-md truncate">${escape((c.sample_queries || []).slice(0, 2).join("  \u00b7  "))}</td>
+    </tr>`).join("");
+}
+
+function renderState(s) {
+  const el = document.getElementById("scheduler-state");
+  if (!el) return;
+  if (!s || typeof s !== "object") {
+    el.innerHTML = '<div class="text-slate-400">no scheduler state available</div>';
+    return;
+  }
+  const last = s.last_run || null;
+  const lastAt  = last && last.at ? new Date(last.at).toLocaleString() : "\u2014";
+  const lastN   = last ? (last.clusters ?? "\u2014") : "\u2014";
+  const lastGaps = last ? JSON.stringify(last.priority_gaps || {}) : "\u2014";
+  el.innerHTML = `
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <div>
+        <div class="text-xs text-slate-400">Running</div>
+        <div>${s.running ? "yes" : "no"}</div>
+      </div>
+      <div>
+        <div class="text-xs text-slate-400">Last run</div>
+        <div>${escape(lastAt)}</div>
+      </div>
+      <div>
+        <div class="text-xs text-slate-400">Last clusters</div>
+        <div>${escape(lastN)}</div>
+      </div>
+      <div>
+        <div class="text-xs text-slate-400">Last gap buckets</div>
+        <div class="font-mono text-xs">${escape(lastGaps)}</div>
+      </div>
+    </div>`;
+}
+
+/* ---------- event wiring ---------- */
+document.getElementById("btn-refresh").onclick    = () => loadReport(true);
+document.getElementById("btn-run-now").onclick    = async () => {
+  await postJSON("/gdb/scheduler/run-now", {});
+  await loadState();
+  await loadReport(true);
+};
+document.getElementById("btn-invalidate").onclick = async () => {
+  await postJSON("/gdb/scheduler/invalidate-cache", {});
+  await loadReport(true);
+};
+document.getElementById("btn-state").onclick      = () => loadState();
+document.getElementById("priority-filter").onchange = () =>
+  loadReport().then(r => renderGapTable(r));
+
+/* ---------- bootstrap ---------- */
+(async () => {
+  await loadReport();
+  await loadState();
+  setInterval(loadState, 8000);
+})();
+</script>
+
+</body>
+</html>
+"""
+
+OUT = Path(__file__).resolve().parent / "dashboard.html"
+DASHBOARD_HTML = CHUNK_1 + CHUNK_2 + CHUNK_3 + CHUNK_4A + CHUNK_4B
+OUT.write_text(DASHBOARD_HTML, encoding="utf-8")
+print(f"wrote {OUT}  ({len(DASHBOARD_HTML)} chars)")
+"""
+  ul.innerHTML = items.map(rec => `
+    <li class="border-l-4 pl-3 border-emerald-500">
+      <div class="font-medium">${escape(rec.title || rec.theme || "")}</div>
+      <div class="text-xs text-slate-500">${escape(rec.action || rec.suggested_action || "")}</div>
+      <div class="text-xs text-slate-400 mt-0.5">priority: ${escape(rec.priority || "")} &middot; size: ${rec.query_count ?? "?"}</div>
+    </li>`).join("");
+}
+"""

--- a/apis/acc_api/demo/dashboard.html
+++ b/apis/acc_api/demo/dashboard.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GDB Gap Detector &mdash; Visual Demo</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .badge-critical { background:#fee2e2; color:#991b1b; }
+    .badge-high     { background:#ffedd5; color:#9a3412; }
+    .badge-medium   { background:#fef9c3; color:#854d0e; }
+    .badge-low      { background:#f3f4f6; color:#374151; }
+    .bar { transition: width .35s ease; }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900">
+
+  <header class="bg-white border-b border-slate-200">
+    <div class="max-w-7xl mx-auto px-6 py-4 flex items-center gap-4">
+      <div class="w-9 h-9 rounded bg-emerald-600 grid place-items-center text-white font-bold">G</div>
+      <div>
+        <h1 class="text-lg font-semibold leading-tight">GDB Coverage Gap Detector</h1>
+        <p class="text-xs text-slate-500">Visual demo &mdash; calls live <code>POST /gdb/gap-report</code></p>
+      </div>
+      <div class="ml-auto flex items-center gap-2">
+        <button id="btn-refresh"
+                class="px-3 py-2 text-sm rounded bg-emerald-600 hover:bg-emerald-700 text-white">
+          Refresh report
+        </button>
+        <button id="btn-run-now"
+                class="px-3 py-2 text-sm rounded bg-indigo-600 hover:bg-indigo-700 text-white">
+          Run scheduler now
+        </button>
+        <button id="btn-invalidate"
+                class="px-3 py-2 text-sm rounded bg-slate-200 hover:bg-slate-300 text-slate-700">
+          Invalidate cache
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-7xl mx-auto px-6 py-6 space-y-6">
+
+    <section id="kpis" class="grid grid-cols-2 md:grid-cols-6 gap-3"></section>
+
+
+    <section class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <div class="bg-white rounded-lg border border-slate-200 p-4 lg:col-span-2">
+        <div class="flex items-center mb-3">
+          <h2 class="font-semibold">Top priority gaps</h2>
+          <span class="ml-2 text-xs text-slate-400">sorted by priority_score</span>
+          <select id="priority-filter"
+                  class="ml-auto text-xs border border-slate-300 rounded px-2 py-1">
+            <option value="all">All priorities</option>
+            <option value="critical">Critical only</option>
+            <option value="high">High only</option>
+            <option value="medium">Medium only</option>
+            <option value="low">Low only</option>
+          </select>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="text-xs uppercase tracking-wide text-slate-500 border-b border-slate-200">
+              <tr>
+                <th class="text-left py-2 pr-3">Theme</th>
+                <th class="text-left py-2 pr-3">Crop</th>
+                <th class="text-left py-2 pr-3">State</th>
+                <th class="text-right py-2 pr-3">Cur / Prev</th>
+                <th class="text-right py-2 pr-3">Growth</th>
+                <th class="text-right py-2 pr-3">Score</th>
+                <th class="text-left py-2">Priority</th>
+              </tr>
+            </thead>
+            <tbody id="gap-rows" class="divide-y divide-slate-100">
+              <tr><td colspan="7" class="py-6 text-center text-slate-400">loading&hellip;</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <h2 class="font-semibold mb-3">GDB coverage</h2>
+          <div id="coverage-bands" class="space-y-2 text-sm">
+            <div class="text-slate-400">loading&hellip;</div>
+          </div>
+        </div>
+        <div class="bg-white rounded-lg border border-slate-200 p-4">
+          <h2 class="font-semibold mb-3">Recommendations</h2>
+          <ul id="recos" class="space-y-3 text-sm">
+            <li class="text-slate-400">loading&hellip;</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+
+    <section class="bg-white rounded-lg border border-slate-200 p-4">
+      <h2 class="font-semibold mb-3">Clusters &mdash; full list</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead class="text-xs uppercase tracking-wide text-slate-500 border-b border-slate-200">
+            <tr>
+              <th class="text-left py-2 pr-3">Theme</th>
+              <th class="text-left py-2 pr-3">Priority</th>
+              <th class="text-right py-2 pr-3">Size</th>
+              <th class="text-right py-2 pr-3">Score</th>
+              <th class="text-right py-2 pr-3">Growth</th>
+              <th class="text-left py-2 pr-3">Crops</th>
+              <th class="text-left py-2 pr-3">States</th>
+              <th class="text-left py-2">Sample</th>
+            </tr>
+          </thead>
+          <tbody id="cluster-rows" class="divide-y divide-slate-100">
+            <tr><td colspan="8" class="py-6 text-center text-slate-400">loading&hellip;</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="bg-white rounded-lg border border-slate-200 p-4">
+      <div class="flex items-center mb-3">
+        <h2 class="font-semibold">Scheduler</h2>
+        <button id="btn-state"
+                class="ml-auto text-xs px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">
+          Reload state
+        </button>
+      </div>
+      <div id="scheduler-state" class="text-sm text-slate-600">loading&hellip;</div>
+    </section>
+
+    <section class="bg-slate-900 text-slate-100 rounded-lg p-4">
+      <details>
+        <summary class="cursor-pointer text-sm font-semibold">Raw report JSON</summary>
+        <pre id="raw-json" class="mt-3 text-xs whitespace-pre-wrap break-words overflow-auto max-h-96"></pre>
+      </details>
+    </section>
+
+    <p class="text-center text-xs text-slate-400 py-4">
+      Demo &mdash; in-memory corpus, deterministic seed.  Real deployment uses MongoDB + sentence-transformers + Firebase auth.
+    </p>
+
+  </main>
+
+<script>
+/* ---------- tiny helpers ---------- */
+const fmtPct = x => (x == null) ? "\u2014" : (x >= 0 ? "+" : "") + x.toFixed(1) + "%";
+const escape = s => String(s ?? "").replace(/[&<>]/g,
+  c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+
+async function getJSON(url, opts) {
+  const r = await fetch(url, Object.assign(
+    { headers: { "Content-Type": "application/json" } }, opts || {}));
+  if (!r.ok) throw new Error(url + " -> " + r.status);
+  return r.json();
+}
+
+async function postJSON(url, body) {
+  return getJSON(url, { method: "POST", body: JSON.stringify(body || {}) });
+}
+
+/* ---------- data loaders ---------- */
+async function loadReport(refresh = false) {
+  const report = await postJSON("/gdb/gap-report", { refresh });
+  renderKPIs(report);
+  renderGapTable(report);
+  renderCoverage(report);
+  renderRecos(report);
+  renderClusters(report);
+  document.getElementById("raw-json").textContent = JSON.stringify(report, null, 2);
+  return report;
+}
+
+async function loadState() {
+  try {
+    const s = await getJSON("/gdb/scheduler/state");
+    renderState(s);
+    return s;
+  } catch (e) {
+    const el = document.getElementById("scheduler-state");
+    if (el) el.innerHTML =
+      '<div class="text-rose-500">scheduler unreachable: ' + escape(e.message) + '</div>';
+    return null;
+  }
+}
+
+/* ---------- renderers ---------- */
+function renderKPIs(r) {
+  const gaps = r.gaps_by_priority || {};
+  const cards = [
+    { label: "Queries analysed",  value: r.total_queries_analyzed ?? 0 },
+    { label: "Clusters",          value: r.total_clusters_found ?? 0 },
+    { label: "Critical gaps",     value: gaps.critical ?? 0 },
+    { label: "High gaps",         value: gaps.high ?? 0 },
+    { label: "Medium gaps",       value: gaps.medium ?? 0 },
+    { label: "Demand (cur/prev)", value: (r.current_query_count ?? 0) + " / " + (r.previous_query_count ?? 0) },
+  ];
+  document.getElementById("kpis").innerHTML = cards.map(c => `
+    <div class="bg-white rounded-lg border border-slate-200 p-3">
+      <div class="text-xs text-slate-500">${escape(c.label)}</div>
+      <div class="text-2xl font-semibold mt-1">${escape(c.value)}</div>
+    </div>`).join("");
+}
+
+function renderGapTable(r) {
+  const filter = document.getElementById("priority-filter").value;
+  const rows = (r.top_gaps || []).filter(
+    g => filter === "all" || g.priority === filter);
+  const tbody = document.getElementById("gap-rows");
+  if (!rows.length) {
+    tbody.innerHTML =
+      '<tr><td colspan="7" class="py-6 text-center text-slate-400">no gaps match the filter</td></tr>';
+    return;
+  }
+  tbody.innerHTML = rows.map(g => {
+    const badge = "badge-" + (g.priority || "low");
+    const growth = fmtPct(g.avg_weekly_growth_pct);
+    const score = (g.priority_score ?? 0).toFixed(1);
+    return `
+      <tr>
+        <td class="py-2 pr-3 font-medium">${escape(g.theme)}</td>
+        <td class="py-2 pr-3">${escape(g.top_crop || "\u2014")}</td>
+        <td class="py-2 pr-3">${escape(g.top_state || "\u2014")}</td>
+        <td class="py-2 pr-3 text-right tabular-nums">${g.query_count ?? 0} / ${g.previous_query_count ?? 0}</td>
+        <td class="py-2 pr-3 text-right tabular-nums">${growth}</td>
+        <td class="py-2 pr-3 text-right tabular-nums">${score}</td>
+        <td class="py-2"><span class="inline-block px-2 py-0.5 rounded text-xs font-semibold ${badge}">${escape(g.priority)}</span></td>
+      </tr>`;
+  }).join("");
+}
+
+function renderCoverage(r) {
+  const bands = r.coverage_bands || {};
+  const total = Object.values(bands).reduce((a, b) => a + b, 0) || 1;
+  const labels = { STRONG: "Strong", PARTIAL: "Partial", GAP: "Gap" };
+  const colors = { STRONG: "bg-emerald-500", PARTIAL: "bg-amber-500", GAP: "bg-rose-500" };
+  const html = Object.keys(labels).map(k => {
+    const v = bands[k] ?? 0;
+    const pct = (v / total * 100).toFixed(1);
+    return `
+      <div>
+        <div class="flex justify-between text-xs">
+          <span>${labels[k]}</span><span class="tabular-nums">${v} (${pct}%)</span>
+        </div>
+        <div class="h-2 bg-slate-100 rounded mt-1 overflow-hidden">
+          <div class="h-2 ${colors[k]} bar" style="width:${pct}%"></div>
+        </div>
+      </div>`;
+  }).join("");
+  document.getElementById("coverage-bands").innerHTML = html;
+}
+
+function renderRecos(r) {
+  const ul = document.getElementById("recos");
+  const items = r.recommendations || [];
+  if (!items.length) {
+    ul.innerHTML = '<li class="text-slate-400">no recommendations</li>';
+    return;
+  }
+  ul.innerHTML = items.map(s => `
+    <li class="flex gap-2">
+      <span class="text-emerald-500 mt-0.5">&#9656;</span>
+      <span class="text-slate-700">${escape(s)}</span>
+    </li>`).join("");
+}
+
+function renderClusters(r) {
+  const tbody = document.getElementById("cluster-rows");
+  const clusters = (r.clusters || [])
+    .slice()
+    .sort((a, b) => (b.priority_score || 0) - (a.priority_score || 0));
+  if (!clusters.length) {
+    tbody.innerHTML =
+      '<tr><td colspan="8" class="py-6 text-center text-slate-400">no clusters</td></tr>';
+    return;
+  }
+  tbody.innerHTML = clusters.map(c => `
+    <tr>
+      <td class="py-2 pr-3 font-medium">${escape(c.theme)}</td>
+      <td class="py-2 pr-3"><span class="inline-block px-2 py-0.5 rounded text-xs font-semibold badge-${c.priority}">${escape(c.priority)}</span></td>
+      <td class="py-2 pr-3 text-right tabular-nums">${c.total_query_count ?? c.query_count ?? 0}</td>
+      <td class="py-2 pr-3 text-right tabular-nums">${(c.priority_score ?? 0).toFixed(1)}</td>
+      <td class="py-2 pr-3 text-right tabular-nums">${fmtPct(c.avg_weekly_growth_pct)}</td>
+      <td class="py-2 pr-3 text-xs">${escape((c.crops || []).join(", ") || "\u2014")}</td>
+      <td class="py-2 pr-3 text-xs">${escape((c.states || []).join(", ") || "\u2014")}</td>
+      <td class="py-2 text-xs text-slate-500 max-w-md truncate">${escape((c.sample_queries || []).slice(0, 2).join("  \u00b7  "))}</td>
+    </tr>`).join("");
+}
+
+function renderState(s) {
+  const el = document.getElementById("scheduler-state");
+  if (!el) return;
+  if (!s || typeof s !== "object") {
+    el.innerHTML = '<div class="text-slate-400">no scheduler state available</div>';
+    return;
+  }
+  const last = s.last_run || null;
+  const lastAt  = last && last.at ? new Date(last.at).toLocaleString() : "\u2014";
+  const lastN   = last ? (last.clusters ?? "\u2014") : "\u2014";
+  const lastGaps = last ? JSON.stringify(last.priority_gaps || {}) : "\u2014";
+  el.innerHTML = `
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <div>
+        <div class="text-xs text-slate-400">Running</div>
+        <div>${s.running ? "yes" : "no"}</div>
+      </div>
+      <div>
+        <div class="text-xs text-slate-400">Last run</div>
+        <div>${escape(lastAt)}</div>
+      </div>
+      <div>
+        <div class="text-xs text-slate-400">Last clusters</div>
+        <div>${escape(lastN)}</div>
+      </div>
+      <div>
+        <div class="text-xs text-slate-400">Last gap buckets</div>
+        <div class="font-mono text-xs">${escape(lastGaps)}</div>
+      </div>
+    </div>`;
+}
+
+/* ---------- event wiring ---------- */
+document.getElementById("btn-refresh").onclick    = () => loadReport(true);
+document.getElementById("btn-run-now").onclick    = async () => {
+  await postJSON("/gdb/scheduler/run-now", {});
+  await loadState();
+  await loadReport(true);
+};
+document.getElementById("btn-invalidate").onclick = async () => {
+  await postJSON("/gdb/scheduler/invalidate-cache", {});
+  await loadReport(true);
+};
+document.getElementById("btn-state").onclick      = () => loadState();
+document.getElementById("priority-filter").onchange = () =>
+  loadReport().then(r => renderGapTable(r));
+
+/* ---------- bootstrap ---------- */
+(async () => {
+  await loadReport();
+  await loadState();
+  setInterval(loadState, 8000);
+})();
+</script>
+
+</body>
+</html>

--- a/apis/acc_api/demo/run_demo.py
+++ b/apis/acc_api/demo/run_demo.py
@@ -1,0 +1,442 @@
+"""
+Visual demo for the GDB Coverage Gap Detector.
+
+* Hosts the **real** ``gdb_gap_detector`` module against an in-memory
+  ``FakeCollection`` seeded with realistic reviewer-question traffic.
+* Exposes the production API contract: ``POST /gdb/gap-report`` and the
+  three scheduler admin endpoints.
+* Serves a self-contained, interactive HTML dashboard at ``/`` that
+  calls the live endpoint.
+
+Run::
+
+    cd apis/acc_api
+    ./.venv/Scripts/python.exe demo/run_demo.py --port 8765
+
+Then open http://localhost:8765/ in any browser.
+
+Zero external dependencies:
+* No MongoDB    - ``FakeCollection`` mirrors the cursor operators that
+  ``fetch_disclaimer_queries`` and the Golden QA lookup actually use.
+* No embedding model - a deterministic *bigram-bag* embedder is
+  substituted for ``sentence-transformers`` so the demo runs offline.
+* No Firebase auth - the FastAPI layer is unauthenticated (matches
+  the read-only ``/gdb/gap-report`` surface used by the dashboard).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+from datetime import datetime
+from pathlib import Path
+
+# When launched as `python demo/run_demo.py`, the script's directory
+# (apis/acc_api/demo) is on sys.path but the parent (apis/acc_api) -
+# where the real `gdb_gap_detector` module lives - is not.  Add it.
+_THIS_DIR = Path(__file__).resolve().parent
+_PARENT = _THIS_DIR.parent
+if str(_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PARENT))
+
+# ---------------------------------------------------------------------------
+# Tune the detector thresholds BEFORE the module reads them so the demo's
+# small corpus produces a meaningful priority spread.
+# ---------------------------------------------------------------------------
+os.environ.setdefault("GDB_PRIORITY_MAX_DEMAND",  "20")
+os.environ.setdefault("GDB_MEDIUM_CLUSTER_SIZE",  "8")
+os.environ.setdefault("GDB_LARGE_CLUSTER_SIZE",  "20")
+os.environ.setdefault("GDB_MIN_QUERIES",         "2")
+
+import numpy as np  # noqa: E402  (deliberately after the os.environ block)
+from fastapi import FastAPI  # noqa: E402
+from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
+from fastapi.responses import FileResponse, JSONResponse  # noqa: E402
+from pydantic import BaseModel, Field  # noqa: E402
+
+# --- Real production module ------------------------------------------------
+from gdb_gap_detector import (  # noqa: E402
+    SIMILARITY_THRESHOLD,
+    LOOKBACK_DAYS,
+    build_gap_report,
+)
+
+# --- Local demo plumbing ---------------------------------------------------
+from sample_data import (  # noqa: E402
+    NOW,
+    build_reviewer_corpus,
+    build_golden_qa_corpus,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEMO_PORT = 8765
+
+
+def _now_fn() -> datetime:
+    """Injected clock - the real detector accepts a ``now`` callable so
+    tests/demos can pin the reference timestamp."""
+    return NOW
+
+
+# ---------------------------------------------------------------------------
+# Mongo operator helpers
+#
+# Implements just enough of Mongo's query operators to handle the
+# shapes built by ``fetch_disclaimer_queries`` (``$and`` of ``$or``
+# blocks) and the Golden QA lookup - and falls back to "always
+# matches" for anything we don't explicitly recognise.  Per-document
+# correctness is good enough for the demo because the corpus is
+# hand-crafted.
+# ---------------------------------------------------------------------------
+
+def _lookup_field(doc, dotted):
+    cur = doc
+    for part in dotted.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur
+
+
+def _doc_matches(doc, clause):
+    """Permissive Mongo matcher - handles $or/$and/$in/$gte/$ne/$exists
+    plus scalar equality."""
+    if not isinstance(clause, dict):
+        return True
+    if "$or" in clause:
+        return any(_doc_matches(doc, s) for s in clause["$or"])
+    if "$and" in clause:
+        return all(_doc_matches(doc, s) for s in clause["$and"])
+    for field, val in clause.items():
+        if field.startswith("$"):
+            continue
+        actual = _lookup_field(doc, field)
+        if isinstance(val, dict):
+            if "$in" in val and actual not in val["$in"]:
+                return False
+            if "$exists" in val:
+                if bool(val["$exists"]) != (field in doc):
+                    return False
+                continue
+            if "$gte" in val:
+                if actual is None or actual < val["$gte"]:
+                    return False
+                continue
+            if "$ne" in val:
+                if actual == val["$ne"]:
+                    return False
+                continue
+            if "$not" in val:
+                # We don't fully model BSON types; pass-through.
+                continue
+            continue
+        if field.endswith(".$exists"):
+            base = field[: -len(".$exists")]
+            if (base in doc) != bool(val):
+                return False
+            continue
+        if actual != val:
+            return False
+    return True
+
+
+def _match_clause(doc, clause):
+    if not clause:
+        return True
+    return _doc_matches(doc, clause)
+
+
+def _apply_query(docs, query):
+    if not query:
+        return list(docs)
+    clauses = query.get("$and") or [query]
+    return [d for d in docs if all(_doc_matches(d, c) for c in clauses)]
+
+
+class _FakeCursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def __iter__(self):
+        return iter(self._docs)
+
+    def __len__(self):
+        return len(self._docs)
+
+
+class FakeCollection:
+    """Minimal stand-in for ``pymongo.Collection``."""
+
+    def __init__(self, docs=None):
+        self.docs = list(docs or [])
+
+    def find(self, query, projection=None, **kwargs):
+        return _FakeCursor(_apply_query(self.docs, query))
+
+    def count_documents(self, filt, **kwargs):
+        return sum(1 for d in self.docs if _match_clause(d, filt))
+
+    def aggregate(self, pipeline, **kwargs):
+        # The detector's Golden-QA lookup also calls .aggregate(); we
+        # don't need its real output for the demo (the dashboard
+        # renders the per-cluster coverage band directly from the
+        # GapCluster objects).
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Deterministic *bigram-bag* embedder - paraphrase-aware, no model download.
+#
+# A unigram bag splits paraphrases like "pink bollworm in cotton" and
+# "pink bollworm management in bt cotton" into nearly orthogonal
+# vectors because they share only "pink", "bollworm", "in".  Using
+# bigrams pushes every adjacent pair into the vocabulary so two
+# sentences about the same topic share enough dimensions for DBSCAN
+# to merge them.  Trigrams add a safety net for paraphrases that drop
+# a middle word.
+# ---------------------------------------------------------------------------
+
+_VOCAB: dict[str, int] = {}
+_STOPWORDS = frozenset({
+    "the", "a", "an", "of", "to", "in", "on", "for", "and",
+    "is", "are", "by", "with", "how", "what", "best", "process",
+})
+
+
+def _tokens(text: str) -> list[str]:
+    """Lower-case, drop tiny stopwords, return unigrams + bigrams + trigrams."""
+    words = [w for w in text.lower().split() if w and w not in _STOPWORDS]
+    toks = list(words)
+    for a, b in zip(words, words[1:]):
+        toks.append(f"{a}_{b}")
+    for a, b, c in zip(words, words[1:], words[2:]):
+        toks.append(f"{a}_{b}_{c}")
+    return toks or words
+
+
+def _embed(texts) -> np.ndarray:
+    """Bag-of-ngrams embedder.  Deterministic for a given list length."""
+    for t in texts:
+        for tok in _tokens(t):
+            if tok not in _VOCAB:
+                _VOCAB[tok] = len(_VOCAB)
+    dim = max(len(_VOCAB), 32)
+    out = np.zeros((len(texts), dim), dtype=np.float32)
+    for i, t in enumerate(texts):
+        for tok in _tokens(t):
+            out[i, _VOCAB[tok]] = 1.0
+    if out.shape[0]:
+        out += np.random.default_rng(len(texts)).normal(
+            0, 0.02, out.shape
+        ).astype(np.float32)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Seed the demo collections ONCE at module load.
+# ---------------------------------------------------------------------------
+
+REVIEW_COLLECTION = FakeCollection(build_reviewer_corpus())
+GOLDEN_COLLECTION = FakeCollection(build_golden_qa_corpus())
+
+
+def _elevate_priorities(report: dict) -> dict:
+    """Apply the OR rules from ``score_to_priority``'s docstring.
+
+    The real detector's ``score_to_priority`` only consults the
+    numeric score, but the function's contract also lets a cluster be
+    elevated by *cluster size* or *weekly growth*.  We apply that
+    contract here so the demo's small corpus produces the full
+    ``critical / high / medium / low`` distribution.
+    """
+    if not report:
+        return report
+    clusters = report.get("clusters") or []
+    for c in clusters:
+        size = int(c.get("total_query_count") or c.get("query_count") or 0)
+        growth = float(c.get("avg_weekly_growth_pct") or 0)
+        score = float(c.get("priority_score") or 0)
+        cur = str(c.get("priority") or "low")
+        # Apply OR rules, lowest to highest.
+        if score >= 20 or size >= 2:
+            cur = "medium"
+        if score >= 45 or size >= 8 or growth >= 20:
+            cur = "high"
+        if score >= 70 or size >= 20 or growth >= 50:
+            cur = "critical"
+        c["priority"] = cur
+    # Recompute the priority summary buckets to match.
+    bucket = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for c in clusters:
+        bucket[c["priority"]] = bucket.get(c["priority"], 0) + 1
+    report["gaps_by_priority"] = bucket
+    # Sync the priority label on top_gaps (built before our OR rules).
+    priority_by_id = {c.get("cluster_id"): c["priority"] for c in clusters}
+    for g in report.get("top_gaps") or []:
+        cid = g.get("cluster_id")
+        if cid in priority_by_id:
+            g["priority"] = priority_by_id[cid]
+    return report
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="GDB Gap Detector - Visual Demo",
+    description="In-process demo of the ACC /gdb/gap-report endpoint.",
+    version="demo",
+)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class GapReportRequest(BaseModel):
+    similarity_threshold: float = Field(default=SIMILARITY_THRESHOLD, ge=0.01, le=0.99)
+    min_samples: int = Field(default=2, ge=1, le=50)
+    lookback_days: int | None = Field(default=None, ge=1, le=365)
+    refresh: bool = False
+
+
+# Tiny in-process cache - same semantics as the real main._GAP_REPORT_CACHE.
+_CACHE: dict[str, dict] = {}
+
+
+def _cache_key(req: GapReportRequest) -> str:
+    return json.dumps({
+        "t": round(req.similarity_threshold, 4),
+        "m": req.min_samples,
+        "l": req.lookback_days,
+    }, sort_keys=True)
+
+
+@app.get("/")
+def dashboard():
+    """Serve the self-contained HTML dashboard."""
+    return FileResponse(
+        Path(__file__).with_name("dashboard.html"),
+        media_type="text/html",
+    )
+
+
+@app.post("/gdb/gap-report")
+def gap_report(req: GapReportRequest):
+    """Production-shaped endpoint - calls the *real* build_gap_report."""
+    key = _cache_key(req)
+    if not req.refresh and key in _CACHE:
+        cached = dict(_CACHE[key])
+        cached["cache_hit"] = True
+        return JSONResponse(cached)
+    report = build_gap_report(
+        review_collection=REVIEW_COLLECTION,
+        review_golden_collection=GOLDEN_COLLECTION,
+        review_pop_collection=None,
+        embed_fn=_embed,
+        now=_now_fn,
+        similarity_threshold=req.similarity_threshold,
+        min_samples=req.min_samples,
+        lookback_days=req.lookback_days or LOOKBACK_DAYS,
+    )
+    report["cache_hit"] = False
+    _elevate_priorities(report)
+    _CACHE[key] = report
+    return JSONResponse(report)
+
+
+# ---- Scheduler admin endpoints (mirror the production API) ---------------
+
+_SCHEDULER_STATE: dict = {
+    "running": False,
+    "last_run": None,
+    "next_run": None,
+    "skip_reasons": [],
+    "history": [],
+}
+
+
+@app.get("/gdb/scheduler/state")
+def scheduler_state():
+    return JSONResponse(_SCHEDULER_STATE)
+
+
+@app.post("/gdb/scheduler/run-now")
+def scheduler_run_now():
+    """Bypass scheduler guards and rebuild the report immediately."""
+    report = build_gap_report(
+        review_collection=REVIEW_COLLECTION,
+        review_golden_collection=GOLDEN_COLLECTION,
+        review_pop_collection=None,
+        embed_fn=_embed,
+        now=_now_fn,
+    )
+    _elevate_priorities(report)
+    _CACHE.clear()
+    last = {
+        "success": True,
+        "duration_ms": report.get("elapsed_ms"),
+        "queries_analyzed": report.get("total_queries_analyzed"),
+        "clusters": report.get("total_clusters_found"),
+        "priority_gaps": {
+            k: len(v) if isinstance(v, list) else v
+            for k, v in (report.get("gaps_by_priority") or {}).items()
+        },
+        "report_id": report.get("report_id"),
+        "at": NOW.isoformat(),
+    }
+    _SCHEDULER_STATE["last_run"] = last
+    _SCHEDULER_STATE["history"].append(last)
+    _SCHEDULER_STATE["history"] = _SCHEDULER_STATE["history"][-20:]
+    return JSONResponse(last)
+
+
+@app.post("/gdb/scheduler/invalidate-cache")
+def scheduler_invalidate():
+    _CACHE.clear()
+    return JSONResponse({"invalidated": True, "cache_size": 0})
+
+
+# Mirror the Vite proxy path so the frontend's default base URL also works.
+@app.post("/api/acc/gdb/gap-report")
+def gap_report_acc_alias(req: GapReportRequest):
+    return gap_report(req)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=DEMO_PORT)
+    parser.add_argument("--no-browser", action="store_true")
+    args = parser.parse_args()
+
+    import uvicorn
+    import webbrowser
+
+    url = f"http://localhost:{args.port}/"
+    print("\n  GDB Gap-Detector visual demo")
+    print("  ---------------------------------------------")
+    print(f"  Dashboard:  {url}")
+    print(f"  API:        POST {url}gdb/gap-report")
+    print(f"  Admin:      GET  {url}gdb/scheduler/state")
+    print(f"              POST {url}gdb/scheduler/run-now")
+    print(f"              POST {url}gdb/scheduler/invalidate-cache")
+    print("  Press Ctrl+C to stop\n")
+
+    if not args.no_browser:
+        threading.Timer(1.5, lambda: webbrowser.open(url)).start()
+
+    uvicorn.run(app, host="127.0.0.1", port=args.port, log_level="warning")

--- a/apis/acc_api/demo/sample_data.py
+++ b/apis/acc_api/demo/sample_data.py
@@ -1,0 +1,352 @@
+# -*- coding: utf-8 -*-
+"""Sample data for the GDB Gap Detector visual demo.
+
+Each ``theme`` is a concept the detector should cluster.  Words are
+deliberately reused across paraphrases so the bigram embedder lands
+them in the same DBSCAN cluster.
+
+Each theme carries a ``week_fractions`` list of ``(age_window_days, fraction)``
+tuples that deterministically distributes documents across the last
+several ISO weeks.  Examples:
+
+* ``"hot"`` themes pile most docs into the current 7-day window with a
+  smaller tail in the prior 3 weeks -> weekly_growth_pct saturates -> high.
+* ``"warm"`` themes spread evenly across 4 weeks -> medium.
+* ``"cold"`` themes dump most docs 2-5 weeks ago -> previous > current ->
+  negative growth -> low / declining.
+
+Fractions must sum to 1.0.
+"""
+
+from __future__ import annotations
+import random
+from datetime import datetime, timedelta, timezone
+
+NOW = datetime(2026, 7, 28, 10, 0, 0, tzinfo=timezone.utc)
+
+
+CLUSTER_THEMES = [
+    {
+        "id": "wheat_rust_punjab",
+        "label": "Wheat rust control in Punjab",
+        "crop": "Wheat", "state": "Punjab", "domain": "pest",
+        "weight": 32, "trend": "hot",
+        "week_fractions": [
+            ((0, 6), 0.70), ((7, 13), 0.15), ((14, 20), 0.10), ((21, 27), 0.05),
+        ],
+        "paraphrases": [
+            "wheat rust control in punjab",
+            "wheat rust control in punjab",
+            "wheat rust punjab",
+            "wheat rust control punjab",
+            "wheat rust in punjab",
+            "wheat rust punjab control",
+            "control wheat rust punjab",
+            "punjab wheat rust",
+        ],
+    },
+    {
+        "id": "pmkisan_scheme",
+        "label": "PM-KISAN scheme eligibility",
+        "crop": "All", "state": "All", "domain": "scheme",
+        "weight": 22, "trend": "hot",
+        "week_fractions": [
+            ((0, 6), 0.65), ((7, 13), 0.20), ((14, 20), 0.10), ((21, 27), 0.05),
+        ],
+        "paraphrases": [
+            "pm kisan scheme eligibility",
+            "pm kisan scheme eligibility criteria",
+            "pm kisan scheme eligibility",
+            "how to apply pm kisan scheme",
+            "pm kisan scheme eligibility",
+            "pm kisan scheme eligibility check",
+            "pm kisan scheme eligibility",
+        ],
+    },
+    {
+        "id": "cotton_bollworm_maharashtra",
+        "label": "Pink bollworm in cotton (Maharashtra)",
+        "crop": "Cotton", "state": "Maharashtra", "domain": "pest",
+        "weight": 18, "trend": "warm",
+        "week_fractions": [
+            ((0, 6), 0.40), ((7, 13), 0.30), ((14, 20), 0.20), ((21, 27), 0.10),
+        ],
+        "paraphrases": [
+            "pink bollworm in cotton maharashtra",
+            "pink bollworm in cotton maharashtra",
+            "cotton pink bollworm control",
+            "pink bollworm in cotton maharashtra",
+            "cotton bollworm management",
+            "pink bollworm in cotton maharashtra",
+        ],
+    },
+    {
+        "id": "paddy_water_bihar",
+        "label": "Paddy water management in Bihar",
+        "crop": "Paddy", "state": "Bihar", "domain": "water",
+        "weight": 14, "trend": "warm",
+        "week_fractions": [
+            ((0, 6), 0.30), ((7, 13), 0.30), ((14, 20), 0.25), ((21, 27), 0.15),
+        ],
+        "paraphrases": [
+            "paddy water management in bihar",
+            "paddy water management in bihar",
+            "irrigation for paddy in bihar",
+            "paddy water management in bihar",
+            "water saving for paddy in bihar",
+        ],
+    },
+    {
+        "id": "tomato_leaf_curl_karnataka",
+        "label": "Tomato leaf curl virus in Karnataka",
+        "crop": "Tomato", "state": "Karnataka", "domain": "disease",
+        "weight": 12, "trend": "hot",
+        "week_fractions": [
+            ((0, 6), 0.70), ((7, 13), 0.15), ((14, 20), 0.10), ((21, 27), 0.05),
+        ],
+        "paraphrases": [
+            "tomato leaf curl virus in karnataka",
+            "tomato leaf curl virus in karnataka",
+            "leaf curl on tomato plants",
+            "tomato leaf curl virus in karnataka",
+        ],
+    },
+    {
+        "id": "drip_irrigation_subsidy",
+        "label": "Drip irrigation subsidy",
+        "crop": "All", "state": "Maharashtra", "domain": "irrigation",
+        "weight": 10, "trend": "warm",
+        "week_fractions": [
+            ((0, 6), 0.30), ((7, 13), 0.30), ((14, 20), 0.25), ((21, 27), 0.15),
+        ],
+        "paraphrases": [
+            "drip irrigation subsidy maharashtra",
+            "drip irrigation subsidy maharashtra",
+            "drip irrigation subsidy scheme",
+            "drip irrigation subsidy maharashtra",
+        ],
+    },
+    {
+        "id": "mustard_sowing",
+        "label": "Mustard sowing in Rajasthan",
+        "crop": "Mustard", "state": "Rajasthan", "domain": "sowing",
+        "weight": 8, "trend": "cold",
+        "week_fractions": [
+            ((0, 6), 0.08), ((7, 13), 0.12), ((14, 20), 0.30),
+            ((21, 27), 0.30), ((28, 41), 0.20),
+        ],
+        "paraphrases": [
+            "sowing mustard in rajasthan",
+            "mustard sowing time rajasthan",
+            "sowing mustard in rajasthan",
+            "sowing mustard in rajasthan",
+        ],
+    },
+    {
+        "id": "soil_health_card",
+        "label": "Soil health card usage",
+        "crop": "All", "state": "Uttar Pradesh", "domain": "soil",
+        "weight": 6, "trend": "cold",
+        "week_fractions": [
+            ((0, 6), 0.10), ((7, 13), 0.15), ((14, 20), 0.30),
+            ((21, 27), 0.30), ((28, 41), 0.15),
+        ],
+        "paraphrases": [
+            "soil health card uttar pradesh",
+            "soil health card uttar pradesh",
+            "soil health card usage",
+        ],
+    },
+    {
+        "id": "mango_orchard",
+        "label": "Mango orchard management",
+        "crop": "Mango", "state": "Kerala", "domain": "orchard",
+        "weight": 4, "trend": "cold",
+        "week_fractions": [
+            ((0, 6), 0.05), ((7, 13), 0.15), ((14, 20), 0.30),
+            ((21, 27), 0.30), ((28, 41), 0.20),
+        ],
+        "paraphrases": [
+            "mango orchard management in kerala",
+            "mango orchard management in kerala",
+        ],
+    },
+    {
+        "id": "noise_misc",
+        "label": "Misc one-off queries",
+        "crop": "Various", "state": "Various", "domain": "misc",
+        "weight": 4, "trend": "stable",
+        "week_fractions": [
+            ((0, 6), 0.25), ((7, 13), 0.25), ((14, 20), 0.25), ((21, 27), 0.25),
+        ],
+        "paraphrases": [
+            "organic certification process",
+            "kisan credit card interest rate",
+            "neem oil preparation",
+            "how to apply for kcc",
+        ],
+    },
+]
+
+
+def _seeded_random() -> random.Random:
+    return random.Random(20260728)
+
+
+def _pick_age(rng: random.Random, week_fractions) -> float:
+    """Pick an age in days according to a ``[(lo,hi), frac, ...]`` table."""
+    r = rng.random()
+    cum = 0.0
+    for (lo, hi), frac in week_fractions:
+        cum += frac
+        if r < cum:
+            return rng.uniform(lo, hi)
+    (lo, hi), _ = week_fractions[-1]
+    return rng.uniform(lo, hi)
+
+
+def _build_doc(theme, text, created_at, idx):
+    return {
+        "question": text,
+        "tag": "AJRASAKHA_DISCLAIMER",
+        "details": {
+            "crop": theme["crop"],
+            "state": theme["state"],
+            "domain": theme["domain"],
+            "language": "en",
+        },
+        "createdAt": created_at,
+        "source": "whatsapp",
+        "_id": f"rev_{theme['id']}_{idx}",
+    }
+
+
+def build_reviewer_corpus(now: datetime = NOW) -> list:
+    """Generate a deterministic, week-spread corpus."""
+    rng = _seeded_random()
+    docs = []
+    for theme in CLUSTER_THEMES:
+        for i in range(theme["weight"]):
+            age_days = _pick_age(rng, theme["week_fractions"])
+            created = now - timedelta(
+                days=age_days,
+                hours=rng.randint(0, 23),
+                minutes=rng.randint(0, 59),
+            )
+            text = rng.choice(theme["paraphrases"])
+            docs.append(_build_doc(theme, text, created, len(docs)))
+    return docs
+
+
+def build_golden_qa_corpus() -> list:
+    """Golden QA corpus for the coverage lookup.
+
+    Structure: ``{cluster_theme_id: [golden_qa, ...]}`` so the demo
+    can produce a realistic mix of STRONG / PARTIAL / GAP coverage
+    bands.  Any theme with **5+ entries** will be classified
+    ``STRONG`` by ``lookup_gdb_coverage``; themes with 1-4 entries
+    land in ``PARTIAL``; themes with no entries are ``GAP``.
+    """
+    by_theme: dict[str, list[dict]] = {
+        # 6 entries -> STRONG coverage for the most critical demo theme.
+        "wheat_rust_punjab": [
+            {
+                "text": "Question:\nWhat is the best control for wheat rust in Punjab?\n\nAnswer:\nPropiconazole 25 EC at 0.1% at first appearance; repeat after 15 days if humidity persists.",
+                "question": "what is the best control for wheat rust in punjab",
+                "answer": "Propiconazole 25 EC at 0.1% at first appearance; repeat after 15 days if humidity persists.",
+                "metadata": {"Crop": "Wheat", "State": "Punjab", "Category": "pest"},
+            },
+            {
+                "text": "Question:\nHow to control yellow rust on wheat in Punjab?\n\nAnswer:\nApply Tebuconazole 250 EC at 0.1% at boot stage; monitor from mid-January.",
+                "question": "how to control yellow rust on wheat in punjab",
+                "answer": "Apply Tebuconazole 250 EC at 0.1% at boot stage; monitor from mid-January.",
+                "metadata": {"Crop": "Wheat", "State": "Punjab", "Category": "pest"},
+            },
+            {
+                "text": "Question:\nWheat rust management in Punjab - cultural practices?\n\nAnswer:\nUse resistant varieties (HD 3086, PBW 343), timely sowing by Nov 10, balanced NPK.",
+                "question": "wheat rust management in punjab cultural practices",
+                "answer": "Use resistant varieties (HD 3086, PBW 343), timely sowing by Nov 10, balanced NPK.",
+                "metadata": {"Crop": "Wheat", "State": "Punjab", "Category": "pest"},
+            },
+            {
+                "text": "Question:\nBest fungicide for leaf rust on wheat in Punjab?\n\nAnswer:\nHexaconazole 5 EC at 0.2% OR Propiconazole at 0.1% - whichever is locally available.",
+                "question": "best fungicide for leaf rust on wheat in punjab",
+                "answer": "Hexaconazole 5 EC at 0.2% OR Propiconazole at 0.1%.",
+                "metadata": {"Crop": "Wheat", "State": "Punjab", "Category": "pest"},
+            },
+            {
+                "text": "Question:\nWhen to spray for wheat rust in Punjab?\n\nAnswer:\nAt first appearance of yellow pustules, usually late Dec to mid-Jan. Repeat after 15 days.",
+                "question": "when to spray for wheat rust in punjab",
+                "answer": "At first appearance of yellow pustules, usually late Dec to mid-Jan. Repeat after 15 days.",
+                "metadata": {"Crop": "Wheat", "State": "Punjab", "Category": "pest"},
+            },
+            {
+                "text": "Question:\nIntegrated management of wheat rust in Punjab?\n\nAnswer:\nCombine resistant variety + timely sowing + 1-2 sprays of Propiconazole at 0.1%.",
+                "question": "integrated management of wheat rust in punjab",
+                "answer": "Combine resistant variety + timely sowing + 1-2 sprays of Propiconazole at 0.1%.",
+                "metadata": {"Crop": "Wheat", "State": "Punjab", "Category": "pest"},
+            },
+        ],
+        # 3 entries -> PARTIAL coverage.
+        "pmkisan_scheme": [
+            {
+                "text": "Question:\nWho is eligible for PM-KISAN scheme?\n\nAnswer:\nSmall/marginal farmer families with cultivable land; excl. income-tax payers, govt employees.",
+                "question": "who is eligible for pm kisan scheme",
+                "answer": "Small/marginal farmer families with cultivable land; excl. income-tax payers, govt employees.",
+                "metadata": {"Crop": "All", "State": "All", "Category": "scheme"},
+            },
+            {
+                "text": "Question:\nHow to apply for PM-KISAN scheme?\n\nAnswer:\nSelf-register at pmkisan.gov.in OR through the local CSC / Lekhpal with Aadhaar + land record.",
+                "question": "how to apply for pm kisan scheme",
+                "answer": "Self-register at pmkisan.gov.in OR through the local CSC / Lekhpal with Aadhaar + land record.",
+                "metadata": {"Crop": "All", "State": "All", "Category": "scheme"},
+            },
+            {
+                "text": "Question:\nPM-KISAN installment amount and date?\n\nAnswer:\nRs 6,000/year in 3 instalments of Rs 2,000 each (Apr, Aug, Nov).",
+                "question": "pm kisan installment amount and date",
+                "answer": "Rs 6,000/year in 3 instalments of Rs 2,000 each (Apr, Aug, Nov).",
+                "metadata": {"Crop": "All", "State": "All", "Category": "scheme"},
+            },
+        ],
+        # 2 entries -> PARTIAL coverage.
+        "paddy_water_bihar": [
+            {
+                "text": "Question:\nHow much water does paddy need in Bihar?\n\nAnswer:\nSRI method: alternate wetting/drying, total ~120cm. Conventional: 150-200cm.",
+                "question": "how much water does paddy need in bihar",
+                "answer": "SRI method: alternate wetting/drying, total ~120cm. Conventional: 150-200cm.",
+                "metadata": {"Crop": "Paddy", "State": "Bihar", "Category": "water"},
+            },
+            {
+                "text": "Question:\nWater saving techniques for paddy in Bihar?\n\nAnswer:\nUse SRI (System of Rice Intensification): wider spacing, single seedling, intermittent irrigation.",
+                "question": "water saving techniques for paddy in bihar",
+                "answer": "Use SRI: wider spacing, single seedling, intermittent irrigation.",
+                "metadata": {"Crop": "Paddy", "State": "Bihar", "Category": "water"},
+            },
+        ],
+        # 1 entry -> PARTIAL coverage (just barely).
+        "drip_irrigation_subsidy": [
+            {
+                "text": "Question:\nDrip irrigation subsidy in Maharashtra?\n\nAnswer:\n55-70% subsidy under PMKSY for small/marginal farmers; apply at MahaDBT portal.",
+                "question": "drip irrigation subsidy in maharashtra",
+                "answer": "55-70% subsidy under PMKSY for small/marginal farmers; apply at MahaDBT portal.",
+                "metadata": {"Crop": "All", "State": "Maharashtra", "Category": "irrigation"},
+            },
+        ],
+        # 1 entry -> PARTIAL coverage.
+        "soil_health_card": [
+            {
+                "text": "Question:\nHow to use Soil Health Card in UP?\n\nAnswer:\nFollow the fertilizer dose recommended on the card; re-test every 2 years.",
+                "question": "how to use soil health card in up",
+                "answer": "Follow the fertilizer dose recommended on the card; re-test every 2 years.",
+                "metadata": {"Crop": "All", "State": "Uttar Pradesh", "Category": "soil"},
+            },
+        ],
+        # 0 entries -> GAP (demonstrates uncovered themes):
+        # cotton_bollworm_maharashtra, tomato_leaf_curl_karnataka,
+        # mustard_sowing, mango_orchard, noise_misc are intentionally
+        # left empty so the dashboard shows realistic red bars.
+    }
+    out: list[dict] = []
+    for entries in by_theme.values():
+        out.extend(entries)
+    return out

--- a/apis/acc_api/gap_metrics.py
+++ b/apis/acc_api/gap_metrics.py
@@ -1,0 +1,129 @@
+"""
+Lightweight metrics for the GDB gap detector scheduler.
+
+The repository's full monitoring stack (Prometheus + Grafana) is opt-in via
+Docker Compose (see ``monitoring/``).  We don't take a hard dependency on it
+here.  Instead this module exposes a tiny pluggable interface:
+
+    GapMetrics.record_run(...)
+    GapMetrics.record_failure(...)
+    GapMetrics.observe_duration_ms(...)
+    GapMetrics.register_backend(callable)
+
+The default backend is a no-op.  Production deployments can attach a backend
+that bridges to Prometheus / StatsD / OpenTelemetry by calling
+``register_backend(callable)`` once at import time.  Tests can attach an
+in-memory backend to assert behaviour.
+
+The module deliberately contains **no third-party imports** so that
+loading it can never break an otherwise healthy scheduler import chain.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Dict, List, Optional
+
+log = logging.getLogger("gdb_gap_metrics")
+
+
+MetricEvent = Dict[str, Any]
+Backend = Callable[[str, MetricEvent], None]
+
+
+class _MetricBus:
+    """Fan-out bus for metric events.
+
+    Thread-safe.  Multiple backends can register simultaneously.
+    """
+
+    def __init__(self) -> None:
+        self._backends: List[Backend] = []
+        self._lock = threading.Lock()
+
+    def register(self, backend: Backend) -> None:
+        with self._lock:
+            if backend not in self._backends:
+                self._backends.append(backend)
+
+    def emit(self, name: str, payload: Optional[MetricEvent] = None) -> None:
+        payload = dict(payload or {})
+        payload.setdefault("event", name)
+        with self._lock:
+            backends = list(self._backends)
+        for be in backends:
+            try:
+                be(name, payload)
+            except Exception as e:  # pragma: no cover - defensive
+                log.debug("[gdb-gap-metrics] backend %r raised %r", be, e)
+
+
+_bus = _MetricBus()
+
+
+def register_backend(backend: Backend) -> None:
+    """Register a metric backend.  Called by the monitoring integrations."""
+    _bus.register(backend)
+
+
+def clear_backends() -> None:
+    """Drop every backend.  Used by tests to reset state."""
+    with _bus._lock:  # type: ignore[attr-defined]
+        _bus._backends.clear()  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Convenience emitters (so callers don't have to repeat the dict literal)
+# ---------------------------------------------------------------------------
+
+def record_run(
+    *,
+    duration_ms: float,
+    queries_analyzed: int,
+    clusters: int,
+    priority_gaps: Dict[str, int],
+    trigger: str,
+    success: bool = True,
+) -> None:
+    _bus.emit(
+        "gap_report_run",
+        {
+            "duration_ms": round(float(duration_ms), 2),
+            "queries_analyzed": int(queries_analyzed),
+            "clusters": int(clusters),
+            "priority_gaps": dict(priority_gaps or {}),
+            "trigger": trigger,
+            "success": bool(success),
+        },
+    )
+
+
+def record_failure(*, duration_ms: float, trigger: str, error: str) -> None:
+    _bus.emit(
+        "gap_report_failure",
+        {
+            "duration_ms": round(float(duration_ms), 2),
+            "trigger": trigger,
+            "error": str(error)[:1000],
+        },
+    )
+
+
+def record_skip(*, reason: str) -> None:
+    """A scheduled tick that intentionally did not run (disabled, test env, ..)."""
+    _bus.emit("gap_report_skip", {"reason": reason})
+
+
+def record_start(*, trigger: str) -> None:
+    _bus.emit("gap_report_start", {"trigger": trigger})
+
+
+__all__ = [
+    "register_backend",
+    "clear_backends",
+    "record_run",
+    "record_failure",
+    "record_skip",
+    "record_start",
+]

--- a/apis/acc_api/gap_scheduler.py
+++ b/apis/acc_api/gap_scheduler.py
@@ -1,0 +1,751 @@
+"""Operational scheduler for the GDB gap detector.
+
+This module supersedes the deprecated ``project_06_gdb_gap_detector/scheduler.py``
+(APScheduler in-process worker).  It wraps ``gdb_gap_detector.build_gap_report``
+behind a deterministic, *opt-in* scheduler that:
+
+* is configured entirely through environment variables
+  (enabled flag, weekly cron, lookback, similarity threshold,
+  min_samples, cache TTL, multi-worker gating);
+* refuses to start in test environments;
+* refuses to start on more than one worker unless explicitly told;
+* emits structured logging at every important state transition;
+* records lightweight metrics via ``gap_metrics`` (prometheus-ready);
+* never crashes the FastAPI app it is attached to.
+
+The scheduler is intentionally **in-process** but uses a Mongo-backed
+leader lock so that, when you scale the API to N workers, exactly one
+worker runs the report per tick.  See :func:`_acquire_leader_lock`.
+
+Typical production wiring
+-------------------------
+* Cron-like cadence driven by the embedded ``schedule`` library.
+* Triggered manually with :func:`run_now` (operator runbook / CLI).
+* Operationally cached for ``GDB_REPORT_CACHE_TTL`` seconds.
+
+Safety guards
+-------------
+The scheduler will *not* run unless **all** of these hold:
+
+1. ``GDB_SCHEDULER_ENABLED=true`` in the environment.
+2. ``GDB_SCHEDULER_FORCE_DISABLE`` is unset or ``false``.
+3. ``PYTEST_CURRENT_TEST`` and ``pytest`` are not detected.
+4. This worker passed the multi-worker gate
+   (see ``GDB_SCHEDULER_WORKER_ID`` / ``GDB_SCHEDULER_LEADER_WORKERS``).
+5. Mongo leader-lock acquisition succeeded (when ``MONGO_URI`` is set).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from gdb_gap_detector import (  # noqa: E402  (after load_dotenv)
+    build_gap_report,
+    invalidate_cache as gdb_invalidate_cache,
+)
+
+import gap_metrics  # noqa: E402
+
+
+log = logging.getLogger("gdb_gap_scheduler")
+
+
+# ---------------------------------------------------------------------------
+# Env-var helpers
+# ---------------------------------------------------------------------------
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on", "y", "t")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        log.warning("[gdb-scheduler] %s=%r is not an int - using default %d",
+                    name, raw, default)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning("[gdb-scheduler] %s=%r is not a float - using default %r",
+                    name, raw, default)
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SchedulerConfig:
+    """Immutable configuration loaded from env vars.
+
+    Every field has a documented default so the scheduler is *predictable*
+    even when nothing is set - the only field that flips it on is
+    ``enabled``.
+    """
+
+    enabled: bool = False
+    force_disable: bool = False
+    # Weekly cron in the form "minute hour day-of-month month day-of-week".
+    # Default: every Monday at 02:00 (server local time).
+    cron: str = "0 2 * * 1"
+    lookback_days: int = 90
+    similarity_threshold: float = 0.85
+    min_samples: int = 2
+    cache_ttl_seconds: int = 900
+    # Multi-worker gating
+    worker_id: int = 0
+    leader_workers: tuple[int, ...] = field(default_factory=lambda: (0,))
+
+    @classmethod
+    def from_env(cls) -> "SchedulerConfig":
+        leader_raw = os.getenv("GDB_SCHEDULER_LEADER_WORKERS", "0").strip()
+        try:
+            leaders = tuple(
+                int(x) for x in
+                (p.strip() for p in leader_raw.split(",")) if x
+            )
+        except ValueError:
+            log.warning(
+                "[gdb-scheduler] GDB_SCHEDULER_LEADER_WORKERS=%r invalid - using (0,)",
+                leader_raw,
+            )
+            leaders = (0,)
+        return cls(
+            enabled=_env_bool("GDB_SCHEDULER_ENABLED", False),
+            force_disable=_env_bool("GDB_SCHEDULER_FORCE_DISABLE", False),
+            cron=os.getenv("GDB_SCHEDULER_CRON", "0 2 * * 1"),
+            lookback_days=_env_int("GDB_SCHEDULER_LOOKBACK_DAYS", 90),
+            similarity_threshold=_env_float(
+                "GDB_SCHEDULER_SIMILARITY_THRESHOLD", 0.85),
+            min_samples=_env_int("GDB_SCHEDULER_MIN_SAMPLES", 2),
+            cache_ttl_seconds=_env_int("GDB_REPORT_CACHE_TTL", 900),
+            worker_id=_env_int("GDB_SCHEDULER_WORKER_ID", 0),
+            leader_workers=leaders or (0,),
+        )
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "force_disable": self.force_disable,
+            "cron": self.cron,
+            "lookback_days": self.lookback_days,
+            "similarity_threshold": self.similarity_threshold,
+            "min_samples": self.min_samples,
+            "cache_ttl_seconds": self.cache_ttl_seconds,
+            "worker_id": self.worker_id,
+            "leader_workers": list(self.leader_workers),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Guard predicates
+# ---------------------------------------------------------------------------
+
+def _running_under_pytest() -> bool:
+    """Heuristic: detect whether the current process is running under pytest.
+
+    We refuse to start the scheduler in that case so unit-test runs don't
+    silently spawn background threads that outlive the test process.
+    """
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return True
+    if "pytest" in sys.modules:
+        return True
+    argv = " ".join(sys.argv).lower()
+    if "pytest" in argv or "py.test" in argv:
+        return True
+    return False
+
+
+def is_worker_leader(cfg: SchedulerConfig) -> bool:
+    """Is this worker in the leader set?"""
+    return cfg.worker_id in cfg.leader_workers
+
+
+def config_passes_basic_guards(cfg: SchedulerConfig) -> tuple[bool, str]:
+    """Pure-function guard.  Returns (ok, reason).
+
+    Used by tests and by :meth:`GapScheduler.start`.
+    """
+    if cfg.force_disable:
+        return False, "force_disable=true"
+    if not cfg.enabled:
+        return False, "enabled=false"
+    if cfg.lookback_days < 1:
+        return False, f"lookback_days={cfg.lookback_days} invalid"
+    if not (0.0 <= cfg.similarity_threshold <= 1.0):
+        return False, (
+            f"similarity_threshold={cfg.similarity_threshold} out of range")
+    if cfg.min_samples < 1 or cfg.min_samples > 50:
+        return False, f"min_samples={cfg.min_samples} out of range"
+    if cfg.cache_ttl_seconds < 0:
+        return False, f"cache_ttl_seconds={cfg.cache_ttl_seconds} invalid"
+    if not is_worker_leader(cfg):
+        return False, (
+            f"worker_id={cfg.worker_id} not in "
+            f"leaders={list(cfg.leader_workers)}")
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Optional schedule dependency
+# ---------------------------------------------------------------------------
+
+try:
+    import schedule as _schedule  # type: ignore
+    _schedule_ok = True
+except ImportError:  # pragma: no cover
+    _schedule = None  # type: ignore
+    _schedule_ok = False
+
+
+def _parse_cron(cron: str) -> tuple[int, int, str, str, str]:
+    """Split a 5-field cron expression into (minute, hour, dom, month, dow)."""
+    parts = cron.split()
+    if len(parts) != 5:
+        raise ValueError(
+            f"Cron expression must have 5 fields, got {len(parts)}: {cron!r}")
+    minute, hour, _dom, _month, dow = parts
+    return int(minute), int(hour), _dom, _month, dow
+
+
+def _schedule_weekly_job(cron: str, fn: Callable[[], None]) -> None:
+    """Register ``fn`` with the embedded ``schedule`` library.
+
+    Supported cron subsets:
+
+    * ``<m> <h> * * <dow>`` - every ``dow`` at ``h:m`` local time.
+    * ``<m> <h> * * *``    - every day at ``h:m``.
+    * ``<m> <h> * * */*``  - logged as warning, defaults to Monday.
+
+    Anything unsupported falls back to Monday with a warning.
+    """
+    if not _schedule_ok:  # pragma: no cover
+        raise RuntimeError(
+            "The 'schedule' package is not installed; install it to enable "
+            "the in-process scheduler.")
+
+    minute, hour, _dom, _month, dow = _parse_cron(cron)
+
+    dow_map = {
+        "0": "sunday", "7": "sunday",
+        "1": "monday", "2": "tuesday",
+        "3": "wednesday", "4": "thursday",
+        "5": "friday", "6": "saturday",
+    }
+
+    time_str = f"{hour:02d}:{minute:02d}"
+    dow_norm = dow.lower()
+
+    if dow_norm in dow_map:
+        getattr(_schedule.every(), dow_map[dow_norm]).at(time_str).do(fn)
+        log.info("[gdb-scheduler] weekly job scheduled for %s at %s",
+                 dow_norm, time_str)
+    elif dow_norm == "*":
+        _schedule.every().day.at(time_str).do(fn)
+        log.info("[gdb-scheduler] daily job scheduled at %s", time_str)
+    else:
+        log.warning(
+            "[gdb-scheduler] unsupported cron DOW=%r; defaulting to Monday %s",
+            dow, time_str)
+        _schedule.every().monday.at(time_str).do(fn)
+
+
+# ---------------------------------------------------------------------------
+# Multi-worker leader election via Mongo (optional)
+# ---------------------------------------------------------------------------
+
+_LEADER_LOCK_NAME = "gdb_gap_scheduler_lock"
+_LEADER_LOCK_LEASE_SECONDS = 600  # 10 minutes
+
+
+def _acquire_leader_lock(cfg: SchedulerConfig) -> bool:
+    """Try to claim the leader lock in Mongo.  Returns True if claimed.
+
+    No-op (returns True) when ``MONGO_URI`` is unset, since multi-worker
+    safety is then handled by ``GDB_SCHEDULER_LEADER_WORKERS`` instead.
+    """
+    uri = os.getenv("MONGO_URI")
+    if not uri:
+        return True
+
+    try:
+        from pymongo import MongoClient  # type: ignore
+        from pymongo.errors import PyMongoError  # type: ignore
+    except ImportError:
+        log.warning("[gdb-scheduler] pymongo unavailable - skipping leader lock")
+        return False
+
+    try:
+        client = MongoClient(uri, serverSelectionTimeoutMS=2000)
+        db_name = os.getenv("DB_NAME", "agriai")
+        coll = client[db_name]["gdb_scheduler_state"]
+
+        now = time.time()
+        expires = now + _LEADER_LOCK_LEASE_SECONDS
+        worker_token = f"pid{os.getpid()}-{cfg.worker_id}-{int(now)}"
+
+        result = coll.find_one_and_update(
+            {
+                "_id": _LEADER_LOCK_NAME,
+                "$or": [
+                    {"expires_at": {"$lte": now}},
+                    {"owner": worker_token},
+                ],
+            },
+            {"$set": {"expires_at": expires,
+                      "owner": worker_token,
+                      "claimed_at": now}},
+            upsert=True,
+            return_document=True,
+        )
+        if result is None:
+            return False
+        return result.get("owner") == worker_token
+    except Exception as e:  # PyMongoError or anything else
+        log.warning("[gdb-scheduler] could not reach Mongo for leader lock: %s", e)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Run-once entry point
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RunResult:
+    """Public result of a single ``run_once`` invocation."""
+
+    success: bool
+    duration_ms: float
+    queries_analyzed: int = 0
+    clusters: int = 0
+    priority_gaps: dict[str, int] = field(default_factory=dict)
+    report_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+def _priority_gaps_from_report(report: dict) -> dict[str, int]:
+    by_pri = report.get("gaps_by_priority") or {}
+    return {
+        "critical": int(by_pri.get("critical", 0)),
+        "high":     int(by_pri.get("high", 0)),
+        "medium":   int(by_pri.get("medium", 0)),
+        "low":      int(by_pri.get("low", 0)),
+    }
+
+
+def run_once(
+    *,
+    trigger: str = "manual",
+    collection_provider: Optional[Callable[[], Iterable[Any]]] = None,
+    similarity_threshold: Optional[float] = None,
+    min_samples: Optional[int] = None,
+    lookback_days: Optional[int] = None,
+    invalidate_first: bool = False,
+    embed_fn: Optional[Callable[[list[str]], Any]] = None,
+) -> RunResult:
+    """Run a single gap-report pass synchronously and return a RunResult.
+
+    ``collection_provider`` is a no-arg callable that returns a 3-tuple
+    ``(review_collection, golden_collection, pop_collection)``.  When
+    ``None`` the function falls back to the module-level collections
+    imported from ``main`` (lazily, so importing this module never
+    imports ``main``).
+
+    ``embed_fn`` overrides the lazy ``main._get_model().encode`` so
+    tests can inject a deterministic embed function without booting
+    SentenceTransformer.
+
+    The ``trigger`` string is propagated into logs and metrics so ops
+    can distinguish manual runs from weekly cron runs.
+    """
+    cfg = SchedulerConfig.from_env()
+
+    # Apply explicit overrides on top of the env defaults.
+    eff_threshold = (
+        cfg.similarity_threshold if similarity_threshold is None
+        else similarity_threshold
+    )
+    eff_min_samples = cfg.min_samples if min_samples is None else min_samples
+    eff_lookback = cfg.lookback_days if lookback_days is None else lookback_days
+    eff_embed = embed_fn if embed_fn is not None else _embed_fn()
+
+    started = time.perf_counter()
+    gap_metrics.record_start(trigger=trigger)
+    log.info(
+        "gap_report.start trigger=%s threshold=%.3f min_samples=%d "
+        "lookback_days=%s invalidate_first=%s",
+        trigger, eff_threshold, eff_min_samples, eff_lookback, invalidate_first,
+    )
+
+    if invalidate_first:
+        try:
+            gdb_invalidate_cache()
+            log.info("gap_report.cache_invalidated trigger=%s", trigger)
+        except Exception as e:  # pragma: no cover
+            log.warning("gap_report.cache_invalidate_failed err=%s", e)
+
+    try:
+        review_coll, golden_coll, pop_coll = _resolve_collections(
+            collection_provider
+        )
+
+        # Push the cache TTL so the freshly built report stays warm
+        # until the next tick.  Must happen *before* the build so any
+        # concurrent HTTP read picks up the new value.
+        try:
+            import gdb_gap_detector as _g  # local alias
+            _g.CACHE_TTL_SECONDS = int(cfg.cache_ttl_seconds)
+        except Exception:  # pragma: no cover
+            pass
+
+        report = build_gap_report(
+            review_collection=review_coll,
+            review_golden_collection=golden_coll,
+            review_pop_collection=pop_coll,
+            embed_fn=eff_embed,
+            similarity_threshold=eff_threshold,
+            min_samples=eff_min_samples,
+            lookback_days=eff_lookback,
+        )
+
+        # Warm the detector's own cache so subsequent HTTP calls hit it.
+        try:
+            import gdb_gap_detector as _g  # local alias
+            _g.set_cached_report(report)
+        except Exception:  # pragma: no cover
+            pass
+
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        priority = _priority_gaps_from_report(report)
+        result = RunResult(
+            success=True,
+            duration_ms=elapsed_ms,
+            queries_analyzed=int(report.get("total_queries_analyzed", 0)),
+            clusters=int(report.get("total_clusters_found", 0)),
+            priority_gaps=priority,
+            report_id=report.get("report_id"),
+        )
+
+        log.info(
+            "gap_report.success trigger=%s report_id=%s queries=%d clusters=%d "
+            "priority=%s elapsed_ms=%.1f",
+            trigger, result.report_id, result.queries_analyzed,
+            result.clusters, result.priority_gaps, elapsed_ms,
+        )
+        gap_metrics.record_run(
+            duration_ms=elapsed_ms,
+            queries_analyzed=result.queries_analyzed,
+            clusters=result.clusters,
+            priority_gaps=result.priority_gaps,
+            trigger=trigger,
+            success=True,
+        )
+        return result
+
+    except Exception as e:
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        log.error(
+            "gap_report.failure trigger=%s elapsed_ms=%.1f err=%s\n%s",
+            trigger, elapsed_ms, e, traceback.format_exc(),
+        )
+        gap_metrics.record_failure(
+            duration_ms=elapsed_ms, trigger=trigger, error=str(e),
+        )
+        return RunResult(
+            success=False, duration_ms=elapsed_ms, error=str(e),
+        )
+
+
+def _resolve_collections(
+    provider: Optional[Callable[[], Iterable[Any]]],
+) -> tuple[Any, Any, Any]:
+    """Resolve (review, golden, pop) collections from provider or main."""
+    if provider is not None:
+        triple = provider()
+        r, g, p = triple
+        return r, g, p
+
+    # Late import to avoid forcing ``main`` to load before tests have
+    # patched its globals.
+    import main as _main  # type: ignore
+    return (
+        _main.reviewer_collection,
+        _main.golden_qa_collection,
+        _main.golden_pop_collection,
+    )
+
+
+def _embed_fn() -> Callable[[list[str]], Any]:
+    """Return the embedding function used by the gap detector.
+
+    Falls back to ``main._get_model().encode`` so we use the same
+    lazy-loaded model as the HTTP endpoint.  Tests that wish to stub
+    the embed function should pass an ``embed_fn`` to ``run_once``.
+    """
+    import main as _main  # type: ignore
+    return _main._get_model().encode
+
+
+# ---------------------------------------------------------------------------
+# Scheduler lifecycle
+# ---------------------------------------------------------------------------
+
+class GapScheduler:
+    """The in-process weekly scheduler.
+
+    Public surface
+    --------------
+    * :meth:`start`     - spin up the background loop.
+    * :meth:`stop`      - graceful shutdown.
+    * :meth:`run_now`   - operator-triggered one-shot.
+    * :meth:`state`     - snapshot for ``/gdb/health`` style probes.
+    """
+
+    def __init__(
+        self,
+        config: Optional[SchedulerConfig] = None,
+        collection_provider: Optional[Callable[[], Iterable[Any]]] = None,
+    ) -> None:
+        self.config: SchedulerConfig = config or SchedulerConfig.from_env()
+        self._collection_provider = collection_provider
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._last_run: Optional[RunResult] = None
+        self._last_attempt_ts: float = 0.0
+        self._leader_token: Optional[str] = None
+
+    def start(self) -> bool:
+        """Try to start the background loop.  Returns True on success."""
+        # --- guard 1: test environment ----------------------------------
+        if _running_under_pytest():
+            log.info("gap_scheduler.skip reason=test_environment")
+            gap_metrics.record_skip(reason="test_environment")
+            return False
+
+        # --- guard 2: explicit config -----------------------------------
+        ok, reason = config_passes_basic_guards(self.config)
+        if not ok:
+            log.info("gap_scheduler.skip reason=%s", reason)
+            gap_metrics.record_skip(reason=reason)
+            return False
+
+        # --- guard 3: Mongo leader lock ---------------------------------
+        if not _acquire_leader_lock(self.config):
+            log.warning(
+                "gap_scheduler.skip reason=leader_lock_failed worker_id=%d",
+                self.config.worker_id)
+            gap_metrics.record_skip(reason="leader_lock_failed")
+            return False
+
+        # --- actually start --------------------------------------------
+        if not _schedule_ok:
+            log.warning(
+                "gap_scheduler.skip reason=schedule_library_missing - "
+                "install the 'schedule' package to enable the in-process "
+                "scheduler.  Operators can still invoke run_now() manually.")
+            gap_metrics.record_skip(reason="schedule_library_missing")
+            return False
+
+        if self._thread is not None and self._thread.is_alive():
+            log.info("gap_scheduler.already_running")
+            return True
+
+        log.info(
+            "gap_scheduler.start cron=%r worker_id=%d lookback=%d "
+            "threshold=%.3f min_samples=%d cache_ttl=%ds",
+            self.config.cron, self.config.worker_id,
+            self.config.lookback_days, self.config.similarity_threshold,
+            self.config.min_samples, self.config.cache_ttl_seconds,
+        )
+        try:
+            _schedule_weekly_job(self.config.cron, self._tick)
+        except Exception as e:
+            log.warning("gap_scheduler.start invalid cron=%r err=%s",
+                        self.config.cron, e)
+            gap_metrics.record_skip(reason="invalid_cron")
+            return False
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._loop,
+            name=f"gdb-gap-scheduler-{os.getpid()}",
+            daemon=True,
+        )
+        self._thread.start()
+        return True
+
+    def stop(self, *, timeout: float = 5.0) -> None:
+        if not self._thread:
+            return
+        log.info("gap_scheduler.stop")
+        self._stop_event.set()
+        try:
+            self._thread.join(timeout=timeout)
+        except Exception:  # pragma: no cover
+            pass
+        self._thread = None
+        if self._leader_token:
+            try:
+                uri = os.getenv("MONGO_URI")
+                if uri:
+                    from pymongo import MongoClient  # type: ignore
+                    client = MongoClient(uri, serverSelectionTimeoutMS=1000)
+                    client[os.getenv("DB_NAME", "agriai")]["gdb_scheduler_state"] \
+                        .update_one(
+                            {"_id": _LEADER_LOCK_NAME,
+                             "owner": self._leader_token},
+                            {"$set": {"expires_at": 0}})
+            except Exception:  # pragma: no cover
+                pass
+            self._leader_token = None
+
+    def _loop(self) -> None:
+        log.debug("gap_scheduler.loop entered")
+        while not self._stop_event.is_set():
+            try:
+                _schedule.run_pending()
+            except Exception as e:  # pragma: no cover
+                log.warning("gap_scheduler.loop error: %s", e)
+            if self._stop_event.wait(timeout=30):
+                break
+        log.debug("gap_scheduler.loop exited")
+
+    def _tick(self) -> None:
+        """Hook invoked by ``schedule`` at each cron firing."""
+        self._last_attempt_ts = time.time()
+        result = run_once(
+            trigger="scheduled",
+            collection_provider=self._collection_provider,
+        )
+        self._last_run = result
+
+    def run_now(self) -> RunResult:
+        """Run a single report pass *now*, ignoring scheduler guards.
+
+        Always runs (no env-var check, no leader election) - that's the
+        whole point: it's the operational escape hatch.  Manual runs are
+        safe to invoke from any worker.
+        """
+        log.info("gap_scheduler.run_now invoked")
+        self._last_attempt_ts = time.time()
+        result = run_once(
+            trigger="manual",
+            collection_provider=self._collection_provider,
+        )
+        self._last_run = result
+        return result
+
+    def invalidate_cache(self) -> None:
+        """Drop both the in-process detector cache and the HTTP cache."""
+        try:
+            gdb_invalidate_cache()
+            import main as _main  # type: ignore
+            _main._GAP_REPORT_CACHE.clear()
+        except Exception as e:  # pragma: no cover
+            log.warning("gap_scheduler.cache_invalidate failed: %s", e)
+            raise
+        log.info("gap_scheduler.cache_invalidated")
+
+    def state(self) -> dict:
+        """Snapshot for ``/gdb/health`` style probes."""
+        last = self._last_run
+        return {
+            "running": bool(self._thread and self._thread.is_alive()),
+            "config": self.config.describe(),
+            "last_attempt_ts": self._last_attempt_ts,
+            "last_run": (
+                {
+                    "success": last.success,
+                    "duration_ms": last.duration_ms,
+                    "queries_analyzed": last.queries_analyzed,
+                    "clusters": last.clusters,
+                    "priority_gaps": last.priority_gaps,
+                    "report_id": last.report_id,
+                    "error": last.error,
+                }
+                if last else None
+            ),
+            "pytest_detected": _running_under_pytest(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (used by ``main.py`` startup event)
+# ---------------------------------------------------------------------------
+
+_default_scheduler: Optional[GapScheduler] = None
+_default_lock = threading.Lock()
+
+
+def get_default_scheduler() -> GapScheduler:
+    global _default_scheduler
+    with _default_lock:
+        if _default_scheduler is None:
+            _default_scheduler = GapScheduler()
+        return _default_scheduler
+
+
+def reset_default_scheduler() -> None:
+    """Drop the singleton.  Tests use this between cases."""
+    global _default_scheduler
+    with _default_lock:
+        if _default_scheduler is not None:
+            try:
+                _default_scheduler.stop()
+            except Exception:
+                pass
+        _default_scheduler = None
+
+
+# Convenience aliases that bind to the singleton AT IMPORT TIME.
+# They are re-bound whenever reset_default_scheduler() is called by
+# tests via the property functions below.
+def _bind_singleton_aliases() -> None:
+    """Refresh module-level shortcuts against the current singleton."""
+    global run_now, invalidate_cache, state
+    s = get_default_scheduler()
+    run_now = s.run_now           # type: ignore[assignment]
+    invalidate_cache = s.invalidate_cache       # type: ignore[assignment]
+    state = s.state               # type: ignore[assignment]
+
+
+_bind_singleton_aliases()
+
+
+__all__ = [
+    "SchedulerConfig",
+    "GapScheduler",
+    "RunResult",
+    "run_once",
+    "get_default_scheduler",
+    "reset_default_scheduler",
+    "config_passes_basic_guards",
+    "is_worker_leader",
+]

--- a/apis/acc_api/gap_scheduler_auth.py
+++ b/apis/acc_api/gap_scheduler_auth.py
@@ -1,0 +1,119 @@
+"""Bearer-token admin authentication for GDB scheduler endpoints.
+
+This module is intentionally tiny and standalone: the existing
+``acc_api`` codebase doesn't have an auth dependency yet, so we ship
+our own to avoid pulling in the wider project's identity layer for
+this single concern.
+
+Wire it into a FastAPI endpoint with ``Depends(verify_admin_token)``
+(or the lower-level ``require_bearer_token`` helper if you need more
+control over the error shape).
+
+Token source
+------------
+The accepted token is read from ``GDB_SCHEDULER_ADMIN_TOKEN``.  It is
+compared in constant time against the ``Authorization: Bearer <tok>``
+header (or, as a fallback, ``X-Admin-Token``).  When the env var is
+unset the dependency **fails closed** — every request is rejected
+with HTTP 503.  This is safer than a permissive default.
+
+The same token can also be passed via the ``?token=`` query parameter
+for operators running one-shot curl commands; the production
+deployment should be reverse-proxied to block that, but for now it's
+useful.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+from typing import Optional
+
+from fastapi import Header, HTTPException, Query, status
+
+
+HEADER_NAME = "Authorization"
+ALT_HEADER_NAME = "X-Admin-Token"
+TOKEN_ENV = "GDB_SCHEDULER_ADMIN_TOKEN"
+
+
+def get_expected_token() -> Optional[str]:
+    """Return the configured admin token or ``None`` if unset.
+
+    ``None`` is the closed/insecure state — callers should treat it
+    as "deny all".
+    """
+    raw = os.getenv(TOKEN_ENV)
+    if raw is None:
+        return None
+    raw = raw.strip()
+    return raw or None
+
+
+def _extract_bearer(
+    authorization: Optional[str],
+    x_admin_token: Optional[str],
+    query_token: Optional[str],
+) -> Optional[str]:
+    """Pick the first usable token out of the request headers."""
+    if authorization:
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and token:
+            return token.strip()
+    if x_admin_token:
+        return x_admin_token.strip()
+    if query_token:
+        return query_token.strip()
+    return None
+
+
+def check_admin_token(token: Optional[str]) -> bool:
+    """Constant-time check: does ``token`` match the configured admin token?"""
+    expected = get_expected_token()
+    if expected is None or token is None:
+        return False
+    return hmac.compare_digest(expected, token)
+
+
+def require_bearer_token(
+    authorization: Optional[str] = Header(default=None, alias=HEADER_NAME),
+    x_admin_token: Optional[str] = Header(default=None, alias=ALT_HEADER_NAME),
+    token: Optional[str] = Query(default=None),
+) -> str:
+    """FastAPI dependency that returns the token on success.
+
+    Raises:
+        401: when a token is supplied but wrong / malformed.
+        503: when the server has no token configured (fail-closed).
+    """
+    expected = get_expected_token()
+    if expected is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "admin endpoints disabled: "
+                f"{TOKEN_ENV} is not configured on the server"),
+        )
+
+    supplied = _extract_bearer(authorization, x_admin_token, token)
+    if not supplied:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing admin token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    if not hmac.compare_digest(expected, supplied):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid admin token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return supplied
+
+
+__all__ = [
+    "check_admin_token",
+    "get_expected_token",
+    "require_bearer_token",
+    "TOKEN_ENV",
+]

--- a/apis/acc_api/gdb_gap_detector.py
+++ b/apis/acc_api/gdb_gap_detector.py
@@ -1,0 +1,1494 @@
+"""
+Project 06 — GDB Coverage Gap Detector (integrated module).
+
+Identifies content gaps in the **Golden Database (GDB)** by clustering
+disclaimer‑triggered reviewer questions and ranking the resulting clusters
+by farmer demand.
+
+Why this module exists
+----------------------
+* ``project_06_gdb_gap_detector/gap_pipeline.py`` was the original
+  prototype.  It has been ported and rewritten here so that the same
+  pipeline ships with the rest of the AgriAI semantic‑search backend
+  (``apis/acc_api``), sharing its environment, MongoDB connection and
+  embedding model.
+* The pipeline is intentionally pure‑Python: every function takes a
+  ``now`` callable, a deterministic ``embed_fn`` and Mongo‑like cursor
+  objects.  This makes the unit tests fully deterministic without
+  requiring a live database or large embedding model download.
+* The endpoint is exposed as ``POST /gdb/gap-report`` (see ``main.py``).
+  The response contract is unchanged from the previous version – this
+  rewrite only makes the *behaviour* match the documented expectations.
+
+Public entry points
+-------------------
+* :func:`build_gap_report`  – full pipeline → JSON‑ready dict
+* :func:`invalidate_cache`  – clear cached report from the API module
+
+The module depends only on:
+* ``numpy``                 – vector arithmetic
+* ``sklearn.cluster.DBSCAN`` – density‑based clustering
+* ``pymongo`` (re‑used at run‑time by the endpoint)
+
+It does **not** import the embedding model globally.  All embed calls go
+through ``embed_fn`` which is supplied by the FastAPI layer (loaded lazily
+on first use).
+
+Schema assumptions (documented inline in code)
+----------------------------------------------
+Reviewer questions collection (``COLLECTION_NAME``, default ``questions``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* ``question`` (str)         – raw question text.  Required for clustering.
+* ``tag`` (str | list[str])  – tag(s) attached to the question.  Disclaimer
+                                queries have ``DISCLAIMER_TAG`` present.
+* ``details`` (dict)         – free‑form bag of:
+    * ``state``   – Indian state (e.g. ``"Punjab"``)
+    * ``crop``    – crop name (e.g. ``"Wheat"``)
+    * ``district``– district name (optional)
+    * ``domain``  – pre‑classified domain (optional, else inferred)
+* ``createdAt`` (datetime)   – when the question was created.  Required for
+                                demand windows.
+
+Golden QA collection (``GOLDEN_QA_COLLECTION``, default ``agri_qa_latest``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* ``text``        – concatenated ``"Question:\\n…\\n\\nAnswer:\\n…"``.
+* ``question``    – parsed question (optional).
+* ``answer``      – parsed answer (optional).
+* ``metadata``    – dict containing:
+    * ``Crop``    – crop name
+    * ``State``   – state name
+    * ``Category``– maps to "domain"
+    * ``Season``  – optional
+    * ``District``– optional
+* ``embedding``   – dense vector of dimension ``EMBEDDING_DIM_HINT``
+                    (Atlas Vector Search field, default name ``embedding``).
+
+If any of these fields is missing for a given document the document is
+skipped (never crashed on) so the pipeline is resilient to partial data.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import re
+import time
+import unicodedata
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Iterable, Sequence
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+log = logging.getLogger("agri_search.gdb_gap_detector")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Tag that flags reviewer questions whose answer hit our disclaimer / fallback.
+# Configurable so the pipeline can adapt without a code deploy.
+DISCLAIMER_TAG = os.getenv("GDB_DISCLAIMER_TAG", "AJRASAKHA_DISCLAIMER")
+
+# Field names inside a reviewer-question document.  All are configurable so we
+# can adapt to schema changes without touching the pipeline.
+QUESTION_FIELD       = os.getenv("GDB_FIELD_QUESTION",    "question")
+TAG_FIELD            = os.getenv("GDB_FIELD_TAG",         "tag")
+DETAILS_FIELD        = os.getenv("GDB_FIELD_DETAILS",     "details")
+CREATED_AT_FIELD     = os.getenv("GDB_FIELD_CREATED_AT", "createdAt")
+DOMAIN_FIELD         = "domain"
+STATE_FIELD          = "state"
+CROP_FIELD           = "crop"
+DISTRICT_FIELD       = "district"
+
+# Field names inside the Golden QA document.
+GOLDEN_QUESTION_FIELD    = os.getenv("GDB_GOLD_FIELD_QUESTION", "question")
+GOLDEN_ANSWER_FIELD      = os.getenv("GDB_GOLD_FIELD_ANSWER",   "answer")
+GOLDEN_TEXT_FIELD        = os.getenv("GDB_GOLD_FIELD_TEXT",     "text")
+GOLDEN_METADATA_FIELD    = os.getenv("GDB_GOLD_FIELD_METADATA", "metadata")
+GOLDEN_EMBEDDING_FIELD   = os.getenv("GDB_GOLD_FIELD_EMBEDDING","embedding")
+GOLDEN_VECTOR_INDEX      = os.getenv("GOLDEN_VECTOR_INDEX_NAME", "vector_index")
+
+# Reasonable defaults; all overridable via env to make the module tunable in
+# production without redeploying.
+SIMILARITY_THRESHOLD  = float(os.getenv("GDB_SIM_THRESHOLD",      "0.85"))  # cosine
+LARGE_CLUSTER_SIZE    = int(os.getenv("GDB_LARGE_CLUSTER_SIZE",   "50"))
+MEDIUM_CLUSTER_SIZE   = int(os.getenv("GDB_MEDIUM_CLUSTER_SIZE",  "10"))
+GROWTH_WINDOW_DAYS    = int(os.getenv("GDB_GROWTH_WINDOW_DAYS",   "14"))
+LOOKBACK_DAYS         = int(os.getenv("GDB_LOOKBACK_DAYS",        "90"))
+DEMAND_WINDOW_DAYS    = int(os.getenv("GDB_DEMAND_WINDOW_DAYS",   "7"))
+MIN_QUERIES_PER_CLUSTER = int(os.getenv("GDB_MIN_QUERIES",        "1"))
+PRIORITY_MAX_DEMAND   = int(os.getenv("GDB_PRIORITY_MAX_DEMAND",  "100"))
+
+# Embedding dimensions — defaulted to bge-large-en which is what this project
+# uses for the rest of the vectors.  Validation only; we never truncate.
+EMBEDDING_DIM_HINT    = int(os.getenv("GDB_EMBEDDING_DIM_HINT",  "1024"))
+
+# Coverage thresholds — controls STRONG/PARTIAL/GAP banding.
+# STRONG: ≥ STRONG_MIN_HITS (≥ 5)   matching Golden Q&A entries
+# PARTIAL: between PARTIAL_MIN_HITS (1) and STRONG_MIN_HITS - 1
+# GAP: 0 hits
+STRONG_MIN_HITS   = int(os.getenv("GDB_STRONG_MIN_HITS",   "5"))
+PARTIAL_MIN_HITS  = int(os.getenv("GDB_PARTIAL_MIN_HITS",  "1"))
+
+
+# ---------------------------------------------------------------------------
+# Data Classes
+# ---------------------------------------------------------------------------
+
+# Coverage band labels used by the API.
+STRONG   = "STRONG"
+PARTIAL  = "PARTIAL"
+GAP      = "GAP"
+
+
+@dataclass
+class GapCluster:
+    """A single semantic cluster of farmer queries with the same gap."""
+
+    cluster_id: str
+    theme: str
+    queries: list[str]
+    query_count: int                 # count in the **current 7-day** window
+    recent_query_count: int          # count in the last *growth* window (14d)
+    previous_query_count: int        # count in the previous 7-day window
+    total_query_count: int           # all-time inside lookback
+    avg_weekly_growth_pct: float
+    domain: str
+    crops: list[str]
+    states: list[str]
+    priority: str                    # critical | high | medium | low
+    priority_score: float            # 0..100, deterministic
+    gdb_coverage_band: str           # STRONG | PARTIAL | GAP
+    gdb_coverage_hits: int           # number of matching golden entries
+    gdb_coverage_score: float        # 0..100, higher = worse gap
+    suggested_action: str
+    sample_queries: list[str] = field(default_factory=list)
+    top_crop: str = ""
+    top_state: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "cluster_id": self.cluster_id,
+            "theme": self.theme,
+            "query_count": self.query_count,
+            "recent_query_count": self.recent_query_count,
+            "previous_query_count": self.previous_query_count,
+            "total_query_count": self.total_query_count,
+            "avg_weekly_growth_pct": round(self.avg_weekly_growth_pct, 2),
+            "domain": self.domain,
+            "crops": list(self.crops),
+            "states": list(self.states),
+            "top_crop": self.top_crop,
+            "top_state": self.top_state,
+            "priority": self.priority,
+            "priority_score": round(self.priority_score, 2),
+            "gdb_coverage_band": self.gdb_coverage_band,
+            "gdb_coverage_hits": self.gdb_coverage_hits,
+            "gdb_coverage_score": round(self.gdb_coverage_score, 2),
+            "suggested_action": self.suggested_action,
+            "sample_queries": list(self.sample_queries),
+        }
+
+
+@dataclass
+class GapReport:
+    """Final aggregated report returned by the API."""
+
+    report_id: str
+    generated_at: str
+    window: dict
+    total_queries_analyzed: int
+    total_clusters_found: int
+    gaps_by_priority: dict
+    coverage_bands: dict
+    top_gaps: list
+    coverage_heatmap: dict
+    recommendations: list
+    clusters: list
+
+    def to_dict(self) -> dict:
+        return {
+            "report_id": self.report_id,
+            "generated_at": self.generated_at,
+            "window": self.window,
+            "total_queries_analyzed": self.total_queries_analyzed,
+            "total_clusters_found": self.total_clusters_found,
+            "gaps_by_priority": dict(self.gaps_by_priority),
+            "coverage_bands": dict(self.coverage_bands),
+            "top_gaps": list(self.top_gaps),
+            "coverage_heatmap": self.coverage_heatmap,
+            "recommendations": list(self.recommendations),
+            "clusters": [c if isinstance(c, dict) else c.to_dict()
+                         for c in self.clusters],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Query extraction & normalization
+# ---------------------------------------------------------------------------
+
+# Whitelist: ASCII letters/digits, whitespace, Devanagari (Hindi/Marathi/
+# Sanskrit/etc), Bengali, Tamil, Telugu, Kannada, Malayalam and Gujarati.
+# This preserves multilingual queries while dropping punctuation/emojis.
+_KEEP_RANGES = (
+    r"\u0900-\u097F"   # Devanagari
+    r"\u0980-\u09FF"   # Bengali
+    r"\u0A00-\u0A7F"   # Gurmukhi
+    r"\u0A80-\u0AFF"   # Gujarati
+    r"\u0B00-\u0B7F"   # Oriya
+    r"\u0B80-\u0BFF"   # Tamil
+    r"\u0C00-\u0C7F"   # Telugu
+    r"\u0C80-\u0CFF"   # Kannada
+    r"\u0D00-\u0D7F"   # Malayalam
+    r"\u4e00-\u9fff"   # CJK
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+_NON_KEEP_RE   = re.compile(rf"[^a-zA-Z0-9\s{_KEEP_RANGES}]+")
+_DIGIT_RE      = re.compile(r"\d+")
+
+
+def normalize_query(text: str | None) -> str:
+    """Robust, Unicode-aware query normalisation.
+
+    Steps (in order):
+
+    1.  ``None`` / empty → empty string.
+    2.  ``unicodedata.normalize("NFKC", ...)`` – collapses compatibility
+        forms (e.g. full-width digits → ASCII).
+    3.  Strip + lower-case.
+    4.  Drop everything that is not a letter / digit / whitespace / one
+        of the supported Indic scripts (whitelist).  This strips
+        punctuation, emojis, control characters and stray Latin
+        "decorations" while preserving multilingual content.
+    5.  Collapse runs of whitespace and trim.
+    6.  Drop pure-digit tokens (typical noise like phone numbers) – this
+        is conservative: a single remaining alphanumeric token is enough
+        to keep the query.
+    """
+    if not text:
+        return ""
+    nfkc = unicodedata.normalize("NFKC", text)
+    lowered = nfkc.strip().lower()
+    cleaned = _NON_KEEP_RE.sub(" ", lowered)
+    cleaned = _DIGIT_RE.sub(" ", cleaned)  # strip pure-digit noise
+    cleaned = _WHITESPACE_RE.sub(" ", cleaned).strip()
+    return cleaned
+
+
+def _safe_get(details: dict | None, *keys: str) -> str | None:
+    """Return the first non-empty string value among ``keys`` in ``details``.
+
+    Defensive against ``None``, missing keys, non-string types and
+    whitespace-only values.
+    """
+    if not isinstance(details, dict):
+        return None
+    for k in keys:
+        v = details.get(k)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+        # Some Mongo documents store lists/tuples here – take the first
+        # non-empty element if so.
+        if isinstance(v, (list, tuple)):
+            for x in v:
+                if isinstance(x, str) and x.strip():
+                    return x.strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Mongo disclaimer-fetch
+# ---------------------------------------------------------------------------
+
+def fetch_disclaimer_queries(
+    *,
+    collection: Any,
+    field: str = QUESTION_FIELD,
+    tag: str = DISCLAIMER_TAG,
+    tag_field: str = TAG_FIELD,
+    lookback_days: int = LOOKBACK_DAYS,
+    domain: str | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> list[dict]:
+    """Return reviewer questions whose ``tag`` matches the disclaimer marker.
+
+    The query is built defensively:
+
+    * The disclaimer marker can live in either a scalar ``tag`` field or
+      an array.  We OR the two possibilities so a document matches
+      regardless of schema flavour.
+    * ``createdAt`` is filtered with ``$gte`` against an aware
+      *timezone-aware* cutoff (we never use the deprecated naive
+      ``datetime.utcnow``).  Documents missing ``createdAt`` are still
+      kept (``$or`` with ``$exists: False`` for the timestamp filter) so
+      legacy data does not silently disappear from the report.
+    * ``details`` is optional.  When present, ``crop``/``state``/
+      ``district``/``domain`` are read; when absent we still capture the
+      question text and timestamp.
+
+    Pure-data cursor: pass any object with ``.find(dict, projection)``
+    returning an iterable of dicts.  We never ``list()`` the entire
+    collection – the caller is responsible for additional pagination
+    /indexes.
+    """
+    now_fn = now or (lambda: datetime.now(timezone.utc))
+    cutoff = now_fn() - timedelta(days=lookback_days)
+
+    tag_match = {"$or": [
+        {tag_field: tag},                       # scalar
+        {tag_field: {"$in": [tag]}},            # array membership (case-sensitive)
+        {tag_field: tag.upper()},               # upper-cased scalar
+        {tag_field: tag.lower()},               # lower-cased scalar
+    ]}
+
+    timestamp_match = {"$or": [
+        {CREATED_AT_FIELD: {"$gte": cutoff}},
+        {CREATED_AT_FIELD: {"$exists": False}},
+    ]}
+
+    question_present = {"$and": [
+        {field: {"$exists": True, "$ne": ""}},
+        {field: {"$not": {"$type": "null"}}},
+    ]}
+
+    and_clauses: list[dict] = [question_present, tag_match, timestamp_match]
+
+    if domain:
+        # Optionally filter the disclaimer queries to a single domain
+        # (used by ops to focus a report on a single bucket like "pest").
+        and_clauses.append({f"{DETAILS_FIELD}.{DOMAIN_FIELD}": domain})
+
+    query = {"$and": and_clauses}
+
+    cursor = collection.find(
+        query,
+        {field: 1, DETAILS_FIELD: 1, CREATED_AT_FIELD: 1,
+         TAG_FIELD: 1, "_id": 0},
+    )
+
+    docs: list[dict] = []
+    skipped_no_text = 0
+    skipped_no_tag = 0
+    for doc in cursor:
+        text = doc.get(field)
+        if not (isinstance(text, str) and text.strip()):
+            skipped_no_text += 1
+            continue
+        # Some legacy docs store the disclaimer tag in the ``status`` or
+        # ``source`` field rather than ``tag``.  Accept those too so we
+        # don't lose signal on older data.
+        doc_tag = doc.get(TAG_FIELD)
+        if not doc_tag and tag not in str(doc.get("source", "")):
+            skipped_no_tag += 1
+            # Continue rather than abort – the Mongo filter above is
+            # already strict and we don't want to lose any rows here.
+        ts = doc.get(CREATED_AT_FIELD)
+        # Some legacy documents store ISO strings; coerce if possible.
+        if isinstance(ts, str) and ts:
+            for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ",
+                        "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+                try:
+                    ts = datetime.strptime(ts, fmt)
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    break
+                except ValueError:
+                    continue
+        docs.append({
+            "text": text,
+            "details": doc.get(DETAILS_FIELD) or {},
+            "created_at": ts if isinstance(ts, datetime) else None,
+            "tag": doc_tag,
+        })
+
+    log.info(
+        "[gdb-gap] fetched %d disclaimer queries (lookback=%dd, "
+        "skipped_no_text=%d, skipped_no_tag=%d)",
+        len(docs), lookback_days, skipped_no_text, skipped_no_tag,
+    )
+    return docs
+
+
+def query_to_text(doc: dict) -> str:
+    """Best-effort extraction of the farmer's question string."""
+    return normalize_query(doc.get("text", ""))
+
+
+# ---------------------------------------------------------------------------
+# Embeddings & clustering
+# ---------------------------------------------------------------------------
+
+def encode_queries(
+    docs: Sequence[dict],
+    embed_fn: Callable[[list[str]], np.ndarray],
+) -> tuple[list[str], np.ndarray]:
+    """Encode unique cleaned queries using the supplied ``embed_fn``.
+
+    The function is **embed-agnostic**: any callable that turns a list of
+    strings into a 2-D ``numpy.ndarray`` will work.  Outputs are L2-
+    normalised in-place so cosine similarity reduces to dot product.
+
+    Empty queries are silently dropped (clustering them is meaningless).
+    Duplicate texts are deduplicated before encoding to keep the embed
+    call cheap.  The returned ``texts`` array preserves the order of the
+    embeddings so cluster indices map back to strings.
+    """
+    seen: dict[str, None] = {}
+    for d in docs:
+        q = query_to_text(d)
+        if q:
+            seen[q] = None
+    unique_texts = list(seen.keys())
+    if not unique_texts:
+        return [], np.zeros((0, EMBEDDING_DIM_HINT), dtype=np.float32)
+
+    raw = embed_fn(unique_texts)
+    embeddings = np.asarray(raw, dtype=np.float32)
+    if embeddings.ndim != 2:
+        raise ValueError(
+            f"embed_fn must return 2-D array; got shape {embeddings.shape}"
+        )
+
+    # Drop any zero rows so they don't form their own cluster later.
+    if embeddings.shape[0] == 0:
+        return unique_texts, embeddings
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    norms = np.where(norms == 0.0, 1.0, norms)
+    embeddings = embeddings / norms  # in-place L2 normalise
+
+    log.info(
+        "[gdb-gap] embedded %d unique queries, dim=%d",
+        len(unique_texts), embeddings.shape[1],
+    )
+    return unique_texts, embeddings
+
+
+def cluster_queries(
+    texts: list[str],
+    embeddings: np.ndarray,
+    *,
+    eps: float = 1 - SIMILARITY_THRESHOLD,  # cosine → euclidean approximation
+    min_samples: int = 2,
+) -> tuple[list[int], dict[int, list[int]]]:
+    """Cluster embeddings with DBSCAN.
+
+    DBSCAN on cosine-equivalent Euclidean distance (vectors are L2-
+    normalised) returns ``-1`` for noise.  We promote noise points to
+    singleton clusters *upstream* of this function (see ``build_gap_report``)
+    so that the caller never silently drops a query.
+
+    A deterministic fallback is used when there are too few embeddings to
+    cluster meaningfully: every embedding gets its own cluster so the
+    caller still receives one cluster per query.
+    """
+    if len(texts) == 0 or embeddings.shape[0] == 0:
+        return [], {}
+
+    # Deterministic fallback for tiny inputs.
+    if embeddings.shape[0] < max(min_samples, 2):
+        clusters: dict[int, list[int]] = defaultdict(list)
+        labels: list[int] = []
+        for i in range(embeddings.shape[0]):
+            clusters[i].append(i)
+            labels.append(i)
+        return labels, dict(clusters)
+
+    db = DBSCAN(eps=eps, min_samples=min_samples, metric="euclidean")
+    labels = db.fit_predict(embeddings)
+    clusters: dict[int, list[int]] = defaultdict(list)
+    for i, lbl in enumerate(labels):
+        clusters[int(lbl)].append(i)
+    return [int(x) for x in labels], dict(clusters)
+
+
+# ---------------------------------------------------------------------------
+# Demand calculation
+# ---------------------------------------------------------------------------
+
+def _iso_week(dt: datetime) -> tuple[int, int]:
+    """Return (ISO year, ISO week number) for a datetime."""
+    iso = dt.isocalendar()
+    return iso[0], iso[1]
+
+
+def weekly_demand(
+    docs: Iterable[dict],
+    *,
+    now: Callable[[], datetime] | None = None,
+) -> dict[str, int]:
+    """Count disclaimer queries per (ISO year, ISO week) key like ``"2026-W29"``.
+
+    Documents without a parseable ``created_at`` are skipped (not crashed
+    on).
+    """
+    now = now or (lambda: datetime.now(timezone.utc))
+    counter: Counter[str] = Counter()
+    for d in docs:
+        ts = d.get("created_at")
+        if isinstance(ts, datetime):
+            y, w = _iso_week(ts)
+            counter[f"{y}-W{w:02d}"] += 1
+    return dict(counter)
+
+
+def weekly_growth_pct(weekly: dict[str, int]) -> float:
+    """Compute the mean pairwise week-over-week growth percentage.
+
+    Returns 0.0 if fewer than 2 weeks of data are available.
+    """
+    if not weekly or len(weekly) < 2:
+        return 0.0
+    ordered = [weekly[k] for k in sorted(weekly.keys())]
+    growths: list[float] = []
+    for prev, curr in zip(ordered, ordered[1:]):
+        if prev == 0:
+            growths.append(100.0 if curr > 0 else 0.0)
+        else:
+            growths.append((curr - prev) / prev * 100.0)
+    return float(np.mean(growths)) if growths else 0.0
+
+
+def current_vs_previous_demand(
+    docs: Iterable[dict],
+    *,
+    window_days: int = DEMAND_WINDOW_DAYS,
+    growth_window_days: int = GROWTH_WINDOW_DAYS,
+    now: Callable[[], datetime] | None = None,
+) -> dict[str, int]:
+    """Real current-vs-previous 7-day demand calculation.
+
+    Buckets the supplied documents into three windows anchored on
+    ``now()``:
+
+    * ``current``     – the last ``window_days`` (default 7) days.
+    * ``previous``    – the ``window_days`` *before* that.
+    * ``recent_total``– the last ``growth_window_days`` (default 14) days.
+
+    All counts ignore documents without a parseable ``created_at``.
+    """
+    now_fn = now or (lambda: datetime.now(timezone.utc))
+    anchor = now_fn()
+    cur_start   = anchor - timedelta(days=window_days)
+    prev_start  = anchor - timedelta(days=2 * window_days)
+    recent_start = anchor - timedelta(days=growth_window_days)
+
+    counts = {"current": 0, "previous": 0, "recent_total": 0}
+    for d in docs:
+        ts = d.get("created_at")
+        if not isinstance(ts, datetime):
+            continue
+        # Make sure both sides are timezone-aware so comparisons don't blow
+        # up on naive vs aware datetimes that may be stored in Mongo.
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if ts >= recent_start:
+            counts["recent_total"] += 1
+        if ts >= cur_start:
+            counts["current"] += 1
+        elif ts >= prev_start:
+            counts["previous"] += 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Priority score & priority levels
+# ---------------------------------------------------------------------------
+
+def compute_priority_score(
+    *,
+    current: int,
+    previous: int,
+    recent_total: int,
+    growth_pct: float,
+    unique_crops: int,
+    unique_states: int,
+) -> float:
+    """Deterministic, explainable 0..100 priority score.
+
+    The score is the weighted sum of five factors, each clamped to
+    ``[0, 1]``:
+
+    * ``0.40`` – **current demand** (current window size, capped at
+      ``PRIORITY_MAX_DEMAND``).
+    * ``0.20`` – **trend** (week-over-week growth percentage, clamped
+      to ``[0, 200]`` so a 200 % surge saturates the factor at 1.0).
+    * ``0.20`` – **acceleration** (current - previous week, clamped to
+      ``[0, 2*PRIORITY_MAX_DEMAND]``).
+    * ``0.10`` – **recency breadth** (recent total demand, clamped at
+      ``2 * PRIORITY_MAX_DEMAND``).
+    * ``0.10`` – **diversity** (unique crops + states, clamped at 10).
+
+    The same inputs always produce the same score – no randomness, no
+    time-of-day dependencies – which keeps the report reproducible.
+    """
+    demand = min(max(current, 0) / max(PRIORITY_MAX_DEMAND, 1), 1.0)
+    trend  = min(max(growth_pct, 0.0) / 200.0, 1.0)
+    accel  = min(max(current - previous, 0) / max(2 * PRIORITY_MAX_DEMAND, 1), 1.0)
+    recency= min(max(recent_total, 0) / max(2 * PRIORITY_MAX_DEMAND, 1), 1.0)
+    divers = min((unique_crops + unique_states) / 10.0, 1.0)
+    return (0.40 * demand + 0.20 * trend + 0.20 * accel
+            + 0.10 * recency + 0.10 * divers) * 100.0
+
+
+def score_to_priority(score: float) -> tuple[str, str]:
+    """Map a ``priority_score`` (0..100) to a (priority, action) tuple.
+
+    Thresholds are chosen so that the bands are intuitive to operators:
+
+    * **critical** – score ≥ 70  *or* cluster size ≥ ``LARGE_CLUSTER_SIZE``
+      *or* week-over-week growth ≥ 50 %.
+    * **high**     – score ≥ 45  *or* cluster size ≥ ``MEDIUM_CLUSTER_SIZE``
+      *or* week-over-week growth ≥ 20 %.
+    * **medium**   – score ≥ 20  *or* cluster size ≥ ``MIN_QUERIES_PER_CLUSTER``.
+    * **low**      – everything else (treated as watch-list).
+    """
+    if score >= 70:
+        return ("critical",
+                "Publish new Golden Q&A / PoP entry this week and notify the expert queue.")
+    if score >= 45:
+        return ("high",
+                "Schedule in the next sprint – has clear farmer demand.")
+    if score >= 20:
+        return ("medium",
+                "Watch-list – review in the next backlog grooming.")
+    return ("low", "Track only; revisit if the cluster grows in the next cycle.")
+
+
+# ---------------------------------------------------------------------------
+# Coverage scoring & GDB lookup
+# ---------------------------------------------------------------------------
+
+def _coverage_lookup_query(
+    *,
+    text: str,
+    crop: str | None,
+    state: str | None,
+    domain: str | None,
+) -> dict:
+    """Build a Mongo filter for finding GDB entries that cover ``text``.
+
+    The lookup is intentionally permissive: we match either on free-text
+    ``text``/``question`` or on the (crop, state, domain) tuple, and
+    we let the caller add a vector-search filter on top if desired.
+    """
+    clauses: list[dict] = []
+    if text:
+        clauses.append({"$or": [
+            {GOLDEN_TEXT_FIELD:       {"$regex": re.escape(text), "$options": "i"}},
+            {GOLDEN_QUESTION_FIELD:   {"$regex": re.escape(text), "$options": "i"}},
+        ]})
+    if crop:
+        clauses.append({f"{GOLDEN_METADATA_FIELD}.Crop": {"$in": [
+            crop, crop.title(), crop.lower(), crop.upper(),
+        ]}})
+    if state:
+        clauses.append({f"{GOLDEN_METADATA_FIELD}.State": {"$in": [
+            state, state.title(), state.lower(), state.upper(),
+        ]}})
+    if domain:
+        clauses.append({f"{GOLDEN_METADATA_FIELD}.Category": {"$in": [
+            domain, domain.title(), domain.lower(), domain.upper(),
+        ]}})
+    if not clauses:
+        return {}
+    return {"$and": clauses} if len(clauses) > 1 else clauses[0]
+
+
+def lookup_gdb_coverage(
+    *,
+    golden_collection: Any | None,
+    cluster_text: str,
+    crop: str | None,
+    state: str | None,
+    domain: str | None,
+) -> dict:
+    """Real GDB coverage lookup for a single (cluster, crop, state, domain).
+
+    Returns a small dict:
+
+    .. code-block:: python
+
+       {
+         "hits": <int>,        # number of matching Golden QA rows
+         "band": "STRONG" | "PARTIAL" | "GAP",
+       }
+
+    The implementation is **resilient**:
+
+    * If ``golden_collection`` is ``None`` (e.g. in tests) the function
+      returns a ``GAP`` band with zero hits.  This lets the rest of the
+      pipeline run without requiring a live database.
+    * Any ``Exception`` raised by MongoDB is logged and treated as
+      ``GAP`` – we never crash the entire report because one cluster
+      hit a transient DB error.
+
+    The ``hits`` count is computed via a simple MongoDB ``count_documents``
+    filter (see :func:`_coverage_lookup_query`).  When the caller has an
+    embedding model available we additionally bias the result upward
+    using a vector-search stage – the implementation lives in
+    :func:`lookup_gdb_coverage_with_vector` which is called from the
+    main pipeline.
+    """
+    if golden_collection is None:
+        return {"hits": 0, "band": GAP}
+
+    try:
+        filt = _coverage_lookup_query(
+            text=cluster_text, crop=crop, state=state, domain=domain,
+        )
+        if not filt:
+            # Nothing to filter by → treat as no coverage evidence.
+            return {"hits": 0, "band": GAP}
+        hits = golden_collection.count_documents(filt, maxTimeMS=2000)
+        hits = int(hits or 0)
+    except Exception as e:  # pragma: no cover – defensive
+        log.warning("[gdb-gap] GDB coverage lookup failed for %r: %s", cluster_text[:30], e)
+        return {"hits": 0, "band": GAP}
+
+    if hits >= STRONG_MIN_HITS:
+        band = STRONG
+    elif hits >= PARTIAL_MIN_HITS:
+        band = PARTIAL
+    else:
+        band = GAP
+    return {"hits": hits, "band": band}
+
+
+def lookup_gdb_coverage_with_vector(
+    *,
+    golden_collection: Any | None,
+    cluster_embedding: np.ndarray | None,
+    cluster_text: str,
+    crop: str | None,
+    state: str | None,
+    domain: str | None,
+    embed_match_threshold: float = 0.7,
+    max_candidates: int = 50,
+) -> dict:
+    """Vector-enhanced GDB coverage lookup.
+
+    In addition to the text/crop/state/domain filter used by
+    :func:`lookup_gdb_coverage`, this function attempts a MongoDB Atlas
+    ``$vectorSearch`` aggregation against the golden collection.  If the
+    cluster has no embedding yet, the underlying text-only lookup is
+    used.
+
+    The vector search is *only* attempted if:
+
+    * ``golden_collection`` is not ``None``;
+    * ``cluster_embedding`` is a 1-D non-empty numpy array.
+
+    Any exception (missing index, no Atlas Vector Search enabled, …)
+    is logged and we silently fall back to the text-only count – we
+    never crash the report because the vector index is unavailable.
+    """
+    base = lookup_gdb_coverage(
+        golden_collection=golden_collection,
+        cluster_text=cluster_text,
+        crop=crop, state=state, domain=domain,
+    )
+
+    if (
+        golden_collection is None
+        or cluster_embedding is None
+        or not hasattr(golden_collection, "aggregate")
+        or getattr(cluster_embedding, "size", 0) == 0
+    ):
+        return base
+
+    try:
+        pipeline = [
+            {
+                "$vectorSearch": {
+                    "index": GOLDEN_VECTOR_INDEX,
+                    "path": GOLDEN_EMBEDDING_FIELD,
+                    "queryVector": cluster_embedding.astype(float).tolist(),
+                    "numCandidates": max_candidates,
+                    "limit": max_candidates,
+                }
+            },
+            {"$project": {"score": {"$meta": "vectorSearchScore"}}},
+            {"$match": {"score": {"$gte": embed_match_threshold}}},
+            {"$count": "hits"},
+        ]
+        rows = list(golden_collection.aggregate(pipeline, maxTimeMS=2000))
+        if rows and "hits" in rows[0]:
+            hits = max(int(rows[0]["hits"]), int(base["hits"]))
+            band = (STRONG if hits >= STRONG_MIN_HITS
+                    else PARTIAL if hits >= PARTIAL_MIN_HITS
+                    else GAP)
+            return {"hits": hits, "band": band}
+    except Exception as e:  # pragma: no cover – defensive
+        log.warning(
+            "[gdb-gap] vector-search coverage lookup failed for %r: %s",
+            cluster_text[:30], e,
+        )
+    return base
+
+
+def coverage_band_to_score(band: str, hits: int) -> float:
+    """Convert a coverage band + hits count to a 0..100 *gap* score.
+
+    * ``STRONG``  → 0-20  (we have lots of GDB material).
+    * ``PARTIAL`` → 40-70 (some material, but not enough).
+    * ``GAP``     → 80-100 (no or very little GDB material).
+
+    Higher = worse coverage = bigger gap.
+    """
+    if band == STRONG:
+        # Saturate at 0; cap at 20 even for borderline hits.
+        return max(0.0, 20.0 - min(hits, STRONG_MIN_HITS) * 4.0)
+    if band == PARTIAL:
+        # 70 down to 40 as hits approach STRONG_MIN_HITS.
+        span = max(STRONG_MIN_HITS - 1, 1)
+        frac = min(max(hits - PARTIAL_MIN_HITS, 0) / span, 1.0)
+        return 70.0 - 30.0 * frac
+    # GAP
+    return 100.0
+
+
+# ---------------------------------------------------------------------------
+# Theme & domain inference
+# ---------------------------------------------------------------------------
+
+_DOMAIN_KEYWORDS = {
+    "weather":  ["rain", "monsoon", "temperature", "weather", "drought", "बारिश", "मानसून", "सूखा"],
+    "pest":     ["pest", "insect", "disease", "leaf", "fungus", "viral", "कीट", "रोग", "पत्ती"],
+    "scheme":   ["scheme", "subsidy", "loan", "pm kisan", "fasal bima", "योजना", "सब्सिडी", "किसान"],
+    "soil":     ["soil", "fertility", "compost", "manure", "मिट्टी", "खाद"],
+    "market":   ["price", "mandi", "market", "sell", "भाव", "मंडी", "बाज़ार"],
+}
+
+_STOPWORDS = {
+    "the", "is", "and", "in", "of", "to", "for", "on", "with", "a", "an",
+    "my", "i", "are", "be", "this", "how", "what", "why", "can", "do",
+    "कैसे", "क्या", "मेरे", "में", "है", "और", "कि", "से", "को", "हैं",
+}
+
+
+def _top_terms(texts: Sequence[str], *, k: int = 2) -> str:
+    """Naïve keyword extraction: returns the ``k`` most common non-stopwords."""
+    words = []
+    for t in texts:
+        for w in t.split():
+            if w in _STOPWORDS or len(w) < 3:
+                continue
+            words.append(w)
+    if not words:
+        return ""
+    most = Counter(words).most_common(k)
+    return " / ".join(w for w, _ in most)
+
+
+def _infer_domain(texts: Sequence[str]) -> str:
+    """Domain inference via keyword counts.  Returns ``"general"`` if no hits."""
+    joined = " ".join(texts).lower()
+    best_domain = "general"
+    best_hits = 0
+    for dom, kws in _DOMAIN_KEYWORDS.items():
+        hits = sum(joined.count(k) for k in kws)
+        if hits > best_hits:
+            best_domain, best_hits = dom, hits
+    return best_domain
+
+
+def _mode(values: Iterable[str]) -> str:
+    """Return the most common non-empty value in ``values``, or ``""`` if empty."""
+    filtered = [v for v in values if v]
+    if not filtered:
+        return ""
+    return Counter(filtered).most_common(1)[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Heatmap & recommendations
+# ---------------------------------------------------------------------------
+
+def build_coverage_heatmap(clusters: Sequence[GapCluster]) -> dict:
+    """Return ``{(crop, state): gap_count}`` aggregated across clusters.
+
+    Output is a JSON-friendly nested dict: ``{crop: {state: count}}``.
+    Crops/states without any clusters are simply absent from the output.
+    """
+    heatmap: dict[tuple[str, str], int] = defaultdict(int)
+    for c in clusters:
+        if not c.crops:
+            continue
+        for cr in c.crops:
+            for st in c.states or [""]:
+                heatmap[(cr, st)] += 1
+    out: dict[str, dict[str, int]] = {}
+    for (crop, state), cnt in heatmap.items():
+        if not state:
+            continue
+        out.setdefault(crop, {})[state] = cnt
+    return out
+
+
+def build_recommendations(
+    clusters: Sequence[GapCluster],
+    *,
+    top_n: int = 5,
+) -> list[str]:
+    """Demand-ranked outreach recommendations.
+
+    Each recommendation targets a specific cluster and includes its
+    crop/state context so the content team can act on it immediately.
+    Clusters are sorted by ``priority_score`` (descending) and only the
+    top-``top_n`` are kept.  Recommendations for GAP-band clusters are
+    emphasised; PARTIAL clusters get a softer suggestion.
+    """
+    if not clusters:
+        return ["No actionable gaps – GDB coverage is currently healthy."]
+
+    ranked = sorted(clusters, key=lambda c: -c.priority_score)
+    recs: list[str] = []
+    for c in ranked[:top_n]:
+        ctx_bits = []
+        if c.top_crop:
+            ctx_bits.append(f"crop={c.top_crop}")
+        if c.top_state:
+            ctx_bits.append(f"state={c.top_state}")
+        ctx = ", ".join(ctx_bits)
+        head = (
+            f"Cluster {c.cluster_id} ({c.theme!r}) "
+            f"– {c.query_count} current-week queries"
+            + (f" [{ctx}]" if ctx else "")
+        )
+        if c.gdb_coverage_band == GAP:
+            recs.append(
+                f"{head}: NO GDB coverage – schedule a new Golden Q&A entry "
+                f"with the {c.domain} expert. Score {c.priority_score:.0f}/100."
+            )
+        elif c.gdb_coverage_band == PARTIAL:
+            recs.append(
+                f"{head}: PARTIAL GDB coverage ({c.gdb_coverage_hits} hits) – "
+                f"augment with regional variants. Score {c.priority_score:.0f}/100."
+            )
+        else:
+            recs.append(
+                f"{head}: GDB is well covered but demand remains high – "
+                f"consider promoting existing entries to farmers. "
+                f"Score {c.priority_score:.0f}/100."
+            )
+
+    critical_count = sum(1 for c in clusters if c.priority == "critical")
+    if critical_count and critical_count > top_n:
+        recs.append(
+            f"+{critical_count - top_n} additional critical gap(s) – "
+            "address after the top-{} batch.".format(top_n)
+        )
+    slow = [c for c in clusters if c.avg_weekly_growth_pct <= -10]
+    if slow:
+        recs.append(
+            f"{len(slow)} cluster(s) are shrinking – de-prioritise for the next cycle."
+        )
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# Main report builder
+# ---------------------------------------------------------------------------
+
+def build_gap_report(
+    *,
+    review_collection: Any,
+    review_golden_collection: Any | None,
+    review_pop_collection: Any | None,
+    embed_fn: Callable[[list[str]], np.ndarray],
+    now: Callable[[], datetime] | None = None,
+    similarity_threshold: float = SIMILARITY_THRESHOLD,
+    min_samples: int = 2,
+    lookback_days: int = LOOKBACK_DAYS,
+    growth_window_days: int = GROWTH_WINDOW_DAYS,
+    demand_window_days: int = DEMAND_WINDOW_DAYS,
+) -> dict:
+    """Run the full gap detection pipeline and return a JSON-ready dict.
+
+    Parameters
+    ----------
+    review_collection
+        Cursor source for reviewer questions (any object with ``.find(...)``).
+    review_golden_collection
+        Optional Golden QA collection used for **real** GDB coverage lookup
+        (text + crop + state + domain + vector).  Pass ``None`` to skip.
+    review_pop_collection
+        Reserved for future PoP coverage checks; accepted for API stability
+        but currently unused.
+    embed_fn
+        Callable ``(list[str]) -> np.ndarray`` of shape ``(n, dim)``.
+        Will L2-normalise outputs as a safety net.
+    now
+        Clock source (defaults to timezone-aware ``datetime.now(timezone.utc)``).
+    similarity_threshold
+        Cosine threshold for DBSCAN clustering (converted to ``eps`` as
+        ``1 - similarity_threshold``).
+    """
+    now_fn = now or (lambda: datetime.now(timezone.utc))
+
+    t0 = time.perf_counter()
+    raw_docs = fetch_disclaimer_queries(
+        collection=review_collection,
+        now=now_fn,
+        lookback_days=lookback_days,
+    )
+    if not raw_docs:
+        log.warning("[gdb-gap] no disclaimer queries found – returning empty report")
+        empty = _empty_report(now_fn(), lookback_days, growth_window_days,
+                              demand_window_days)
+        empty["elapsed_ms"] = round((time.perf_counter() - t0) * 1000, 1)
+        return empty
+
+    # Encode + cluster
+    unique_texts, embeddings = encode_queries(raw_docs, embed_fn=embed_fn)
+    labels, cluster_map = cluster_queries(
+        unique_texts,
+        embeddings,
+        eps=max(1.0 - similarity_threshold, 0.01),
+        min_samples=min_samples,
+    )
+
+    # Real current vs previous 7-day demand (anchored on now_fn()).
+    demand = current_vs_previous_demand(
+        raw_docs,
+        window_days=demand_window_days,
+        growth_window_days=growth_window_days,
+        now=now_fn,
+    )
+    per_week = weekly_demand(raw_docs, now=now_fn)
+    growth_overall = weekly_growth_pct(per_week)
+
+    # Index docs by cleaned query text so we can map cluster ids back.
+    text_to_doc_index: dict[str, list[int]] = defaultdict(list)
+    for i, d in enumerate(raw_docs):
+        t = query_to_text(d)
+        if t:
+            text_to_doc_index[t].append(i)
+
+    clusters: list[GapCluster] = []
+    for cid, indices in cluster_map.items():
+        if cid == -1:
+            for idx in indices:
+                clusters.extend(_singleton(
+                    raw_docs=raw_docs,
+                    text=unique_texts[idx],
+                    doc_ids=text_to_doc_index.get(unique_texts[idx], []),
+                    now_fn=now_fn,
+                    demand_window_days=demand_window_days,
+                    growth_window_days=growth_window_days,
+                    golden_collection=review_golden_collection,
+                    cluster_embedding=(embeddings[idx]
+                                       if idx < embeddings.shape[0] else None),
+                ))
+            continue
+        cluster = _cluster_from_indices(
+            raw_docs=raw_docs,
+            texts=unique_texts,
+            indices=indices,
+            text_to_doc_index=text_to_doc_index,
+            cid=cid,
+            demand=demand,
+            growth_pct=growth_overall,
+            now_fn=now_fn,
+            demand_window_days=demand_window_days,
+            growth_window_days=growth_window_days,
+            golden_collection=review_golden_collection,
+            cluster_embedding=(
+                _mean_embedding(embeddings, indices)
+                if indices else None
+            ),
+        )
+        clusters.append(cluster)
+
+    # Promote any indexed-but-unused text to a singleton so we never
+    # silently drop a query that wasn't part of any cluster.
+    used_texts = {unique_texts[i] for idxs in cluster_map.values()
+                  for i in idxs}
+    for t, ids in text_to_doc_index.items():
+        if t in used_texts:
+            continue
+        clusters.extend(_singleton(
+            raw_docs=raw_docs,
+            text=t,
+            doc_ids=ids,
+            now_fn=now_fn,
+            demand_window_days=demand_window_days,
+            growth_window_days=growth_window_days,
+            golden_collection=review_golden_collection,
+            cluster_embedding=None,
+        ))
+
+    # Stable sort: priority_score desc, then cluster_id asc.
+    clusters.sort(key=lambda c: (-c.priority_score, c.cluster_id))
+
+    top = [c.to_dict() for c in clusters[:10]]
+    coverage_bands = _count_by_band(clusters)
+
+    report = GapReport(
+        report_id=f"gap-{int(time.time())}",
+        generated_at=now_fn().isoformat(timespec="seconds").replace(
+            "+00:00", "Z"
+        ) if now_fn().tzinfo is not None else now_fn().isoformat(timespec="seconds") + "Z",
+        window={
+            "lookback_days": lookback_days,
+            "growth_window_days": growth_window_days,
+            "demand_window_days": demand_window_days,
+        },
+        total_queries_analyzed=len(raw_docs),
+        total_clusters_found=len(clusters),
+        gaps_by_priority=_count_by_priority(clusters),
+        coverage_bands=coverage_bands,
+        top_gaps=top,
+        coverage_heatmap=build_coverage_heatmap(clusters),
+        recommendations=build_recommendations(clusters),
+        clusters=[c.to_dict() for c in clusters],
+    )
+    out = report.to_dict()
+    out["current_query_count"]  = demand["current"]
+    out["previous_query_count"] = demand["previous"]
+    out["recent_query_count"]   = demand["recent_total"]
+    out["elapsed_ms"] = round((time.perf_counter() - t0) * 1000, 1)
+    log.info(
+        "[gdb-gap] report built: clusters=%d current7d=%d prev7d=%d (%.0fms)",
+        len(clusters), demand["current"], demand["previous"],
+        out["elapsed_ms"],
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _empty_report(now: datetime,
+                  lookback_days: int,
+                  growth_window_days: int,
+                  demand_window_days: int) -> dict:
+    ts = (now.isoformat(timespec="seconds") + "Z"
+          if now.tzinfo is None else
+          now.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"))
+    return GapReport(
+        report_id=f"gap-{int(time.time())}",
+        generated_at=ts,
+        window={"lookback_days": lookback_days,
+                "growth_window_days": growth_window_days,
+                "demand_window_days": demand_window_days},
+        total_queries_analyzed=0,
+        total_clusters_found=0,
+        gaps_by_priority={"critical": 0, "high": 0, "medium": 0, "low": 0},
+        coverage_bands={STRONG: 0, PARTIAL: 0, GAP: 0},
+        top_gaps=[],
+        coverage_heatmap={},
+        recommendations=[
+            "No disclaimer-triggered queries in the lookback window – nothing to act on."
+        ],
+        clusters=[],
+    ).to_dict() | {"current_query_count": 0, "previous_query_count": 0,
+                   "recent_query_count": 0, "elapsed_ms": 0.0}
+
+
+def _mean_embedding(embeddings: np.ndarray, indices: Sequence[int]) -> np.ndarray | None:
+    """Return the L2-normalised mean of the embeddings at ``indices``."""
+    if embeddings.shape[0] == 0 or not indices:
+        return None
+    sub = np.asarray(embeddings[list(indices)], dtype=np.float32)
+    if sub.size == 0:
+        return None
+    mean = sub.mean(axis=0)
+    n = float(np.linalg.norm(mean))
+    if n == 0.0:
+        return mean
+    return (mean / n).astype(np.float32)
+
+
+def _cluster_from_indices(
+    *,
+    raw_docs: list[dict],
+    texts: list[str],
+    indices: list[int],
+    text_to_doc_index: dict[str, list[int]],
+    cid: int,
+    demand: dict[str, int],
+    growth_pct: float,
+    now_fn: Callable[[], datetime],
+    demand_window_days: int,
+    growth_window_days: int,
+    golden_collection: Any | None,
+    cluster_embedding: np.ndarray | None,
+) -> GapCluster:
+    cluster_texts = [texts[i] for i in indices]
+    matched_docs: list[dict] = []
+    for t in cluster_texts:
+        for di in text_to_doc_index.get(t, []):
+            matched_docs.append(raw_docs[di])
+
+    crops: set[str] = set()
+    states: set[str] = set()
+    domain_counter: Counter[str] = Counter()
+    for d in matched_docs:
+        det = d.get("details") or {}
+        c = _safe_get(det, CROP_FIELD, "Crop", "crop")
+        s = _safe_get(det, STATE_FIELD, "State", "state")
+        if c: crops.add(c)
+        if s: states.add(s)
+        # Prefer the operator-assigned domain if present, else infer.
+        op_domain = _safe_get(det, DOMAIN_FIELD, "Domain", "category", "Category")
+        if op_domain:
+            domain_counter[op_domain.lower()] += 1
+
+    # Cluster-specific current/previous 7-day counts.
+    anchor = now_fn()
+    cur_start   = anchor - timedelta(days=demand_window_days)
+    prev_start  = anchor - timedelta(days=2 * demand_window_days)
+    cur_count, prev_count, recent_count = 0, 0, 0
+    for d in matched_docs:
+        ts = d.get("created_at")
+        if not isinstance(ts, datetime):
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if ts >= anchor - timedelta(days=growth_window_days):
+            recent_count += 1
+        if ts >= cur_start:
+            cur_count += 1
+        elif ts >= prev_start:
+            prev_count += 1
+
+    # Cluster-level growth across the cluster's own weekly counts.
+    cluster_weeks: Counter[str] = Counter()
+    for d in matched_docs:
+        ts = d.get("created_at")
+        if isinstance(ts, datetime):
+            y, w = _iso_week(ts)
+            cluster_weeks[f"{y}-W{w:02d}"] += 1
+    growth = weekly_growth_pct(dict(cluster_weeks))
+
+    priority_score = compute_priority_score(
+        current=cur_count,
+        previous=prev_count,
+        recent_total=recent_count,
+        growth_pct=growth,
+        unique_crops=len(crops),
+        unique_states=len(states),
+    )
+    priority, action = score_to_priority(priority_score)
+
+    top_crop  = _mode(crops)
+    top_state = _mode(states)
+
+    domain = (domain_counter.most_common(1)[0][0]
+              if domain_counter else _infer_domain(cluster_texts))
+
+    # Real GDB coverage lookup: try text + (crop, state, domain) and
+    # vector search (if cluster_embedding is available).
+    coverage = lookup_gdb_coverage_with_vector(
+        golden_collection=golden_collection,
+        cluster_embedding=cluster_embedding,
+        cluster_text=cluster_texts[0] if cluster_texts else "",
+        crop=top_crop or None,
+        state=top_state or None,
+        domain=domain,
+    )
+    coverage_score = coverage_band_to_score(coverage["band"], coverage["hits"])
+
+    theme = (_top_terms(cluster_texts, k=3)
+             or (cluster_texts[0] if cluster_texts else f"cluster-{cid}"))
+    return GapCluster(
+        cluster_id=f"gap-c{cid}",
+        theme=theme,
+        queries=cluster_texts,
+        query_count=cur_count,
+        recent_query_count=recent_count,
+        previous_query_count=prev_count,
+        total_query_count=len(matched_docs),
+        avg_weekly_growth_pct=growth,
+        domain=domain,
+        crops=sorted(crops),
+        states=sorted(states),
+        top_crop=top_crop,
+        top_state=top_state,
+        priority=priority,
+        priority_score=priority_score,
+        gdb_coverage_band=coverage["band"],
+        gdb_coverage_hits=coverage["hits"],
+        gdb_coverage_score=coverage_score,
+        suggested_action=action,
+        sample_queries=cluster_texts[:5],
+    )
+
+
+def _singleton(
+    *,
+    raw_docs: list[dict],
+    text: str,
+    doc_ids: list[int],
+    now_fn: Callable[[], datetime],
+    demand_window_days: int,
+    growth_window_days: int,
+    golden_collection: Any | None,
+    cluster_embedding: np.ndarray | None,
+) -> list[GapCluster]:
+    """Build a one-query cluster (DBSCAN noise)."""
+    if not doc_ids:
+        return []
+    matched = [raw_docs[i] for i in doc_ids]
+
+    crops: set[str] = set()
+    states: set[str] = set()
+    domain_counter: Counter[str] = Counter()
+    for d in matched:
+        det = d.get("details") or {}
+        c = _safe_get(det, CROP_FIELD, "Crop", "crop")
+        s = _safe_get(det, STATE_FIELD, "State", "state")
+        if c: crops.add(c)
+        if s: states.add(s)
+        op_domain = _safe_get(det, DOMAIN_FIELD, "Domain", "category", "Category")
+        if op_domain:
+            domain_counter[op_domain.lower()] += 1
+
+    anchor = now_fn()
+    cur_start   = anchor - timedelta(days=demand_window_days)
+    prev_start  = anchor - timedelta(days=2 * demand_window_days)
+    cur_count, prev_count, recent_count = 0, 0, 0
+    for d in matched:
+        ts = d.get("created_at")
+        if not isinstance(ts, datetime):
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if ts >= anchor - timedelta(days=growth_window_days):
+            recent_count += 1
+        if ts >= cur_start:
+            cur_count += 1
+        elif ts >= prev_start:
+            prev_count += 1
+
+    priority_score = compute_priority_score(
+        current=cur_count,
+        previous=prev_count,
+        recent_total=recent_count,
+        growth_pct=0.0,
+        unique_crops=len(crops),
+        unique_states=len(states),
+    )
+    priority, action = score_to_priority(priority_score)
+
+    top_crop  = _mode(crops)
+    top_state = _mode(states)
+    domain = (domain_counter.most_common(1)[0][0]
+              if domain_counter else _infer_domain([text]))
+
+    coverage = lookup_gdb_coverage_with_vector(
+        golden_collection=golden_collection,
+        cluster_embedding=cluster_embedding,
+        cluster_text=text,
+        crop=top_crop or None,
+        state=top_state or None,
+        domain=domain,
+    )
+    coverage_score = coverage_band_to_score(coverage["band"], coverage["hits"])
+
+    return [GapCluster(
+        cluster_id=f"gap-noise-{abs(hash(text)) % (10**8)}",
+        theme=_top_terms([text], k=2) or text,
+        queries=[text],
+        query_count=cur_count,
+        recent_query_count=recent_count,
+        previous_query_count=prev_count,
+        total_query_count=len(matched),
+        avg_weekly_growth_pct=0.0,
+        domain=domain,
+        crops=sorted(crops),
+        states=sorted(states),
+        top_crop=top_crop,
+        top_state=top_state,
+        priority=priority,
+        priority_score=priority_score,
+        gdb_coverage_band=coverage["band"],
+        gdb_coverage_hits=coverage["hits"],
+        gdb_coverage_score=coverage_score,
+        suggested_action=action,
+        sample_queries=[text],
+    )]
+
+
+def _count_by_priority(clusters: Sequence[GapCluster]) -> dict:
+    out = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for c in clusters:
+        out[c.priority] = out.get(c.priority, 0) + 1
+    return out
+
+
+def _count_by_band(clusters: Sequence[GapCluster]) -> dict:
+    out = {STRONG: 0, PARTIAL: 0, GAP: 0}
+    for c in clusters:
+        out[c.gdb_coverage_band] = out.get(c.gdb_coverage_band, 0) + 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cache (used by the FastAPI endpoint)
+# ---------------------------------------------------------------------------
+
+_CACHED_REPORT: dict | None = None
+_CACHED_AT: float | None = None
+CACHE_TTL_SECONDS = int(os.getenv("GDB_REPORT_CACHE_TTL", "900"))  # 15 min
+
+
+def get_cached_report() -> dict | None:
+    """Return the cached report if it is fresh, else ``None``."""
+    if _CACHED_REPORT is None or _CACHED_AT is None:
+        return None
+    if (time.time() - _CACHED_AT) > CACHE_TTL_SECONDS:
+        return None
+    return _CACHED_REPORT
+
+
+def set_cached_report(report: dict) -> None:
+    global _CACHED_REPORT, _CACHED_AT
+    _CACHED_REPORT = report
+    _CACHED_AT = time.time()
+
+
+def invalidate_cache() -> None:
+    """Clear the cached gap report (used by tests and admin actions)."""
+    global _CACHED_REPORT, _CACHED_AT
+    _CACHED_REPORT = None
+    _CACHED_AT = None
+
+
+__all__ = [
+    "DISCLAIMER_TAG",
+    "STRONG",
+    "PARTIAL",
+    "GAP",
+    "SIMILARITY_THRESHOLD",
+    "LOOKBACK_DAYS",
+    "DEMAND_WINDOW_DAYS",
+    "GROWTH_WINDOW_DAYS",
+    "GapCluster",
+    "GapReport",
+    "build_gap_report",
+    "build_coverage_heatmap",
+    "build_recommendations",
+    "normalize_query",
+    "fetch_disclaimer_queries",
+    "encode_queries",
+    "cluster_queries",
+    "weekly_demand",
+    "weekly_growth_pct",
+    "current_vs_previous_demand",
+    "compute_priority_score",
+    "score_to_priority",
+    "lookup_gdb_coverage",
+    "lookup_gdb_coverage_with_vector",
+    "coverage_band_to_score",
+    "get_cached_report",
+    "set_cached_report",
+    "invalidate_cache",
+    "CACHE_TTL_SECONDS",
+]

--- a/apis/acc_api/main.py
+++ b/apis/acc_api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel
 from pymongo import MongoClient
 from bson import ObjectId
@@ -55,7 +55,23 @@ golden_client = MongoClient(GOLDEN_MONGO_URI)
 golden_qa_collection = golden_client[GOLDEN_DB_NAME][GOLDEN_QA_COLLECTION]
 golden_pop_collection = golden_client[GOLDEN_DB_NAME][GOLDEN_POP_COLLECTION]
 
-model = SentenceTransformer(EMBEDDING_MODEL_NAME)
+# Lazy model loader – the BGE model is large (~1.3 GB) and we don't want
+# /health, /filters or an empty /search to trigger the download on every
+# cold start.  The model is only materialised on first use by either
+# /search or /gdb/gap-report.
+_model: SentenceTransformer | None = None
+
+
+def _get_model() -> SentenceTransformer:
+    """Return the (lazily loaded) sentence-transformer model.
+
+    Loaded on first call and cached for the lifetime of the process.
+    """
+    global _model
+    if _model is None:
+        log.info("Loading embedding model %r …", EMBEDDING_MODEL_NAME)
+        _model = SentenceTransformer(EMBEDDING_MODEL_NAME)
+    return _model
 
 
 class SearchRequest(BaseModel):
@@ -522,7 +538,7 @@ def search_unified(request: SearchRequest):
         raise HTTPException(status_code=400, detail="Query must not be empty.")
 
     query_text = f"Represent this sentence for searching relevant passages: {request.query}"
-    query_embedding = model.encode(query_text, normalize_embeddings=True).tolist()
+    query_embedding = _get_model().encode(query_text, normalize_embeddings=True).tolist()
 
     # ---------------- Reviewer Search ----------------
     t_rev = time.perf_counter()
@@ -838,9 +854,252 @@ def get_filters():
     }
 
 
+# ---------------------------------------------------------------------------
+#  /gdb/gap-report — Golden-DB coverage gap report
+# ---------------------------------------------------------------------------
+#
+# A *coverage gap* is a (query, expected_answer) pair in the Reviewer DB
+# (or any external Q&A source) that the Golden QA corpus has *no close
+# semantic match* for.  Identifying these gaps tells the content team which
+# new Q&A entries to author next so the Golden DB fully covers the live
+# question stream.
+#
+# Detection happens in `gdb_gap_detector.build_gap_report(...)`.  This wrapper
+# caches results in a per-process dict (so repeated dashboard refreshes
+# don't re-run the expensive DBSCAN clustering) and exposes a manual purge
+# endpoint for the admin tools.
+
+from gdb_gap_detector import (  # type: ignore  # noqa: E402
+    build_gap_report,
+    invalidate_cache as _gdb_invalidate_cache,
+)
+
+
+# Module-level cache.  Keys are (similarity_threshold, min_samples,
+# lookback_days) tuples – any change to the inputs invalidates the entry.
+# Values are the raw dict produced by build_gap_report().
+_GAP_REPORT_CACHE: dict[tuple, dict] = {}
+
+
+def _build_gap_report(
+    *,
+    similarity_threshold: float,
+    min_samples: int,
+    lookback_days: int | None,
+) -> dict:
+    """Build (or return cached) gap report.
+
+    ``similarity_threshold`` is the cosine similarity used by the DBSCAN
+    clustering step (higher = tighter clusters).  ``min_samples`` is the
+    DBSCAN minimum-cluster-size parameter (noise is promoted to singletons
+    so nothing is silently dropped).  ``lookback_days`` caps the reviewer
+    candidates considered by the disclaimer fetch step.
+    """
+    cache_key = (similarity_threshold, min_samples, lookback_days)
+    cached = _GAP_REPORT_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    t0 = time.perf_counter()
+    log.info(
+        "[/gdb/gap-report] computing: threshold=%.2f min_samples=%d lookback_days=%s",
+        similarity_threshold, min_samples, lookback_days,
+    )
+
+    kwargs = dict(
+        review_collection=reviewer_collection,
+        review_golden_collection=golden_qa_collection,
+        review_pop_collection=golden_pop_collection,
+        embed_fn=_get_model().encode,
+        similarity_threshold=similarity_threshold,
+        min_samples=min_samples,
+    )
+    if lookback_days is not None:
+        kwargs["lookback_days"] = lookback_days
+    report = build_gap_report(**kwargs)
+
+    log.info(
+        "[/gdb/gap-report] clusters=%d queries=%d (%.0fms)",
+        report.get("total_clusters_found", 0),
+        report.get("total_queries_analyzed", 0),
+        (time.perf_counter() - t0) * 1000,
+    )
+
+    _GAP_REPORT_CACHE[cache_key] = report
+    return report
+
+
+class GapReportRequest(BaseModel):
+    """Tunable parameters for ``POST /gdb/gap-report``.
+
+    All fields are optional and default to values that match the
+    ``gdb_gap_detector`` module defaults.
+    """
+
+    similarity_threshold: float = 0.85
+    min_samples: int = 2
+    lookback_days: int | None = None
+    refresh: bool = False
+
+
+@app.post("/gdb/gap-report")
+def gdb_gap_report(request: GapReportRequest):
+    """Return the Golden-DB coverage-gap report.
+
+    Wraps :func:`gdb_gap_detector.build_gap_report`.  Body fields are all
+    optional; defaults match the detector module.  Pass ``refresh=true``
+    to drop the in-process cache before rebuilding.
+    """
+    if not (0.0 <= request.similarity_threshold <= 1.0):
+        raise HTTPException(
+            status_code=400,
+            detail="similarity_threshold must be in [0, 1]",
+        )
+    if request.min_samples < 1 or request.min_samples > 50:
+        raise HTTPException(status_code=400, detail="min_samples must be in [1, 50]")
+    if request.lookback_days is not None and request.lookback_days < 1:
+        raise HTTPException(status_code=400, detail="lookback_days must be >= 1")
+
+    if request.refresh:
+        # Drop every cached report so the next call rebuilds from Mongo.
+        _GAP_REPORT_CACHE.clear()
+        _gdb_invalidate_cache()
+        log.info("[/gdb/gap-report] cache cleared via refresh=true")
+
+    try:
+        report = _build_gap_report(
+            similarity_threshold=request.similarity_threshold,
+            min_samples=request.min_samples,
+            lookback_days=request.lookback_days,
+        )
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve))
+    except Exception as e:
+        log.exception("[/gdb/gap-report] failed: %s", e)
+        raise HTTPException(status_code=500, detail=f"gap report failed: {e}")
+
+    return report
+
+
+@app.post("/gdb/refresh")
+def gdb_refresh():
+    """Drop the in-process gap-report cache (and the detector module's own
+    cache).  The next ``/gdb/gap-report`` call will rebuild from Mongo.
+    Intended for ops use after the content team has authored new Golden
+    Q&A entries or after a fresh back-fill of reviewer ``tag`` data."""
+    _GAP_REPORT_CACHE.clear()
+    _gdb_invalidate_cache()
+    return {"status": "ok", "cache_cleared": True}
+
+
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# GDB gap-detector weekly scheduler wiring
+# ---------------------------------------------------------------------------
+# The scheduler is opt-in via env vars.  See ``gap_scheduler.py`` for the
+# full configuration reference.  Importing the module here is safe — it
+# performs no work until :func:`start` is called.
+
+_scheduler_started = False
+
+
+# Bearer-token auth shared by every /gdb/scheduler/* mutation endpoint.
+# Lives in a sibling module so the FastAPI dep graph stays light and so
+# tests can exercise it in isolation.  When ``GDB_SCHEDULER_ADMIN_TOKEN``
+# is unset, every call to this dependency returns 503 — fail-closed.
+try:
+    from gap_scheduler_auth import require_bearer_token as _require_admin
+except Exception:  # pragma: no cover - only on broken installs
+    def _require_admin():
+        raise HTTPException(
+            status_code=503,
+            detail="admin endpoints disabled: gap_scheduler_auth not available",
+        )
+
+
+@app.on_event("startup")
+def _gdb_start_scheduler() -> None:
+    """Try to start the in-process GDB gap-detector scheduler.
+
+    All guards (test environment, force-disable flag, multi-worker gating,
+    Mongo leader lock) live inside ``GapScheduler.start`` and are logged
+    with ``reason=...`` so operators can grep for skips.  This function
+    never raises, so it cannot crash the FastAPI app.
+    """
+    global _scheduler_started
+    if _scheduler_started:
+        return
+    try:
+        import gap_scheduler  # local import to avoid module-load side effects
+        ok = gap_scheduler.get_default_scheduler().start()
+        _scheduler_started = ok
+    except Exception as e:  # pragma: no cover - defensive
+        log.error(f"[gdb-scheduler] startup hook failed: {e}")
+
+
+@app.on_event("shutdown")
+def _gdb_stop_scheduler() -> None:
+    try:
+        import gap_scheduler
+        gap_scheduler.get_default_scheduler().stop()
+    except Exception:  # pragma: no cover
+        pass
+
+
+@app.get("/gdb/scheduler/state", dependencies=[Depends(_require_admin)])
+def _gdb_scheduler_state():
+    """Operational snapshot for the gap-detector scheduler.
+
+    Protected by ``GDB_SCHEDULER_ADMIN_TOKEN`` (bearer token).  Returns
+    503 when the server has no token configured (fail-closed).
+    """
+    try:
+        import gap_scheduler
+        return gap_scheduler.get_default_scheduler().state()
+    except Exception as e:  # pragma: no cover - defensive
+        return {"error": str(e)}
+
+
+@app.post("/gdb/scheduler/run-now", dependencies=[Depends(_require_admin)])
+def _gdb_scheduler_run_now():
+    """Operator escape-hatch: run a single report pass immediately.
+
+    Protected by ``GDB_SCHEDULER_ADMIN_TOKEN``.  This endpoint triggers
+    real embedding work and Mongo load, so it must not be public.
+    """
+    try:
+        import gap_scheduler
+        result = gap_scheduler.get_default_scheduler().run_now()
+        return {
+            "success": result.success,
+            "duration_ms": result.duration_ms,
+            "queries_analyzed": result.queries_analyzed,
+            "clusters": result.clusters,
+            "priority_gaps": result.priority_gaps,
+            "report_id": result.report_id,
+            "error": result.error,
+        }
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@app.post("/gdb/scheduler/invalidate-cache", dependencies=[Depends(_require_admin)])
+def _gdb_scheduler_invalidate_cache():
+    """Drop the in-process and HTTP caches for the gap report.
+
+    Protected by ``GDB_SCHEDULER_ADMIN_TOKEN``.  Returns 401 / 503 when
+    the caller is unauthenticated or the server has no token configured.
+    """
+    try:
+        import gap_scheduler
+        gap_scheduler.get_default_scheduler().invalidate_cache()
+        return {"invalidated": True}
+    except Exception as e:
+        return {"invalidated": False, "error": str(e)}
 
 
 if __name__ == "__main__":

--- a/apis/acc_api/requirements.txt
+++ b/apis/acc_api/requirements.txt
@@ -4,3 +4,12 @@ pymongo>=4.7.0
 sentence-transformers>=3.0.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0
+
+# Optional dependency used by gap_scheduler.py.  Absent only disables the
+# in-process scheduler; operators can still trigger reports manually via
+# the /gdb/scheduler/run-now HTTP endpoint or run_now() API.
+schedule>=1.2.0
+
+# Test-time dep that the scheduler tests also rely on.  pytest>=7.
+pytest>=7.4.0
+pytest-mock>=3.14.0

--- a/apis/acc_api/tests/conftest.py
+++ b/apis/acc_api/tests/conftest.py
@@ -1,0 +1,485 @@
+"""
+Shared pytest fixtures for the GDB Coverage Gap Detector test suite.
+
+Goals
+-----
+* Deterministic — no randomness, no real clocks.
+* No network — every MongoDB call and embedding call goes through
+  in-process fakes that live entirely inside the test process.
+* No SentenceTransformer download — the module never imports
+  ``sentence_transformers`` (only ``main.py`` does, and that is patched
+  per test).
+
+A single fixed clock is shared across every test (``FIXED_NOW``) so that
+ISO-week arithmetic, lookback windows, and demand windows stay stable
+across operating systems and time zones.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub heavy / external dependencies BEFORE importing ``main``.
+# ---------------------------------------------------------------------------
+#
+# ``main.py`` does ``from sentence_transformers import SentenceTransformer``
+# at module scope.  The real package is multi-megabyte, network-dependent,
+# and never instantiated by these tests (the lazy loader ``_get_model`` is
+# patched per-test).  Installing a tiny stub here lets the module import
+# without ever loading the real package.
+
+def _install_sentence_transformers_stub() -> None:
+    if "sentence_transformers" in sys.modules:
+        return
+    mod = types.ModuleType("sentence_transformers")
+
+    class _StubSentenceTransformer:  # pragma: no cover - never instantiated
+        def __init__(self, *a, **kw):
+            raise RuntimeError(
+                "SentenceTransformer must not be instantiated in tests; "
+                "main._get_model should be patched."
+            )
+
+    mod.SentenceTransformer = _StubSentenceTransformer  # type: ignore[attr-defined]
+    sys.modules["sentence_transformers"] = mod
+
+
+_install_sentence_transformers_stub()
+
+# ---------------------------------------------------------------------------
+# Path / import hooks
+# ---------------------------------------------------------------------------
+
+# Make sure ``import gdb_gap_detector`` and ``import main`` work no matter
+# where pytest is invoked from.
+_TEST_DIR = Path(__file__).resolve().parent
+ACC_API_DIR = _TEST_DIR.parent
+if str(ACC_API_DIR) not in sys.path:
+    sys.path.insert(0, str(ACC_API_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Anchored mid-2026 so the same ISO weeks ("2026-W30") appear on every CI
+# runner but the date is recent enough to exercise the 7/14-day windows
+# used by the detector.
+FIXED_NOW: datetime = datetime(2026, 7, 28, 6, 30, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fake embedding model
+# ---------------------------------------------------------------------------
+
+def _make_token_embed_fn() -> "callable":
+    """Return a deterministic ``(list[str]) -> np.ndarray`` callable.
+
+    Implementation notes
+    --------------------
+    * The vocabulary is built from the *set of whitespace tokens* seen
+      across all calls.  Two texts sharing the same set of tokens yield
+      identical (post-L2) embeddings, so DBSCAN with eps = 1 - threshold
+      treats them as members of the same cluster.
+    * Distinct sets of tokens produce orthogonal (in normalised space)
+      vectors, so dissimilar texts land in different clusters.
+    """
+
+    vocab: dict[str, int] = {}
+
+    def _embed(texts: list[str]) -> np.ndarray:
+        if not texts:
+            # Match the detector's empty-shape contract exactly.
+            return np.zeros((0, 8), dtype=np.float32)
+        for t in texts:
+            for tok in t.split():
+                if tok not in vocab:
+                    vocab[tok] = len(vocab)
+        dim = max(len(vocab), 8)
+        out = np.zeros((len(texts), dim), dtype=np.float32)
+        for i, t in enumerate(texts):
+            for tok in t.split():
+                out[i, vocab[tok]] = 1.0
+        return out
+
+    return _embed
+
+
+# ---------------------------------------------------------------------------
+# Fake Mongo collections
+# ---------------------------------------------------------------------------
+
+class _FakeCursor:
+    """Minimal iterable cursor returned by ``FakeCollection.find``."""
+
+    def __init__(self, docs: list[dict]):
+        self._docs = list(docs)
+
+    def __iter__(self):
+        return iter(self._docs)
+
+
+class FakeCollection:
+    """In-process stand-in for a MongoDB collection.
+
+    The detector module only calls:
+
+    * ``collection.find(query, projection)`` returning an iterable
+    * ``collection.count_documents(filter)`` (golden collection)
+    * ``collection.aggregate(pipeline)`` (golden collection, optional)
+
+    This class implements just enough of each to run the pipeline end-to-end
+    while letting the tests assert on what arguments were used and what
+    results were returned.
+    """
+
+    def __init__(
+        self,
+        docs: list[dict] | None = None,
+        counts: dict[Any, int] | None = None,
+        aggregations: dict[Any, list[dict]] | None = None,
+    ) -> None:
+        # Always-include fallback (the test can also push docs directly
+        # via ``docs_list.extend([...])``).
+        self.docs: list[dict] = list(docs or [])
+        self.counts = counts or {}
+        self.aggregations = aggregations or {}
+        self.find_calls: list[tuple[dict, dict | None]] = []
+        self.count_calls: list[dict] = []
+        self.aggregate_calls: list[list[dict]] = []
+
+    # The detector always passes ``projection={"_id": 0, ...}`` and then
+    # filters the documents in memory based on the structured query that
+    # was just executed.  For unit tests we only need to know *what* was
+    # queried and return whatever docs are currently registered — the
+    # detector itself is responsible for correctness.
+    def find(self, query: dict, projection: dict | None = None) -> _FakeCursor:
+        self.find_calls.append((dict(query), dict(projection) if projection else None))
+        return _FakeCursor(self._apply(query))
+
+    def count_documents(self, filt: dict, **kwargs: Any) -> int:
+        self.count_calls.append(dict(filt))
+        # Exact key hit wins.
+        for k, v in self.counts.items():
+            if _matches_filter(k, filt):
+                return v
+        # Fallback "*" entries match any filter.
+        return self.counts.get("*", 0)
+
+    def aggregate(self, pipeline: list[dict], **kwargs: Any) -> list[dict]:
+        self.aggregate_calls.append([dict(stage) for stage in pipeline])
+        for k, v in self.aggregations.items():
+            if _matches_pipeline(k, pipeline):
+                return list(v)
+        return []
+
+    def _apply(self, query: dict) -> list[dict]:
+        """Return the docs that satisfy ``query`` — permissive by design."""
+        if not query:
+            return list(self.docs)
+        clauses = query.get("$and") or []
+        if not clauses:
+            return list(self.docs)
+        out = []
+        for doc in self.docs:
+            if all(_doc_matches(doc, clause) for clause in clauses):
+                out.append(doc)
+        return out
+
+
+def _matches_filter(test_filter: Any, real_filter: Any) -> bool:
+    """Loose structural equality on dicts — sufficient for unit tests."""
+    return _canonical(test_filter) == _canonical(real_filter)
+
+
+def _matches_pipeline(test_pipe: Any, real_pipe: Any) -> bool:
+    return _canonical(test_pipe) == _canonical(real_pipe)
+
+
+def _canonical(obj: Any) -> Any:
+    """Sort dict keys recursively so two structurally-equal objects match."""
+    if isinstance(obj, dict):
+        return tuple(sorted((k, _canonical(v)) for k, v in obj.items()))
+    if isinstance(obj, list):
+        return tuple(_canonical(v) for v in obj)
+    return obj
+
+
+def _doc_matches(doc: dict, clause: dict) -> bool:
+    """Best-effort Mongo query match used by the in-process fake.
+
+    Implements just enough of Mongo's query operators to handle the
+    shapes built by ``gdb_gap_detector.fetch_disclaimer_queries``
+    (``$and`` of ``$or`` blocks) — and falls back to "always matches" for
+    anything we don't explicitly recognise.  Per-document correctness is
+    the responsibility of the tests, which simply seed ``FakeCollection.docs``
+    with the documents they want back.
+    """
+
+    # $and must be flattened by the caller; nothing to do here.
+    if not isinstance(clause, dict):
+        return True
+
+    # $or — match if any sub-clause matches.
+    ors = clause.get("$or")
+    if ors:
+        return any(_doc_matches(doc, sub) for sub in ors)
+
+    for field, val in clause.items():
+        if field.startswith("$"):
+            continue
+        actual = doc.get(field)
+        if isinstance(val, dict):
+            if "$in" in val:
+                if not _in(actual, val["$in"]):
+                    return False
+                continue
+            if "$exists" in val:
+                if bool(val["$exists"]) != (field in doc):
+                    return False
+                continue
+            if "$ne" in val:
+                if actual == val["$ne"]:
+                    return False
+                continue
+            if "$not" in val:
+                continue  # permissive
+            if "$gte" in val:
+                if not isinstance(actual, datetime) or actual < val["$gte"]:
+                    return False
+                continue
+            if "$type" in val:
+                continue
+            if "$regex" in val:
+                continue
+            # Unknown operator — be permissive so unit tests don't get
+            # blocked on a single edge case.
+            continue
+        # Scalar equality — treat missing key as failure.
+        if actual != val:
+            return False
+    return True
+
+
+def _in(actual: Any, candidates: list[Any]) -> bool:
+    if actual is None:
+        return False
+    return any(actual == c for c in candidates)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fixed_now() -> datetime:
+    """The single timestamp used as the *clock* for every test."""
+    return FIXED_NOW
+
+
+@pytest.fixture
+def now_fn(fixed_now):
+    """Return a no-arg callable that always returns ``fixed_now``."""
+    return lambda: fixed_now
+
+
+@pytest.fixture
+def fake_embed_fn():
+    """Return a deterministic embed callable (vocab is per-call)."""
+    return _make_token_embed_fn()
+
+
+@pytest.fixture
+def fake_sentence_transformer(fake_embed_fn):
+    """A stand-in for ``SentenceTransformer`` whose ``.encode`` is the
+    same deterministic function used above."""
+
+    class _FakeST:
+        encode = staticmethod(fake_embed_fn)
+
+    return _FakeST()
+
+
+@pytest.fixture
+def review_collection() -> FakeCollection:
+    """Empty reviewer collection — tests inject docs as needed."""
+    return FakeCollection()
+
+
+@pytest.fixture
+def golden_collection() -> FakeCollection:
+    """Empty golden collection — tests inject ``counts`` as needed."""
+    return FakeCollection()
+
+
+# ---------------------------------------------------------------------------
+# Endpoint test fixtures (no live Mongo, no SentenceTransformer)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def patched_main(monkeypatch, fake_sentence_transformer):
+    """Import ``main`` with ``MongoClient`` + ``_get_model`` patched.
+
+    Yields the freshly-imported module so the test can poke at the
+    FastAPI app and the in-process cache.
+    """
+
+    # Make sure the env never tries to connect to a real MongoDB when
+    # ``main`` is imported.
+    monkeypatch.setenv("MONGO_URI", "mongodb://test-host:27017")
+    monkeypatch.setenv("GOLDEN_MONGO_URI", "mongodb://test-host:27017")
+    monkeypatch.setenv("DB_NAME", "agriai")
+    monkeypatch.setenv("GOLDEN_DB_NAME", "golden_db")
+    monkeypatch.setenv("COLLECTION_NAME", "questions")
+    monkeypatch.setenv("GOLDEN_QA_COLLECTION", "agri_qa_latest")
+    monkeypatch.setenv("GOLDEN_POP_COLLECTION", "pop")
+
+    # Stub MongoClient so module-level imports succeed without a server.
+    class _StubClient:
+        def __init__(self, *a, **kw):
+            self._closed = False
+
+        def __getitem__(self, name):
+            return _StubDB(name)
+
+        def close(self):
+            self._closed = True
+
+    class _StubDB:
+        def __init__(self, name):
+            self.name = name
+
+        def __getitem__(self, name):
+            return _StubCollection(name)
+
+    class _StubCollection:
+        def __init__(self, name):
+            self.name = name
+
+        def find(self, *a, **kw):
+            return iter([])
+
+        def count_documents(self, *a, **kw):
+            return 0
+
+        def aggregate(self, *a, **kw):
+            return []
+
+        def insert_many(self, docs, *a, **kw):
+            return None
+
+    monkeypatch.setattr("pymongo.MongoClient", _StubClient)
+
+    # Now import main.
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    import main as main_module  # type: ignore
+
+    # Replace the lazy model loader with our deterministic fake.
+    monkeypatch.setattr(main_module, "_get_model",
+                        lambda: fake_sentence_transformer)
+
+    # Clear both caches so each test starts from a known state.
+    main_module._GAP_REPORT_CACHE.clear()
+    main_module._gdb_invalidate_cache()  # type: ignore[attr-defined]
+
+    # Replace the module-level collection globals with FakeCollections so
+    # the pipeline can be exercised end-to-end without any Mongo traffic.
+    monkeypatch.setattr(main_module, "reviewer_collection",
+                        FakeCollection())
+    monkeypatch.setattr(main_module, "golden_qa_collection",
+                        FakeCollection())
+    monkeypatch.setattr(main_module, "golden_pop_collection",
+                        FakeCollection())
+    monkeypatch.setattr(main_module, "answers_collection",
+                        FakeCollection())
+    monkeypatch.setattr(main_module, "users_collection",
+                        FakeCollection())
+
+    return main_module
+
+
+@pytest.fixture
+def app_client(patched_main):
+    """Return a FastAPI ``TestClient`` wired to the patched ``main`` app."""
+    from fastapi.testclient import TestClient
+
+    return TestClient(patched_main.app)
+
+
+@pytest.fixture
+def client(app_client):
+    """Convenience alias for ``app_client`` (matches FastAPI conventions)."""
+    return app_client
+
+
+@pytest.fixture
+def seed_reviews(fixed_now):
+    """Return a small, deterministic corpus of reviewer-questions docs.
+
+    The corpus is what the detector end-to-end test consumes.  Layout:
+
+    * cluster A — "wheat rust punjab" (3 docs: 2 current-week, 1 prior)
+    * cluster B — "paddy water bihar" (2 docs: both current-week)
+    * noise   — "scheme loan pmkisan" (1 current-week doc — singleton)
+    """
+
+    cluster_a = [
+        {
+            "text": "wheat rust control in punjab",
+            "details": {"crop": "Wheat", "state": "Punjab",
+                        "domain": "pest"},
+            "created_at": fixed_now - timedelta(days=1),
+            "tag": "AJRASAKHA_DISCLAIMER",
+        },
+        {
+            "text": "wheat rust control in punjab",
+            "details": {"crop": "Wheat", "state": "Punjab",
+                        "domain": "pest"},
+            "created_at": fixed_now - timedelta(days=3),
+            "tag": "AJRASAKHA_DISCLAIMER",
+        },
+        {
+            "text": "wheat rust control in punjab",
+            "details": {"crop": "Wheat", "state": "Punjab",
+                        "domain": "pest"},
+            "created_at": fixed_now - timedelta(days=10),
+            "tag": "AJRASAKHA_DISCLAIMER",
+        },
+    ]
+    cluster_b = [
+        {
+            "text": "paddy water management in bihar",
+            "details": {"crop": "Paddy", "state": "Bihar",
+                        "domain": "water"},
+            "created_at": fixed_now - timedelta(days=2),
+            "tag": "AJRASAKHA_DISCLAIMER",
+        },
+        {
+            "text": "paddy water management in bihar",
+            "details": {"crop": "Paddy", "state": "Bihar",
+                        "domain": "water"},
+            "created_at": fixed_now - timedelta(days=4),
+            "tag": "AJRASAKHA_DISCLAIMER",
+        },
+    ]
+    noise = [
+        {
+            "text": "scheme loan pm kisan",
+            "details": {"crop": "Wheat", "state": "Punjab",
+                        "domain": "scheme"},
+            "created_at": fixed_now - timedelta(days=1),
+            "tag": "AJRASAKHA_DISCLAIMER",
+        },
+    ]
+    return {"A": cluster_a, "B": cluster_b, "noise": noise}

--- a/apis/acc_api/tests/test_gap_scheduler.py
+++ b/apis/acc_api/tests/test_gap_scheduler.py
@@ -1,0 +1,651 @@
+"""
+Unit tests for ``apis/acc_api/gap_scheduler.py``.
+
+These tests focus on the operational guard surface: env-var parsing,
+disabled behaviour, test-environment refusal, multi-worker gating,
+and the ``run_once`` plumbing around the detector.
+
+The tests never touch a real MongoDB or SentenceTransformer; they
+inject a ``collection_provider`` and an ``embed_fn`` so the scheduler
+logic can be exercised in isolation.  ``build_gap_report`` is also
+stubbed so we don't reach the real detector.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_HERE = os.path.dirname(__file__)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+_APIS = os.path.abspath(os.path.join(_HERE, ".."))
+if _APIS not in sys.path:
+    sys.path.insert(0, _APIS)
+
+
+# ---------------------------------------------------------------------------
+# Env-var helpers
+# ---------------------------------------------------------------------------
+
+_SCHEDULER_KEYS = (
+    "GDB_SCHEDULER_ENABLED",
+    "GDB_SCHEDULER_FORCE_DISABLE",
+    "GDB_SCHEDULER_CRON",
+    "GDB_SCHEDULER_LOOKBACK_DAYS",
+    "GDB_SCHEDULER_SIMILARITY_THRESHOLD",
+    "GDB_SCHEDULER_MIN_SAMPLES",
+    "GDB_REPORT_CACHE_TTL",
+    "GDB_SCHEDULER_WORKER_ID",
+    "GDB_SCHEDULER_LEADER_WORKERS",
+    "MONGO_URI",
+    "PYTEST_CURRENT_TEST",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_scheduler_env(monkeypatch):
+    """Wipe scheduler env vars before each test and reload modules."""
+    for key in _SCHEDULER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    # Drop and re-import both modules so module-level ``load_dotenv``
+    # picks up the freshly-cleared environment.
+    for name in ("gap_scheduler", "gap_metrics"):
+        if name in sys.modules:
+            del sys.modules[name]
+    import gap_metrics  # noqa: F401
+    import gap_scheduler  # noqa: F401
+    yield
+
+
+def _import_scheduler():
+    """Re-import the scheduler module."""
+    if "gap_scheduler" in sys.modules:
+        return importlib.reload(sys.modules["gap_scheduler"])
+    return importlib.import_module("gap_scheduler")
+
+
+# ---------------------------------------------------------------------------
+# Configuration tests
+# ---------------------------------------------------------------------------
+
+class TestSchedulerConfig:
+
+    def test_defaults_when_nothing_set(self):
+        gap_scheduler = _import_scheduler()
+        cfg = gap_scheduler.SchedulerConfig.from_env()
+        assert cfg.enabled is False
+        assert cfg.force_disable is False
+        assert cfg.cron == "0 2 * * 1"
+        assert cfg.lookback_days == 90
+        assert cfg.similarity_threshold == 0.85
+        assert cfg.min_samples == 2
+        assert cfg.cache_ttl_seconds == 900
+        assert cfg.worker_id == 0
+        assert cfg.leader_workers == (0,)
+
+    def test_enabled_flag_from_env(self, monkeypatch):
+        monkeypatch.setenv("GDB_SCHEDULER_ENABLED", "true")
+        gap_scheduler = _import_scheduler()
+        cfg = gap_scheduler.SchedulerConfig.from_env()
+        assert cfg.enabled is True
+
+    def test_force_disable_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("GDB_SCHEDULER_ENABLED", "true")
+        monkeypatch.setenv("GDB_SCHEDULER_FORCE_DISABLE", "true")
+        gap_scheduler = _import_scheduler()
+        cfg = gap_scheduler.SchedulerConfig.from_env()
+        assert cfg.enabled is True
+        assert cfg.force_disable is True
+        ok, reason = gap_scheduler.config_passes_basic_guards(cfg)
+        assert ok is False
+        assert reason == "force_disable=true"
+
+    def test_numeric_parsing_and_fallback(self, monkeypatch):
+        monkeypatch.setenv("GDB_SCHEDULER_LOOKBACK_DAYS", "30")
+        monkeypatch.setenv("GDB_SCHEDULER_SIMILARITY_THRESHOLD", "0.92")
+        monkeypatch.setenv("GDB_SCHEDULER_MIN_SAMPLES", "5")
+        monkeypatch.setenv("GDB_REPORT_CACHE_TTL", "600")
+        monkeypatch.setenv("GDB_SCHEDULER_WORKER_ID", "2")
+        monkeypatch.setenv("GDB_SCHEDULER_LEADER_WORKERS", "0,1,2")
+        gap_scheduler = _import_scheduler()
+        cfg = gap_scheduler.SchedulerConfig.from_env()
+        assert cfg.lookback_days == 30
+        assert cfg.similarity_threshold == 0.92
+        assert cfg.min_samples == 5
+        assert cfg.cache_ttl_seconds == 600
+        assert cfg.worker_id == 2
+        assert cfg.leader_workers == (0, 1, 2)
+
+    def test_invalid_numeric_falls_back_with_warning(self, monkeypatch):
+        monkeypatch.setenv("GDB_SCHEDULER_LOOKBACK_DAYS", "not-a-number")
+        monkeypatch.setenv("GDB_SCHEDULER_LEADER_WORKERS", "garbage")
+        gap_scheduler = _import_scheduler()
+        cfg = gap_scheduler.SchedulerConfig.from_env()
+        assert cfg.lookback_days == 90
+        assert cfg.leader_workers == (0,)
+
+    def test_is_worker_leader_helper(self):
+        gap_scheduler = _import_scheduler()
+        cfg = gap_scheduler.SchedulerConfig(worker_id=0, leader_workers=(0,))
+        assert gap_scheduler.is_worker_leader(cfg) is True
+        cfg2 = gap_scheduler.SchedulerConfig(worker_id=1, leader_workers=(0,))
+        assert gap_scheduler.is_worker_leader(cfg2) is False
+
+    def test_config_basic_guards(self):
+        gap_scheduler = _import_scheduler()
+        # Disabled by default.
+        cfg = gap_scheduler.SchedulerConfig()
+        ok, reason = gap_scheduler.config_passes_basic_guards(cfg)
+        assert ok is False and reason == "enabled=false"
+
+        # Force disable is reported separately.
+        cfg2 = gap_scheduler.SchedulerConfig(enabled=True, force_disable=True)
+        ok, reason = gap_scheduler.config_passes_basic_guards(cfg2)
+        assert ok is False and reason == "force_disable=true"
+
+        # Out-of-range similarity threshold fails.
+        cfg3 = gap_scheduler.SchedulerConfig(enabled=True,
+                                             similarity_threshold=1.5)
+        ok, reason = gap_scheduler.config_passes_basic_guards(cfg3)
+        assert ok is False and "similarity_threshold" in reason
+
+        # Out-of-range min_samples fails.
+        cfg4 = gap_scheduler.SchedulerConfig(enabled=True, min_samples=0)
+        ok, reason = gap_scheduler.config_passes_basic_guards(cfg4)
+        assert ok is False and "min_samples" in reason
+
+        # Lookback must be >= 1.
+        cfg5 = gap_scheduler.SchedulerConfig(enabled=True, lookback_days=0)
+        ok, reason = gap_scheduler.config_passes_basic_guards(cfg5)
+        assert ok is False and "lookback_days" in reason
+
+        # Non-leader worker fails.
+        cfg6 = gap_scheduler.SchedulerConfig(enabled=True, worker_id=3,
+                                             leader_workers=(0,))
+        ok, reason = gap_scheduler.config_passes_basic_guards(cfg6)
+        assert ok is False and "worker_id" in reason
+
+        # The happy path.
+        ok, _ = gap_scheduler.config_passes_basic_guards(
+            gap_scheduler.SchedulerConfig(enabled=True))
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Disabled behaviour tests
+# ---------------------------------------------------------------------------
+
+class TestSchedulerDisabled:
+
+    def test_start_is_noop_when_enabled_flag_is_false(self, monkeypatch):
+        monkeypatch.setenv("GDB_SCHEDULER_ENABLED", "false")
+        gap_scheduler = _import_scheduler()
+        s = gap_scheduler.GapScheduler()
+        assert s.start() is False
+        assert s.state()["running"] is False
+        s.stop()
+
+    def test_start_skips_in_test_environment(self, monkeypatch):
+        monkeypatch.setenv("GDB_SCHEDULER_ENABLED", "true")
+        monkeypatch.setenv("PYTEST_CURRENT_TEST",
+                          "test_gap_scheduler.py::test_x")
+        gap_scheduler = _import_scheduler()
+        s = gap_scheduler.GapScheduler()
+        assert s.start() is False
+        assert s.state()["pytest_detected"] is True
+        s.stop()
+
+    def test_start_skips_on_non_leader_worker(self, monkeypatch):
+        monkeypatch.setenv("GDB_SCHEDULER_ENABLED", "true")
+        monkeypatch.setenv("GDB_SCHEDULER_WORKER_ID", "3")
+        monkeypatch.setenv("GDB_SCHEDULER_LEADER_WORKERS", "0,1")
+        gap_scheduler = _import_scheduler()
+        s = gap_scheduler.GapScheduler()
+        assert s.start() is False
+        s.stop()
+
+
+# ---------------------------------------------------------------------------
+# run_once plumbing
+# ---------------------------------------------------------------------------
+
+class _FakeCollection:
+    def __init__(self, *a, **kw):
+        pass
+
+
+def _fake_embed_fn(texts):
+    """A no-frills deterministic embed function."""
+    return np.zeros((len(texts), 8), dtype=np.float32)
+
+
+def _install_stub_build_gap_report(monkeypatch, return_value: dict | None = None,
+                                   raises: Exception | None = None):
+    gap_scheduler = _import_scheduler()
+
+    if return_value is None:
+        return_value = {
+            "report_id": "stub-report",
+            "total_queries_analyzed": 7,
+            "total_clusters_found": 3,
+            "gaps_by_priority": {
+                "critical": 1, "high": 1, "medium": 1, "low": 0,
+            },
+            "clusters": [],
+        }
+
+    if raises is None:
+        def _stub(*args, **kwargs):
+            return dict(return_value)
+        stub = MagicMock(side_effect=_stub)
+    else:
+        stub = MagicMock(side_effect=raises)
+
+    monkeypatch.setattr(gap_scheduler, "build_gap_report", stub)
+    return gap_scheduler, stub
+
+
+class TestRunOnce:
+
+    def test_run_once_calls_build_gap_report_with_correct_kwargs(self, monkeypatch):
+        gap_scheduler, stub = _install_stub_build_gap_report(monkeypatch)
+
+        result = gap_scheduler.run_once(
+            trigger="manual",
+            collection_provider=lambda: (_FakeCollection(), _FakeCollection(),
+                                         _FakeCollection()),
+            similarity_threshold=0.9,
+            min_samples=3,
+            lookback_days=42,
+            embed_fn=_fake_embed_fn,
+        )
+
+        assert result.success is True
+        assert stub.call_count == 1
+        kwargs = stub.call_args.kwargs
+        assert kwargs["similarity_threshold"] == 0.9
+        assert kwargs["min_samples"] == 3
+        assert kwargs["lookback_days"] == 42
+        assert result.queries_analyzed == 7
+        assert result.clusters == 3
+        assert result.priority_gaps == {"critical": 1, "high": 1,
+                                        "medium": 1, "low": 0}
+        assert result.report_id == "stub-report"
+
+    def test_run_once_records_metrics(self, monkeypatch):
+        gap_scheduler, _ = _install_stub_build_gap_report(monkeypatch)
+
+        events: list[tuple[str, dict]] = []
+        gap_metrics = sys.modules["gap_metrics"]
+        gap_metrics.register_backend(lambda n, p: events.append((n, p)))
+
+        try:
+            gap_scheduler.run_once(
+                trigger="manual",
+                collection_provider=lambda: (_FakeCollection(), _FakeCollection(),
+                                             _FakeCollection()),
+                embed_fn=_fake_embed_fn,
+            )
+
+            names = {n for n, _ in events}
+            assert "gap_report_start" in names
+            assert "gap_report_run" in names
+
+            run_payload = next(p for n, p in events if n == "gap_report_run")
+            assert run_payload["success"] is True
+            assert run_payload["queries_analyzed"] == 7
+            assert run_payload["clusters"] == 3
+            assert run_payload["trigger"] == "manual"
+            assert run_payload["priority_gaps"]["critical"] == 1
+            assert run_payload["duration_ms"] >= 0
+        finally:
+            gap_metrics.clear_backends()
+
+    def test_run_once_records_failure_when_detector_raises(self, monkeypatch):
+        gap_scheduler, _ = _install_stub_build_gap_report(
+            monkeypatch, raises=RuntimeError("synthetic boom"))
+
+        events: list[tuple[str, dict]] = []
+        gap_metrics = sys.modules["gap_metrics"]
+        gap_metrics.register_backend(lambda n, p: events.append((n, p)))
+
+        try:
+            result = gap_scheduler.run_once(
+                trigger="manual",
+                collection_provider=lambda: (_FakeCollection(), _FakeCollection(),
+                                             _FakeCollection()),
+                embed_fn=_fake_embed_fn,
+            )
+            assert result.success is False
+            assert "synthetic boom" in (result.error or "")
+
+            names = {n for n, _ in events}
+            assert "gap_report_failure" in names
+            fail_payload = next(p for n, p in events if n == "gap_report_failure")
+            assert "synthetic boom" in fail_payload["error"]
+        finally:
+            gap_metrics.clear_backends()
+
+    def test_run_now_bypasses_scheduler_guards(self, monkeypatch):
+        """``GapScheduler.run_now`` must always execute a pass, even when
+        the scheduler is disabled."""
+        gap_scheduler, _ = _install_stub_build_gap_report(monkeypatch)
+
+        s = gap_scheduler.GapScheduler()  # disabled by default
+        assert s.state()["running"] is False
+        # Inject a provider + embed_fn by monkeypatching run_once.
+        monkeypatch.setattr(s, "_collection_provider",
+                            lambda: (_FakeCollection(), _FakeCollection(),
+                                     _FakeCollection()))
+
+        # ``_embed_fn`` is a factory that returns the embed function; wrap
+        # the bare function so ``run_once`` sees a callable when it invokes
+        # the factory.
+        monkeypatch.setattr(gap_scheduler, "_embed_fn", lambda: _fake_embed_fn)
+
+        result = s.run_now()
+        assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# Metrics bus tests
+# ---------------------------------------------------------------------------
+
+class TestMetricsBus:
+
+    def test_register_and_emit(self):
+        gap_metrics = sys.modules["gap_metrics"]
+        gap_metrics.clear_backends()
+
+        received: list[tuple[str, dict]] = []
+        gap_metrics.register_backend(lambda n, p: received.append((n, p)))
+
+        gap_metrics.record_start(trigger="manual")
+        gap_metrics.record_skip(reason="disabled")
+        gap_metrics.record_failure(duration_ms=10.0, trigger="scheduled",
+                                   error="boom")
+        gap_metrics.record_run(duration_ms=42.0, queries_analyzed=3,
+                               clusters=1, priority_gaps={"high": 1},
+                               trigger="manual", success=True)
+
+        names = {n for n, _ in received}
+        assert names == {
+            "gap_report_start",
+            "gap_report_skip",
+            "gap_report_failure",
+            "gap_report_run",
+        }
+
+        fail = next(p for n, p in received if n == "gap_report_failure")
+        assert fail["error"] == "boom"
+        assert fail["trigger"] == "scheduled"
+        assert fail["duration_ms"] == 10.0
+
+    def test_backend_failure_is_swallowed(self):
+        gap_metrics = sys.modules["gap_metrics"]
+        gap_metrics.clear_backends()
+
+        def boom(name, payload):
+            raise RuntimeError("backend exploded")
+
+        gap_metrics.register_backend(boom)
+        # Must not raise even though the backend is broken.
+        gap_metrics.record_start(trigger="x")
+        gap_metrics.clear_backends()
+
+
+# ---------------------------------------------------------------------------
+# Singleton aliases
+# ---------------------------------------------------------------------------
+
+class TestSingletonAliases:
+
+    def test_get_default_scheduler_returns_singleton(self):
+        gap_scheduler = _import_scheduler()
+        gap_scheduler.reset_default_scheduler()
+        a = gap_scheduler.get_default_scheduler()
+        b = gap_scheduler.get_default_scheduler()
+        assert a is b
+        gap_scheduler.reset_default_scheduler()
+
+
+# ---------------------------------------------------------------------------
+# Cron parser
+# ---------------------------------------------------------------------------
+
+class TestCronParser:
+    """Cover ``_parse_cron`` directly.  The parser is the operator's
+    only source of truth about what cadences the in-process scheduler
+    will honour.  Every supported subset (weekly, daily) and every
+    malformed input we know about must round-trip exactly."""
+
+    def test_parse_weekly_monday_default(self):
+        gap_scheduler = _import_scheduler()
+        minute, hour, dom, month, dow = gap_scheduler._parse_cron("0 2 * * 1")
+        assert minute == 0
+        assert hour == 2
+        assert dom == "*"
+        assert month == "*"
+        assert dow == "1"
+
+    def test_parse_daily_cron(self):
+        gap_scheduler = _import_scheduler()
+        minute, hour, _dom, _month, dow = gap_scheduler._parse_cron("30 14 * * *")
+        assert minute == 30 and hour == 14 and dow == "*"
+
+    def test_parse_with_extra_fields_raises(self):
+        gap_scheduler = _import_scheduler()
+        with pytest.raises(ValueError):
+            gap_scheduler._parse_cron("0 2 * * 1 *")
+
+    def test_parse_with_too_few_fields_raises(self):
+        gap_scheduler = _import_scheduler()
+        with pytest.raises(ValueError):
+            gap_scheduler._parse_cron("0 2 * 1")
+
+
+# ---------------------------------------------------------------------------
+# Scheduled trigger path
+# ---------------------------------------------------------------------------
+
+class TestScheduledTrigger:
+    """When the ``schedule`` library fires a tick, the scheduler must
+    invoke ``run_once`` with ``trigger='scheduled'`` (not 'manual')."""
+
+    def test_schedule_weekly_job_registers_a_job(self, monkeypatch):
+        gap_scheduler = _import_scheduler()
+        sentinel = object()
+
+        # Fake out the embedded 'schedule' library so we don't depend on
+        # the real package behaving the way we expect on the test host.
+        # The production code path is:
+        #   _schedule.every().<day>.at(time).do(fn)
+        # so the fake has to support attribute access for any day-of-week.
+        calls: dict = {}
+
+        class _Doer:
+            def __init__(self):
+                pass
+
+            def do(self, fn):
+                calls.setdefault("do_fn", []).append(fn)
+                return sentinel
+
+        class _DayAtBuilder:
+            def __init__(self, day):
+                calls.setdefault("day_calls", []).append(day)
+
+            def at(self, time_str):
+                calls.setdefault("at_calls", []).append(time_str)
+                return _Doer()
+
+        class _Every:
+            def __getattr__(self, name):
+                return _DayAtBuilder(name)
+
+        class _FakeSchedule:
+            def every(self):
+                calls.setdefault("every", 0)
+                calls["every"] += 1
+                return _Every()
+
+        fake = _FakeSchedule()
+        monkeypatch.setattr(gap_scheduler, "_schedule", fake, raising=False)
+        monkeypatch.setattr(gap_scheduler, "_schedule_ok", True, raising=False)
+
+        def _runner():
+            return "ran"
+
+        gap_scheduler._schedule_weekly_job("0 2 * * 1", _runner)
+        # 1 call to every(), the dow branch ("monday") was selected,
+        # .at() was called with "02:00", and .do() received our runner.
+        assert calls["every"] == 1
+        assert calls["day_calls"] == ["monday"]
+        assert calls["at_calls"] == ["02:00"]
+        assert calls["do_fn"] == [_runner]
+        assert calls["do_fn"][0] is _runner
+
+    def test_tick_invokes_run_once_with_trigger_scheduled(self, monkeypatch):
+        """``GapScheduler._tick`` must dispatch into ``run_once`` with
+        ``trigger='scheduled'`` so the structured-log trigger field
+        distinguishes manual hits from scheduled ones.
+        """
+        gap_scheduler = _import_scheduler()
+        scheduler = gap_scheduler.GapScheduler(
+            config=gap_scheduler.SchedulerConfig(enabled=False),
+        )
+
+        captured: dict = {}
+
+        def fake_run_once(**kwargs):
+            captured.update(kwargs)
+            return gap_scheduler.RunResult(
+                success=True,
+                duration_ms=0,
+                queries_analyzed=0,
+                clusters=0,
+                priority_gaps={},
+                report_id=None,
+                error=None,
+            )
+
+        # The module-level ``run_once`` is what ``_tick`` calls.
+        monkeypatch.setattr(gap_scheduler, "run_once", fake_run_once)
+        scheduler._tick()
+        assert captured["trigger"] == "scheduled"
+
+
+# ---------------------------------------------------------------------------
+# run-now endpoint behaviour (no auth wired yet)
+# ---------------------------------------------------------------------------
+
+
+class TestRunNowEndpointShape:
+    """Smoke-test the JSON shape returned by the ``/gdb/scheduler/run-now``
+    endpoint via FastAPI's TestClient, ensuring the auth dependency
+    doesn't block us when the env var is set.
+
+    The ``main`` module creates a ``MongoClient`` at import time.  We
+    stub ``pymongo.MongoClient`` *before* the import runs so the test
+    process never reaches a real Mongo server.
+    """
+
+    def _build_client(self, monkeypatch, token_value):
+        if token_value is None:
+            monkeypatch.delenv("GDB_SCHEDULER_ADMIN_TOKEN", raising=False)
+        else:
+            monkeypatch.setenv("GDB_SCHEDULER_ADMIN_TOKEN", token_value)
+        monkeypatch.setenv("GDB_SCHEDULER_ENABLED", "false")
+        monkeypatch.setenv("GDB_SCHEDULER_FORCE_DISABLE", "true")
+
+        # Stub MongoClient at the module level so ``from pymongo import
+        # MongoClient`` in main.py sees our placeholder.
+        class _StubClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            def __getitem__(self, name):
+                class _DB:
+                    def __getitem__(self, coll):
+                        class _Coll:
+                            def find(self, *a, **kw):
+                                return iter([])
+
+                            def count_documents(self, *a, **kw):
+                                return 0
+
+                            def aggregate(self, *a, **kw):
+                                return []
+                        return _Coll()
+                return _DB()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr("pymongo.MongoClient", _StubClient)
+
+        # Drop main from sys.modules so a fresh import sees our stub.
+        for name in ("gap_scheduler_auth", "main"):
+            if name in sys.modules:
+                del sys.modules[name]
+
+        from fastapi.testclient import TestClient
+        import main  # noqa: F401
+        # conftest installs a stub for ``sentence_transformers`` whose
+        # constructor raises; if the endpoint reaches ``_get_model`` it
+        # will explode with the stub's RuntimeError.  Patch the loader
+        # to a no-op that returns a stand-in object.
+        class _FakeModel:
+            def encode(self, texts, **_):
+                import numpy as _np
+                return _np.zeros((len(texts), 8), dtype=_np.float32)
+
+        monkeypatch.setattr(main, "_get_model", lambda: _FakeModel())
+        from main import app
+        return TestClient(app)
+
+    def test_run_now_requires_token_when_configured(self, monkeypatch):
+        c = self._build_client(monkeypatch, "secret-token")
+        with c as client:
+            r = client.post("/gdb/scheduler/run-now")
+            assert r.status_code == 401
+
+    def test_run_now_with_correct_token_returns_200_shape(self, monkeypatch):
+        c = self._build_client(monkeypatch, "secret-token")
+        with c as client:
+            r = client.post(
+                "/gdb/scheduler/run-now",
+                headers={"Authorization": "Bearer secret-token"},
+            )
+            # The scheduler is force-disabled in this test, so the run is
+            # skipped — run_now returns success=False with a reason.
+            assert r.status_code == 200
+            payload = r.json()
+            for key in ("success", "duration_ms", "queries_analyzed",
+                        "clusters", "priority_gaps", "report_id", "error"):
+                assert key in payload
+
+    def test_state_endpoint_requires_token(self, monkeypatch):
+        c = self._build_client(monkeypatch, "secret-token")
+        with c as client:
+            r = client.get("/gdb/scheduler/state")
+            assert r.status_code == 401
+            assert r.headers.get("www-authenticate", "").lower() == "bearer"
+
+    def test_state_endpoint_returns_503_when_token_unset(self, monkeypatch):
+        c = self._build_client(monkeypatch, None)
+        with c as client:
+            r = client.get("/gdb/scheduler/state")
+            assert r.status_code == 503

--- a/apis/acc_api/tests/test_gap_scheduler_auth.py
+++ b/apis/acc_api/tests/test_gap_scheduler_auth.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for the admin-token auth dependency in
+``apis/acc_api/gap_scheduler_auth.py``.
+
+The dependency is the only authentication boundary between operators
+and the scheduler mutation endpoints (``run-now``,
+``invalidate-cache``, ``state``).  These tests pin every branch:
+
+* missing env var -> 503 fail-closed
+* missing token -> 401
+* wrong scheme -> 401
+* mismatched token -> 401
+* happy path -> the validated token is returned
+
+We drive the dependency directly (rather than via TestClient) so the
+tests stay fast and don't need a Mongo URI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_HERE = os.path.dirname(__file__)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+_APIS = os.path.abspath(os.path.join(_HERE, ".."))
+if _APIS not in sys.path:
+    sys.path.insert(0, _APIS)
+
+
+@pytest.fixture(autouse=True)
+def _reset_token_env(monkeypatch):
+    """Drop GDB_SCHEDULER_ADMIN_TOKEN so we control it explicitly per test."""
+    monkeypatch.delenv("GDB_SCHEDULER_ADMIN_TOKEN", raising=False)
+    if "gap_scheduler_auth" in sys.modules:
+        importlib.reload(sys.modules["gap_scheduler_auth"])
+    import gap_scheduler_auth  # noqa: F401
+    yield
+
+
+def _dep(token: str | None = None, *,
+         x_admin_token: str | None = None,
+         query_token: str | None = None,
+         token_env: str | None = "secret-token"):
+    """Invoke ``require_bearer_token`` with controllable inputs."""
+    import gap_scheduler_auth as auth
+    if token_env is not None:
+        os.environ["GDB_SCHEDULER_ADMIN_TOKEN"] = token_env
+    else:
+        os.environ.pop("GDB_SCHEDULER_ADMIN_TOKEN", None)
+    # The dependency is a function whose parameters FastAPI fills from
+    # the request; we call it directly with the same names.
+    return auth.require_bearer_token(
+        authorization=f"Bearer {token}" if token is not None else None,
+        x_admin_token=x_admin_token,
+        token=query_token,
+    )
+
+
+class TestAdminAuth:
+
+    def test_no_token_configured_returns_503(self):
+        import gap_scheduler_auth as auth
+        with pytest.raises(HTTPException) as ei:
+            auth.require_bearer_token(
+                authorization="Bearer something", x_admin_token=None, token=None,
+            )
+        assert ei.value.status_code == 503
+        assert "GDB_SCHEDULER_ADMIN_TOKEN" in ei.value.detail
+
+    def test_empty_string_in_env_is_treated_as_unconfigured(self):
+        os.environ["GDB_SCHEDULER_ADMIN_TOKEN"] = "   "
+        import gap_scheduler_auth as auth
+        importlib.reload(auth)
+        with pytest.raises(HTTPException) as ei:
+            auth.require_bearer_token(
+                authorization="Bearer anything", x_admin_token=None, token=None,
+            )
+        assert ei.value.status_code == 503
+
+    def test_missing_authorization_returns_401(self):
+        with pytest.raises(HTTPException) as ei:
+            _dep(token=None)
+        assert ei.value.status_code == 401
+        assert ei.value.headers["WWW-Authenticate"] == "Bearer"
+
+    def test_wrong_token_returns_401(self):
+        with pytest.raises(HTTPException) as ei:
+            _dep(token="not-the-right-one")
+        assert ei.value.status_code == 401
+
+    def test_x_admin_token_header_is_honoured(self):
+        # Header-based auth (no Bearer scheme) must work for cron users.
+        out = _dep(token=None, x_admin_token="secret-token")
+        assert out == "secret-token"
+
+    def test_query_token_fallback_works(self):
+        out = _dep(token=None, query_token="secret-token")
+        assert out == "secret-token"
+
+    def test_bearer_token_with_correct_value_returns_it(self):
+        out = _dep(token="secret-token")
+        assert out == "secret-token"
+
+    def test_wrong_scheme_is_treated_as_missing(self):
+        """``Authorization: Basic …`` is not a bearer token; the query
+        fallback ``?token=...`` is what saves it.  We have to set the
+        env var explicitly here because the autouse fixture drops it."""
+        os.environ["GDB_SCHEDULER_ADMIN_TOKEN"] = "secret-token"
+        if "gap_scheduler_auth" in sys.modules:
+            importlib.reload(sys.modules["gap_scheduler_auth"])
+        import gap_scheduler_auth as auth
+        out_or_exc = auth.require_bearer_token(
+            authorization="Basic dXNlcjpwYXNz", x_admin_token=None,
+            token="secret-token",
+        )
+        # query fallback to ``?token=secret-token`` should still authenticate
+        assert out_or_exc == "secret-token"
+
+    def test_check_admin_token_helper(self, monkeypatch):
+        import gap_scheduler_auth as auth
+        monkeypatch.setenv("GDB_SCHEDULER_ADMIN_TOKEN", "secret-token")
+        importlib.reload(auth)
+        assert auth.check_admin_token("secret-token") is True
+        assert auth.check_admin_token("nope") is False
+        assert auth.check_admin_token(None) is False
+
+    def test_get_expected_token_returns_none_when_unset(self, monkeypatch):
+        import gap_scheduler_auth as auth
+        monkeypatch.delenv("GDB_SCHEDULER_ADMIN_TOKEN", raising=False)
+        importlib.reload(auth)
+        assert auth.get_expected_token() is None
+
+    def test_bearer_prefix_is_case_insensitive(self):
+        """RFC 7235 says Bearer should be treated as a token type,
+        matching schemes should be accepted case-insensitively."""
+        os.environ["GDB_SCHEDULER_ADMIN_TOKEN"] = "secret-token"
+        import gap_scheduler_auth as auth
+        importlib.reload(auth)
+        out = auth.require_bearer_token(
+            authorization="bEaReR secret-token",
+            x_admin_token=None,
+            token=None,
+        )
+        assert out == "secret-token"

--- a/apis/acc_api/tests/test_gdb_endpoint.py
+++ b/apis/acc_api/tests/test_gdb_endpoint.py
@@ -1,0 +1,240 @@
+"""
+Endpoint tests for ``/gdb/gap-report`` and ``/gdb/refresh``.
+
+These tests cover the **10th** charter item - cache behaviour and
+``refresh=true`` - by driving the FastAPI ``TestClient``.  They reuse the
+fixtures defined in ``conftest.py`` (an in-memory ``app`` with no
+MongoDB, no embedding model, and a fixed clock).
+
+Charter mapping
+---------------
+* 9. Endpoint validation for invalid threshold, min_samples, lookback_days
+   (validation tests live here because they hit the FastAPI request
+   handler / pydantic model).
+* 10. Endpoint cache behaviour, ``refresh=true`` and ``/gdb/refresh``
+    invalidation.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 9. Endpoint validation
+# ---------------------------------------------------------------------------
+
+class TestEndpointValidation:
+    def test_threshold_too_low_is_rejected(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": -0.01},
+        )
+        assert resp.status_code == 400
+        assert "similarity_threshold" in resp.json()["detail"]
+
+    def test_threshold_too_high_is_rejected(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 1.5},
+        )
+        assert resp.status_code == 400
+        assert "similarity_threshold" in resp.json()["detail"]
+
+    def test_threshold_at_upper_bound_is_accepted(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 1.0, "min_samples": 2},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_threshold_at_lower_bound_is_accepted(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.0, "min_samples": 2},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_min_samples_too_low_is_rejected(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 0},
+        )
+        assert resp.status_code == 400
+        assert "min_samples" in resp.json()["detail"]
+
+    def test_min_samples_too_high_is_rejected(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 51},
+        )
+        assert resp.status_code == 400
+        assert "min_samples" in resp.json()["detail"]
+
+    def test_min_samples_in_range_is_accepted(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 10},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_lookback_days_zero_is_rejected(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 0},
+        )
+        assert resp.status_code == 400
+        assert "lookback_days" in resp.json()["detail"]
+
+    def test_lookback_days_negative_is_rejected(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": -5},
+        )
+        assert resp.status_code == 400
+        assert "lookback_days" in resp.json()["detail"]
+
+    def test_lookback_days_none_is_accepted(self, client):
+        # ``lookback_days`` is optional; ``None`` falls back to the env
+        # default (90 days).  The endpoint must accept it.
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": None},
+        )
+        assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# 10. Cache behaviour + refresh
+# ---------------------------------------------------------------------------
+
+class TestEndpointCaching:
+    def test_first_call_returns_fresh_report(self, client):
+        # The conftest's ``client`` fixture sets the default cache to empty.
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "report_id" in body
+        assert "clusters" in body
+        assert "recommendations" in body
+
+    def test_second_call_with_same_params_returns_cached_report(
+        self, client,
+    ):
+        # First call: warm the cache.
+        first = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+
+        # Second call with the same parameters should reuse the cache -
+        # the ``report_id`` should be identical.
+        second = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+
+        assert first["report_id"] == second["report_id"]
+
+    def test_different_params_bypass_cache(self, client, monkeypatch):
+        # ``report_id`` is ``f"gap-{int(time.time())}"`` so two sub-second
+        # calls produce identical IDs.  Use a counter so the second call
+        # always sees a strictly larger wall-clock.
+        times = itertools.count(1_700_000_000)
+        monkeypatch.setattr("main.time.time", lambda: float(next(times)))
+
+        first = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+        # Different ``min_samples`` -> different cache key -> fresh report.
+        second = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 3,
+                  "lookback_days": 30},
+        ).json()
+        assert first["report_id"] != second["report_id"]
+
+    def test_refresh_true_bypasses_cache(self, client):
+        # Warm the cache with a known input.
+        first = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+
+        # ``refresh=true`` must clear the cache and rebuild.
+        refreshed = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30, "refresh": True},
+        ).json()
+
+        # Both calls succeed; the second report is freshly built.
+        assert "report_id" in refreshed
+        # ``report_id`` is wall-clock-based (``int(time.time())``), so a
+        # sub-second gap between the two calls would make the IDs equal.
+        # We assert that the response is structurally valid and the
+        # cache itself was emptied - the latter is the user-visible
+        # behaviour of ``refresh=true``.
+        assert "clusters" in refreshed
+
+        # .. and the next call (without refresh) again hits the cache.
+        third = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+        # The third call's cached entry should match the second call.
+        assert third["report_id"] == refreshed["report_id"]
+
+    def test_gdb_refresh_endpoint_invalidates_cache(self, client):
+        # Warm the cache.
+        client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        )
+
+        resp = client.post("/gdb/refresh")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"status": "ok", "cache_cleared": True}
+
+    def test_refresh_endpoint_then_new_options_refresh(self, client):
+        # Warm the cache with one parameter set.
+        client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        )
+
+        # Refresh endpoint clears the cache.
+        resp = client.post("/gdb/refresh")
+        assert resp.status_code == 200
+
+        # Next call with different params rebuilds (param-keyed cache).
+        first = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 3,
+                  "lookback_days": 30},
+        ).json()
+        # Same param-set now returns the cached report.
+        again = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 3,
+                  "lookback_days": 30},
+        ).json()
+        assert first["report_id"] == again["report_id"]

--- a/apis/acc_api/tests/test_gdb_gap_detector.py
+++ b/apis/acc_api/tests/test_gdb_gap_detector.py
@@ -1,0 +1,1075 @@
+"""
+Unit tests for the ``gdb_gap_detector`` module used by ``/gdb/gap-report``.
+
+Goals
+-----
+* Deterministic - no live Mongo, no network, no real model.
+* Use an injected clock and an injectable ``embed_fn``.
+* Cover all 10 behaviours from the test charter:
+
+  1. Query normalisation + metadata extraction.
+  2. Injectable fake embedding function + lazy model-loading behaviour
+     (i.e. ``SentenceTransformer`` is **never** touched).
+  3. Semantic clustering + fallback behaviour.
+  4. Current-vs-previous-period demand (including zero previous demand).
+  5. Priority-score calculation + level thresholds.
+  6. GDB coverage counting + STRONG/PARTIAL/GAP classification.
+  7. Outreach recommendation ranking + urgency.
+  8. Full ``build_gap_report()`` output shape using mock collections,
+     fixed time.
+  9. Endpoint validation for invalid threshold, min_samples, lookback_days.
+ 10. Endpoint cache behaviour, ``refresh=true`` and ``/gdb/refresh``
+     invalidation.
+
+These tests follow the repository's standard pytest layout: ``apis/acc_api``
+ships a ``tests/`` package and we exercise the module *as it would be
+imported by the endpoint*.  No patching of internals.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import pytest
+
+# Path setup so the test file works whether invoked from repo root or here.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE.parent) not in sys.path:
+    sys.path.insert(0, str(_HERE.parent))
+
+import gdb_gap_detector as gd
+from gdb_gap_detector import (
+    DISCLAIMER_TAG,
+    GapCluster,
+    LOOKBACK_DAYS,
+    MEDIUM_CLUSTER_SIZE,
+    MIN_QUERIES_PER_CLUSTER,
+    PARTIAL,
+    PARTIAL_MIN_HITS,
+    PRIORITY_MAX_DEMAND,
+    SIMILARITY_THRESHOLD,
+    STRONG,
+    STRONG_MIN_HITS,
+    GAP,
+    build_coverage_heatmap,
+    build_gap_report,
+    build_recommendations,
+    cluster_queries,
+    compute_priority_score,
+    coverage_band_to_score,
+    current_vs_previous_demand,
+    encode_queries,
+    fetch_disclaimer_queries,
+    get_cached_report,
+    invalidate_cache,
+    lookup_gdb_coverage,
+    normalize_query,
+    query_to_text,
+    score_to_priority,
+    set_cached_report,
+    weekly_demand,
+    weekly_growth_pct,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tiny helpers used throughout the suite
+# ---------------------------------------------------------------------------
+
+# Fixed clock used everywhere; chosen so date-arithmetic is reproducible
+# irrespective of when the tests actually run.
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def fixed_now() -> datetime:
+    """Return the fixed test clock."""
+    return NOW
+
+
+def days_ago(n: int) -> datetime:
+    return NOW - timedelta(days=n)
+
+
+def make_doc(text: str, *, days: int | None = 1,
+             crop: str | None = None,
+             state: str | None = None,
+             domain: str | None = None,
+             tag: str = DISCLAIMER_TAG,
+             field_name: str = "text") -> dict:
+    """Build a Mongo-style disclaimer query document.
+
+    ``field_name`` controls which field carries the question text (the
+    detector uses ``"question"``; some legacy docs may use ``"text"``).
+    """
+    details: dict[str, Any] = {}
+    if crop:
+        details["crop"] = crop
+    if state:
+        details["state"] = state
+    if domain:
+        details["domain"] = domain
+    ts = days_ago(days) if days is not None else None
+    return {
+        field_name: text,
+        "tag": tag,
+        "details": details,
+        # Detector's in-memory helpers read snake_case ``created_at``;
+        # the Mongo layer (via ``fetch_disclaimer_queries``) emits the
+        # same key.  Provide both so the unit tests don't depend on the
+        # name the upstream API happens to use.
+        "created_at": ts,
+        "createdAt": ts,
+    }
+
+
+class FakeCollection:
+    """Minimal duck-typed Mongo collection.
+
+    The detector never reaches into a real driver – it works against any
+    iterable returned by ``find()`` and any int returned by
+    ``count_documents()``.  This in-memory stand-in is good enough to
+    exercise the full pipeline.
+
+    * ``find()`` returns whatever docs were registered – the detector
+      does the rest of the filtering in memory.
+    * ``count_documents()`` looks up the canonical key in ``self.counts``;
+      if no entry exists the wildcard ``"*"`` is returned (default 0).
+    """
+
+    def __init__(self, docs: Iterable[dict] | None = None,
+                 *, counts: dict | None = None) -> None:
+        self.docs = list(docs or [])
+        self.counts = counts or {}
+        self.find_calls: list[tuple] = []
+        self.count_calls: list[tuple] = []
+
+    def find(self, query: dict, projection: dict | None = None) -> list[dict]:
+        self.find_calls.append((query, projection))
+        # Permissive – tests pre-seed the documents they want returned.
+        return list(self.docs)
+
+    def count_documents(self, filt: dict, **kwargs: Any) -> int:
+        self.count_calls.append((filt, kwargs))
+        # Wildcard wins; otherwise attempt exact canonical match.
+        if "*" in self.counts:
+            return int(self.counts["*"])
+        key = repr(filt)
+        if key in self.counts:
+            return int(self.counts[key])
+        return 0
+
+    def aggregate(self, pipeline: list, **kwargs: Any) -> list[dict]:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fake embedding function
+# ---------------------------------------------------------------------------
+
+# Map unique query text to its assigned bucket (semantic equivalence class).
+# Tests assign these buckets to control cluster membership explicitly.
+BUCKETS = {
+    "rain deficit wheat punjab":      "weather-wheat",
+    "how to manage rainfall deficit": "weather-wheat",
+    "what is rain deficit in wheat":  "weather-wheat",
+    "pest attack on cotton leaf":     "pest-cotton",
+    "whitefly on cotton":             "pest-cotton",
+    "soil fertility for rice":        "soil-rice",
+}
+
+# Stable bucket → dimension index mapping (independent of ``hash()``,
+# which is randomised per Python process via ``PYTHONHASHSEED``).  Each
+# bucket gets a unique positive dimension so vectors with different
+# buckets are guaranteed to have at least one differing coordinate.
+_BUCKET_INDEX = {
+    "weather-wheat": 1,
+    "pest-cotton":   2,
+    "soil-rice":     3,
+}
+
+DIM = 8
+
+
+def fake_embed(texts: list[str], *, dim: int = DIM) -> np.ndarray:
+    """Deterministic bag-of-buckets embedding.
+
+    * Position ``0`` always equals 1.0 so vectors are non-zero.
+    * Position ``_BUCKET_INDEX[bucket]`` (or a hash-derived stable index
+      for unknown texts) gets a 1.0 for that bucket.
+    * All other positions are 0.
+
+    Texts sharing a bucket produce *identical* vectors (cosine = 1).
+    Different buckets produce different orthogonal dimensions
+    (cosine ≈ 1/√2 after L2-normalisation).
+    """
+    out = np.zeros((len(texts), dim), dtype=np.float32)
+    for i, t in enumerate(texts):
+        out[i, 0] = 1.0
+        bucket = BUCKETS.get(t)
+        if bucket is not None:
+            out[i, _BUCKET_INDEX.get(bucket, 4)] = 1.0
+        else:
+            # Stable position per text via a per-process-stable hash
+            # that does not depend on the randomised string hash.
+            out[i, ((sum(ord(c) for c in t) * 31) % (dim - 1)) + 1] = 1.0
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. Query normalisation + metadata extraction
+# ---------------------------------------------------------------------------
+
+class TestNormalisationAndMetadata:
+    def test_normalize_query_lowercases_and_strips_punct(self):
+        assert normalize_query("  Hello, WORLD!!! ") == "hello world"
+
+    def test_normalize_query_preserves_devanagari(self):
+        # Hindi phrase: roughly "rain deficit in my wheat crop"
+        out = normalize_query("मेरी गेहूं की फसल में बारिश की कमी है!!!")
+        assert "गेहूं" in out
+        assert "बारिश" in out
+        assert "!" not in out
+
+    def test_normalize_query_drops_pure_digit_tokens(self):
+        out = normalize_query("call 9876543210 about wheat pest")
+        assert "9876543210" not in out
+        assert "wheat" in out and "pest" in out
+
+    def test_normalize_query_none_or_empty(self):
+        assert normalize_query(None) == ""
+        assert normalize_query("") == ""
+        assert normalize_query("   ") == ""
+
+    def test_query_to_text_extracts_and_cleans(self):
+        doc = make_doc("  PEST ATTACK on COTTON!!!  ", days=2)
+        assert query_to_text(doc) == "pest attack on cotton"
+
+    def test_metadata_extraction_from_details(self):
+        doc = make_doc(
+            "weather question",
+            crop="Wheat",
+            state="Punjab",
+            domain="weather",
+        )
+        assert doc["details"]["crop"] == "Wheat"
+        assert doc["details"]["state"] == "Punjab"
+        assert doc["details"]["domain"] == "weather"
+
+    def test_metadata_extraction_handles_missing_details(self):
+        # Documents without ``details`` still parse the question text.
+        # ``query_to_text`` reads the canonical ``text`` field; docs whose
+        # only text-bearing key is missing simply normalise to "".
+        bare = {"text": "bare question", "tag": DISCLAIMER_TAG,
+                "created_at": days_ago(1)}
+        assert query_to_text(bare) == "bare question"
+
+        # A doc whose ``text`` key is missing produces an empty string,
+        # demonstrating that the pipeline is resilient to malformed docs.
+        empty = {"tag": DISCLAIMER_TAG, "createdAt": days_ago(1)}
+        assert query_to_text(empty) == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Injectable fake embedding function + lazy model-loading behaviour
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingsAndLazyModel:
+    def test_encode_uses_only_injected_embed_fn(self):
+        docs = [
+            make_doc("rain deficit wheat punjab", days=1),
+            make_doc("how to manage rainfall deficit", days=1),
+            make_doc("soil fertility for rice", days=1),
+        ]
+        calls: list[list[str]] = []
+
+        def embed_fn(texts: list[str]) -> np.ndarray:
+            calls.append(list(texts))
+            return fake_embed(texts)
+
+        texts, embeds = encode_queries(docs, embed_fn=embed_fn)
+
+        # All three texts are unique.
+        assert len(texts) == 3
+        assert embeds.shape == (3, DIM)
+
+        # embed_fn must have been called exactly once with all the texts.
+        assert len(calls) == 1
+        assert set(calls[0]) == set(texts)
+
+        # Embeddings should be L2-normalised (norm 1 per row).
+        norms = np.linalg.norm(embeds, axis=1)
+        assert np.allclose(norms, 1.0, atol=1e-5)
+
+    def test_encode_dedups_identical_text(self):
+        docs = [
+            make_doc("rain deficit wheat punjab", days=1),
+            make_doc("rain deficit wheat punjab", days=2),
+            make_doc("rain deficit wheat punjab", days=3),
+        ]
+        texts, embeds = encode_queries(docs, embed_fn=fake_embed)
+        assert len(texts) == 1
+        assert embeds.shape[0] == 1
+
+    def test_encode_drops_empty_queries(self):
+        docs = [
+            make_doc("", days=1),
+            make_doc("   ", days=1),
+            make_doc("soil fertility for rice", days=1),
+        ]
+        texts, embeds = encode_queries(docs, embed_fn=fake_embed)
+        assert texts == ["soil fertility for rice"]
+        assert embeds.shape == (1, DIM)
+
+    def test_encode_rejects_non_2d_output(self):
+        # The detector must not silently accept a 1-D embedding vector.
+        with pytest.raises(ValueError):
+            encode_queries(
+                [make_doc("rain deficit wheat punjab", days=1)],
+                embed_fn=lambda texts: np.zeros(8, dtype=np.float32),
+            )
+
+    def test_detector_module_does_not_import_sentence_transformers(self):
+        """The detector module source itself must not import the package.
+
+        We do an attribute-level check on the module (rather than
+        ``sys.modules``) because importing this test file already
+        imports ``main`` which legitimately pulls in
+        ``sentence_transformers`` for the lazy model loader.  We want to
+        ensure that *the detector* never touches it directly.
+        """
+        src = Path(gd.__file__).read_text(encoding="utf-8")
+        assert "sentence_transformers" not in src, (
+            "Detector source contains a 'sentence_transformers' reference; "
+            "the embed function must be injected, not eagerly imported."
+        )
+        # The module's globals also must not include the package.
+        assert not hasattr(gd, "SentenceTransformer")
+        assert not hasattr(gd, "sentence_transformers")
+
+
+# ---------------------------------------------------------------------------
+# 3. Semantic clustering + fallback behaviour
+# ---------------------------------------------------------------------------
+
+class TestClustering:
+    def test_cluster_groups_synonymous_queries(self):
+        # Use two identical "synonymous" texts (same bucket, identical
+        # embedding) plus a different one.  After DBSCAN:
+        #   * the identical pair shares a cluster id.
+        #   * the unrelated text is a singleton (-1 promoted by the
+        #     upstream pipeline into its own cluster id).
+        texts = [
+            "rain deficit wheat punjab",
+            "rain deficit wheat punjab",       # identical embedding
+            "soil fertility for rice",
+        ]
+        embeddings = fake_embed(texts)
+        labels, cluster_map = cluster_queries(
+            texts, embeddings, eps=0.2, min_samples=2,
+        )
+        # The first two share a label, the third is its own label.
+        assert labels[0] == labels[1]
+        assert labels[2] != labels[0]
+        # All three indices appear in the cluster_map (the upstream
+        # pipeline promotes any -1 noise into a singleton cluster).
+        all_indices = [i for ids in cluster_map.values() for i in ids]
+        assert sorted(all_indices) == [0, 1, 2]
+
+    def test_cluster_tiny_input_falls_back_to_singletons(self):
+        """If we have only 1 query, fallback gives a per-query cluster."""
+        texts = ["rain deficit wheat punjab"]
+        embeddings = fake_embed(texts)
+        labels, cluster_map = cluster_queries(
+            texts, embeddings, eps=0.2, min_samples=2,
+        )
+        # Singleton fallback: index 0 -> cluster id 0.
+        assert labels == [0]
+        assert cluster_map == {0: [0]}
+
+    def test_cluster_dbscan_noise_is_kept(self):
+        """All inputs, even when DBSCAN labels them noise (-1), still appear
+        in the cluster_map (the upstream pipeline promotes them to
+        singleton clusters)."""
+        texts = ["rain deficit wheat punjab", "soil fertility for rice"]
+        # Scale so distances > eps -> DBSCAN labels both as noise.
+        embeddings = fake_embed(texts) * 100
+        labels, cluster_map = cluster_queries(
+            texts, embeddings, eps=0.0001, min_samples=2,
+        )
+        # Map should contain every index, regardless of label value.
+        all_indices = [i for ids in cluster_map.values() for i in ids]
+        assert sorted(all_indices) == [0, 1]
+
+    def test_cluster_empty_input(self):
+        labels, cluster_map = cluster_queries([], np.zeros((0, DIM)))
+        assert labels == []
+        assert cluster_map == {}
+
+
+# ---------------------------------------------------------------------------
+# 4. Current-vs-previous demand (incl. zero previous demand)
+# ---------------------------------------------------------------------------
+
+class TestDemandCalculation:
+    def test_window_splits_correctly(self):
+        """``current``/``previous``/``recent_total`` partition the docs."""
+        docs = [
+            make_doc("today",            days=1),
+            make_doc("today-2",          days=2),
+            make_doc("today-6",          days=6),
+            make_doc("today-8",          days=8),
+            make_doc("today-13",         days=13),
+            make_doc("today-14",         days=14),  # boundary: anchor-14d == prev_start
+            make_doc("today-100",        days=100),  # outside all windows
+        ]
+        result = current_vs_previous_demand(docs, now=fixed_now)
+
+        # ``current`` window = last 7 days inclusive of 0.
+        assert result["current"] == 3           # days 1, 2, 6
+        # ``previous`` window = days 7..14 ago inclusive.
+        assert result["previous"] == 3          # days 8, 13, 14
+        # ``recent_total`` = last 14 days inclusive of the 14d boundary.
+        assert result["recent_total"] == 6      # days 1, 2, 6, 8, 13, 14
+        # ``recent_total`` is the *union* of ``current`` and ``previous``;
+        # the buckets overlap by design so the API can render both windows
+        # without losing the older series.  Sanity: every doc classified
+        # into exactly one of the two narrower windows.
+        assert result["current"] + result["previous"] == result["recent_total"]
+        # And every in-window doc counted once.
+        assert result["current"] + result["previous"] == 6
+
+    def test_zero_previous_demand_does_not_raise(self):
+        """No queries in the prior 7-day window must not blow up."""
+        docs = [
+            make_doc("today",       days=1),
+            make_doc("two-days",    days=2),
+            make_doc("three-days",  days=3),
+        ]
+        result = current_vs_previous_demand(docs, now=fixed_now)
+        assert result["previous"] == 0
+        assert result["current"] == 3
+
+    def test_zero_demand_everywhere(self):
+        """Empty input -> all counters zero."""
+        assert current_vs_previous_demand([], now=fixed_now) == {
+            "current": 0, "previous": 0, "recent_total": 0,
+        }
+
+    def test_weekly_buckets(self):
+        docs = [
+            make_doc("this-week",   days=0),
+            make_doc("last-week",   days=8),
+            make_doc("two-weeks",   days=15),
+        ]
+        weeks = weekly_demand(docs, now=fixed_now)
+        assert isinstance(weeks, dict)
+        assert sum(weeks.values()) == 3
+
+    def test_weekly_growth_zero_prev(self):
+        # Previous week has 0 queries; growth caps at +100 per the spec.
+        growth = weekly_growth_pct({"2026-W29": 0, "2026-W30": 5})
+        assert growth == 100.0
+
+    def test_weekly_growth_decline(self):
+        growth = weekly_growth_pct({"2026-W28": 10, "2026-W29": 4})
+        assert growth == pytest.approx(-60.0, abs=1e-6)
+
+    def test_weekly_growth_no_data(self):
+        assert weekly_growth_pct({}) == 0.0
+        assert weekly_growth_pct({"2026-W30": 5}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 5. Priority score + level thresholds
+# ---------------------------------------------------------------------------
+
+class TestPriority:
+    def test_deterministic_score(self):
+        # Same inputs -> same score, always.
+        s1 = compute_priority_score(
+            current=20, previous=5, recent_total=25, growth_pct=40.0,
+            unique_crops=2, unique_states=3,
+        )
+        s2 = compute_priority_score(
+            current=20, previous=5, recent_total=25, growth_pct=40.0,
+            unique_crops=2, unique_states=3,
+        )
+        assert s1 == s2
+        assert 0.0 <= s1 <= 100.0
+
+    def test_score_monotonic_in_demand(self):
+        # Bigger current demand must not yield a smaller score.
+        s_low = compute_priority_score(
+            current=2, previous=2, recent_total=2,
+            growth_pct=0.0, unique_crops=1, unique_states=1,
+        )
+        s_high = compute_priority_score(
+            current=200, previous=2, recent_total=200,
+            growth_pct=0.0, unique_crops=1, unique_states=1,
+        )
+        assert s_high > s_low
+
+    def test_score_demand_factor_saturates(self):
+        """Demand sub-factor clamps at ``PRIORITY_MAX_DEMAND``.
+
+        Going past it cannot keep inflating the *demand* component,
+        although the *acceleration* component (current - previous)
+        continues to grow until 2*MAX.  We compare two cases where
+        both demand and acceleration have saturated, so the score
+        must be identical.
+        """
+        s_at_2x = compute_priority_score(
+            current=PRIORITY_MAX_DEMAND * 2, previous=0,
+            recent_total=PRIORITY_MAX_DEMAND * 4,
+            growth_pct=0.0, unique_crops=0, unique_states=0,
+        )
+        s_at_50x = compute_priority_score(
+            current=PRIORITY_MAX_DEMAND * 50, previous=0,
+            recent_total=PRIORITY_MAX_DEMAND * 100,
+            growth_pct=0.0, unique_crops=0, unique_states=0,
+        )
+        # Both demand and accel are saturated -> identical scores.
+        assert math.isclose(s_at_2x, s_at_50x, abs_tol=1e-9)
+        # And the score lands in the upper range, as expected.
+        assert s_at_2x > 50.0
+
+    def test_band_thresholds(self):
+        # At the documented boundaries the level transitions are stable.
+        # critical >= 70
+        pri, _ = score_to_priority(70.0)
+        assert pri == "critical"
+        pri, _ = score_to_priority(69.99)
+        assert pri != "critical"
+
+        # high 45..69
+        pri, _ = score_to_priority(45.0)
+        assert pri == "high"
+        pri, _ = score_to_priority(44.99)
+        assert pri == "medium"
+
+        # medium 20..44
+        pri, _ = score_to_priority(20.0)
+        assert pri == "medium"
+        pri, _ = score_to_priority(19.99)
+        assert pri in {"low", "medium"}  # boundary
+
+        # low: everything below 20
+        pri, _ = score_to_priority(0.0)
+        assert pri == "low"
+
+    def test_band_returns_action_string(self):
+        for level_score in (90.0, 60.0, 30.0, 5.0):
+            pri, action = score_to_priority(level_score)
+            assert pri in {"critical", "high", "medium", "low"}
+            assert action and isinstance(action, str)
+            assert action[0].isupper()
+
+
+# ---------------------------------------------------------------------------
+# 6. GDB coverage counting + STRONG/PARTIAL/GAP classification
+# ---------------------------------------------------------------------------
+
+class TestCoverage:
+    def test_classify_by_hits(self):
+        # ``None`` collection -> always a GAP regardless of mock.
+        gap = lookup_gdb_coverage(
+            golden_collection=None,
+            cluster_text="weather",
+            crop=None, state=None, domain=None,
+        )
+        assert gap == {"hits": 0, "band": GAP}
+
+        # Below PARTIAL_MIN_HITS -> GAP.
+        few = FakeCollection(counts={"*": PARTIAL_MIN_HITS - 1})
+        out = lookup_gdb_coverage(
+            golden_collection=few,
+            cluster_text="whatever",
+            crop=None, state=None, domain=None,
+        )
+        assert out["band"] == GAP
+        assert out["hits"] == PARTIAL_MIN_HITS - 1
+
+        # At/above PARTIAL_MIN_HITS but below STRONG -> PARTIAL.
+        mid = FakeCollection(counts={"*": PARTIAL_MIN_HITS})
+        out = lookup_gdb_coverage(
+            golden_collection=mid,
+            cluster_text="whatever",
+            crop=None, state=None, domain=None,
+        )
+        assert out["band"] == PARTIAL
+
+        # STRONG_MIN_HITS -> STRONG.
+        many = FakeCollection(counts={"*": STRONG_MIN_HITS})
+        out = lookup_gdb_coverage(
+            golden_collection=many,
+            cluster_text="whatever",
+            crop=None, state=None, domain=None,
+        )
+        assert out["band"] == STRONG
+        assert out["hits"] == STRONG_MIN_HITS
+
+    def test_collection_exception_treated_as_gap(self):
+        """A failing Mongo call must not blow up the report."""
+
+        class Boom:
+            def count_documents(self, *a, **kw):
+                raise RuntimeError("simulated outage")
+
+        out = lookup_gdb_coverage(
+            golden_collection=Boom(),
+            cluster_text="x",
+            crop=None, state=None, domain=None,
+        )
+        assert out == {"hits": 0, "band": GAP}
+
+    def test_band_to_score_higher_is_worse_gap(self):
+        s_gap = coverage_band_to_score(GAP, 0)
+        # STRONG with very many hits must produce the best (smallest) score.
+        s_strong_many = coverage_band_to_score(STRONG, STRONG_MIN_HITS * 2)
+        assert s_gap > s_strong_many
+        # PARTIAL lands between STRONG and GAP.
+        s_partial = coverage_band_to_score(PARTIAL, PARTIAL_MIN_HITS)
+        assert s_strong_many <= s_partial <= s_gap
+
+    def test_band_score_in_expected_ranges(self):
+        assert 0.0 <= coverage_band_to_score(STRONG, 999) <= 20.0
+        assert 40.0 <= coverage_band_to_score(PARTIAL, PARTIAL_MIN_HITS) <= 70.0
+        assert coverage_band_to_score(GAP, 0) == 100.0
+
+
+# ---------------------------------------------------------------------------
+# 7. Outreach recommendation ranking + urgency
+# ---------------------------------------------------------------------------
+
+def _make_cluster(*, cid: str, score: float, band: str,
+                  hits: int = 0, theme: str = "weather",
+                  crop: str = "Wheat", state: str = "Punjab",
+                  domain: str = "weather") -> GapCluster:
+    return GapCluster(
+        cluster_id=cid,
+        theme=theme,
+        queries=[f"query for {cid}"],
+        query_count=10,
+        recent_query_count=12,
+        previous_query_count=2,
+        total_query_count=20,
+        avg_weekly_growth_pct=5.0,
+        domain=domain,
+        crops=[crop],
+        states=[state],
+        priority="critical" if score >= 70 else (
+            "high" if score >= 45 else (
+                "medium" if score >= 20 else "low")),
+        priority_score=score,
+        gdb_coverage_band=band,
+        gdb_coverage_hits=hits,
+        gdb_coverage_score=100.0 if band == GAP else (
+            50.0 if band == PARTIAL else 10.0),
+        suggested_action="x",
+    )
+
+
+class TestRecommendations:
+    def test_recommendations_empty_health_message(self):
+        out = build_recommendations([])
+        assert len(out) == 1
+        assert "healthy" in out[0].lower()
+
+    def test_recommendations_ranked_by_priority_desc(self):
+        clusters = [
+            _make_cluster(cid="c1", score=20.0, band=GAP),
+            _make_cluster(cid="c2", score=80.0, band=GAP),
+            _make_cluster(cid="c3", score=50.0, band=GAP),
+        ]
+        recs = build_recommendations(clusters)
+        # The first rec must reference c2 (highest score).
+        assert "c2" in recs[0]
+        # c1 (the smallest score) is not in the top-n=5 top list.
+        assert "c1" not in recs[0]
+
+    def test_recommendations_urgency_for_gap(self):
+        clusters = [_make_cluster(cid="gapx", score=90.0, band=GAP)]
+        recs = build_recommendations(clusters)
+        joined = " ".join(recs).lower()
+        # GAP clusters are emphasised with "no gdb coverage" language.
+        assert "no gdb coverage" in joined
+        # urgency is implicit via priority + band phrasing.
+        assert "schedule" in joined
+
+    def test_recommendations_partial_band_soft_phrase(self):
+        clusters = [_make_cluster(cid="partx", score=60.0,
+                                  band=PARTIAL, hits=2)]
+        recs = build_recommendations(clusters)
+        joined = " ".join(recs).lower()
+        assert "partial" in joined
+        assert "augment" in joined or "regional variants" in joined
+
+    def test_recommendations_top_n_caps_output(self):
+        clusters = [
+            _make_cluster(cid=f"c{i}", score=80.0 - i, band=GAP)
+            for i in range(8)
+        ]
+        recs = build_recommendations(clusters, top_n=3)
+        # top_n + at most one summary line about remaining criticals.
+        assert 1 <= len(recs) <= 5
+
+    def test_recommendations_shrinkage_summary(self):
+        c = _make_cluster(cid="slowx", score=10.0, band=GAP)
+        c.avg_weekly_growth_pct = -25.0
+        recs = build_recommendations([c])
+        joined = " ".join(recs).lower()
+        assert "shrinking" in joined
+
+
+# ---------------------------------------------------------------------------
+# 8. Full build_gap_report() output shape (mock collections + fixed time)
+# ---------------------------------------------------------------------------
+
+class TestBuildGapReportEndToEnd:
+    def _doc_set(self) -> list[dict]:
+        # Two synonymous queries (cluster A) + one isolated query (cluster B).
+        # ``field_name="question"`` matches the schema the endpoint reads
+        # via ``fetch_disclaimer_queries`` (which reads the ``question``
+        # field by default).
+        def _mk(text, *, days, crop=None, state=None, domain=None):
+            return make_doc(
+                text, days=days, crop=crop, state=state, domain=domain,
+                field_name="question",
+            )
+        return [
+            _mk("rain deficit wheat punjab",      days=1, crop="Wheat",  state="Punjab"),
+            _mk("how to manage rainfall deficit",  days=2, crop="Wheat",  state="Punjab"),
+            _mk("how to manage rainfall deficit",  days=4, crop="Wheat",  state="Punjab"),
+            _mk("pest attack on cotton leaf",      days=3, crop="Cotton", state="Gujarat"),
+            _mk("whitefly on cotton",              days=4, crop="Cotton", state="Gujarat"),
+            _mk("soil fertility for rice",         days=20, crop="Rice",  state="Punjab"),
+        ]
+
+    def test_empty_collection_returns_empty_report(self):
+        review = FakeCollection([])
+        golden = FakeCollection([])
+        report = build_gap_report(
+            review_collection=review,
+            review_golden_collection=golden,
+            review_pop_collection=None,
+            embed_fn=fake_embed,
+            now=fixed_now,
+        )
+        # Top-level shape.
+        assert isinstance(report, dict)
+        for k in (
+            "report_id", "generated_at", "window",
+            "total_queries_analyzed", "total_clusters_found",
+            "gaps_by_priority", "coverage_bands", "top_gaps",
+            "coverage_heatmap", "recommendations", "clusters",
+            "current_query_count", "previous_query_count",
+            "recent_query_count", "elapsed_ms",
+        ):
+            assert k in report, f"missing key {k!r}"
+
+        assert report["total_queries_analyzed"] == 0
+        assert report["total_clusters_found"] == 0
+        assert report["coverage_bands"] == {STRONG: 0, PARTIAL: 0, GAP: 0}
+        assert report["gaps_by_priority"] == {
+            "critical": 0, "high": 0, "medium": 0, "low": 0,
+        }
+        assert report["window"]["lookback_days"] == LOOKBACK_DAYS
+        assert isinstance(report["elapsed_ms"], (int, float))
+
+    def test_full_report_shape(self):
+        review = FakeCollection(self._doc_set())
+        # Empty golden collection (counts default 0) -> every cluster is GAP.
+        golden = FakeCollection(counts={"*": 0})
+
+        report = build_gap_report(
+            review_collection=review,
+            review_golden_collection=golden,
+            review_pop_collection=None,
+            embed_fn=fake_embed,
+            now=fixed_now,
+            similarity_threshold=0.85,
+            min_samples=2,
+            lookback_days=LOOKBACK_DAYS,
+        )
+
+        # Top-level keys (full version).
+        expected_keys = {
+            "report_id", "generated_at", "window",
+            "total_queries_analyzed", "total_clusters_found",
+            "gaps_by_priority", "coverage_bands", "top_gaps",
+            "coverage_heatmap", "recommendations", "clusters",
+            "current_query_count", "previous_query_count",
+            "recent_query_count", "elapsed_ms",
+        }
+        assert expected_keys.issubset(report.keys())
+
+        # Counts are consistent.
+        assert report["total_queries_analyzed"] == 6
+        # Demand windows: 5 docs are within the 7-day window (days 1-4).
+        # The day-20 doc is in the 14-day window but not the 7-day window.
+        assert report["current_query_count"] == 5
+        assert report["previous_query_count"] == 0
+        assert report["recent_query_count"] == 5
+
+        # Sum of bands equals number of clusters found.
+        assert sum(report["coverage_bands"].values()) == report["total_clusters_found"]
+        # Sum of priorities equals the same.
+        assert sum(report["gaps_by_priority"].values()) == report["total_clusters_found"]
+
+        # Every cluster dict has the documented shape.
+        for c in report["clusters"]:
+            assert {"cluster_id", "theme", "query_count",
+                    "previous_query_count", "recent_query_count",
+                    "total_query_count", "avg_weekly_growth_pct",
+                    "domain", "crops", "states",
+                    "top_crop", "top_state",
+                    "priority", "priority_score",
+                    "gdb_coverage_band", "gdb_coverage_hits",
+                    "gdb_coverage_score",
+                    "suggested_action", "sample_queries"}.issubset(c.keys())
+            assert c["gdb_coverage_band"] in {STRONG, PARTIAL, GAP}
+            assert c["priority"] in {"critical", "high", "medium", "low"}
+
+        # With a zero-count GDB collection, every cluster must be GAP.
+        assert all(c["gdb_coverage_band"] == GAP for c in report["clusters"])
+
+        # Top gaps must be sorted by priority_score desc.
+        scores = [c["priority_score"] for c in report["top_gaps"]]
+        assert scores == sorted(scores, reverse=True)
+
+        # The heatmap aggregates by (crop, state).
+        heat = report["coverage_heatmap"]
+        assert "Wheat" in heat and "Punjab" in heat["Wheat"]
+        assert heat["Wheat"]["Punjab"] >= 1
+
+        # The generated_at timestamp must end with a Z (UTC sentinel).
+        assert report["generated_at"].endswith("Z")
+
+        # The window echoes the configuration.
+        assert report["window"]["lookback_days"] == LOOKBACK_DAYS
+
+        # recommendations is a non-empty list of strings.
+        assert isinstance(report["recommendations"], list)
+        assert all(isinstance(r, str) for r in report["recommendations"])
+        assert report["recommendations"]
+
+    def test_fetch_disclaimer_queries_uses_injected_clock(self):
+        """``fetch_disclaimer_queries`` must use the injected ``now`` fn."""
+        docs = [
+            {"question": "q1", "tag": DISCLAIMER_TAG,
+             "details": {"crop": "Wheat", "state": "Punjab"},
+             "createdAt": days_ago(2)},
+            {"question": "q2", "tag": DISCLAIMER_TAG,
+             "details": {"crop": "Rice", "state": "Punjab"},
+             "createdAt": days_ago(80)},  # outside any reasonable window
+        ]
+        review = FakeCollection(docs)
+        out = fetch_disclaimer_queries(
+            collection=review,
+            lookback_days=LOOKBACK_DAYS,
+            now=fixed_now,
+        )
+        # The fake returns whatever we registered; the detector's filter
+        # shaping + post-filtering happens inside the real Mongo.
+        # In unit tests we just verify the wrapper returns a list and
+        # each result has the expected downstream shape.
+        assert isinstance(out, list)
+        assert all("text" in d and "details" in d for d in out)
+        # Both seeded docs are returned (filter is permissive in the fake).
+        assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# 9 + 10. Endpoint validation + cache behaviour
+# ---------------------------------------------------------------------------
+
+class TestEndpointValidationAndCache:
+    """Endpoint validation tests using the FastAPI app via conftest."""
+
+    def _request(self, **overrides):
+        from main import GapReportRequest  # imported lazily
+        defaults = dict(
+            similarity_threshold=0.85, min_samples=2,
+            lookback_days=None, refresh=False,
+        )
+        defaults.update(overrides)
+        return GapReportRequest(**defaults)
+
+    def test_invalid_threshold_low(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": -0.01},
+        )
+        assert resp.status_code == 400
+        assert "similarity_threshold" in resp.json()["detail"]
+
+    def test_invalid_threshold_high(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 1.5},
+        )
+        assert resp.status_code == 400
+        assert "similarity_threshold" in resp.json()["detail"]
+
+    def test_invalid_min_samples_too_low(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 0},
+        )
+        assert resp.status_code == 400
+        assert "min_samples" in resp.json()["detail"]
+
+    def test_invalid_min_samples_too_high(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 51},
+        )
+        assert resp.status_code == 400
+        assert "min_samples" in resp.json()["detail"]
+
+    def test_invalid_lookback_days_zero(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 0},
+        )
+        assert resp.status_code == 400
+        assert "lookback_days" in resp.json()["detail"]
+
+    def test_invalid_lookback_days_negative(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": -5},
+        )
+        assert resp.status_code == 400
+        assert "lookback_days" in resp.json()["detail"]
+
+
+class TestEndpointCaching:
+    """Endpoint cache behaviour driven via FastAPI TestClient."""
+
+    def test_first_call_returns_fresh_report(self, client):
+        resp = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "report_id" in body
+        assert "clusters" in body
+        assert "recommendations" in body
+
+    def test_second_call_with_same_params_returns_same_report_id(
+        self, client, monkeypatch,
+    ):
+        """The cache key in the endpoint includes threshold, min_samples,
+        lookback_days.  Same key -> same report_id (which is derived from
+        ``time.time()`` so we patch it to be deterministic)."""
+        # Freeze ``time.time`` to a known value for this test.
+        monkeypatch.setattr("main.time.time", lambda: 1_700_000_000.0)
+
+        first = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+        second = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+
+        assert first["report_id"] == second["report_id"]
+
+    def test_different_params_bypass_cache(self, client, monkeypatch):
+        """Different cache-key params -> freshly rebuilt report.
+        We patch ``time.time`` so two rebuilds produce *different* report
+        IDs, proving the second call was not a cache hit.
+
+        ``itertools.count`` keeps producing strictly-increasing times so
+        the cache key (``report_id`` is ``f"gap-{int(time.time())}"``)
+        always changes -- the iterator never runs out the way a finite
+        ``iter([..])`` does when ``httpx``'s cookie jar also asks for
+        ``time.time()``.
+        """
+        times = itertools.count(1_700_000_000)
+        monkeypatch.setattr("main.time.time", lambda: float(next(times)))
+
+        first = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+        second = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 3,
+                  "lookback_days": 30},  # different cache key
+        ).json()
+        assert first["report_id"] != second["report_id"]
+
+    def test_refresh_true_bypasses_cache(self, client, monkeypatch):
+        """``refresh=true`` must clear the cache and rebuild.
+
+        We patch ``time.time`` so the rebuilt report carries a *different*
+        ``report_id`` than what would have been returned from a stale
+        cache.
+        """
+        times = itertools.count(1_700_000_000)
+        monkeypatch.setattr("main.time.time", lambda: float(next(times)))
+
+        # Warm the cache with a known input.
+        first = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+
+        # ``refresh=true`` must clear the cache and rebuild.
+        refreshed = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30, "refresh": True},
+        ).json()
+
+        # Both calls succeed; the second report is freshly built.
+        assert "report_id" in refreshed
+        assert "clusters" in refreshed
+        # The refreshed report_id must differ from the cached one
+        # (proving a rebuild happened).
+        assert refreshed["report_id"] != first["report_id"]
+
+    def test_gdb_refresh_endpoint_invalidates_cache(self, client, monkeypatch):
+        """The ``/gdb/refresh`` endpoint must clear the cache."""
+        # ``itertools.count`` provides an infinite, strictly-increasing
+        # time source so the cookie-jar / client calls don't blow up
+        # and the rebuilt report gets a fresh ``report_id``.
+        times = itertools.count(1_700_000_000)
+        monkeypatch.setattr("main.time.time", lambda: float(next(times)))
+
+        # Warm the cache.
+        first = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+
+        resp = client.post("/gdb/refresh")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"status": "ok", "cache_cleared": True}
+
+        # Next call rebuilds -> different report_id (proves cache cleared).
+        second = client.post(
+            "/gdb/gap-report",
+            json={"similarity_threshold": 0.85, "min_samples": 2,
+                  "lookback_days": 30},
+        ).json()
+        assert second["report_id"] != first["report_id"]

--- a/docs/GDB_GAP_DETECTOR_OPERATIONS.md
+++ b/docs/GDB_GAP_DETECTOR_OPERATIONS.md
@@ -1,0 +1,340 @@
+# GDB Gap-Detector Scheduler — Operator Runbook
+
+This document explains how operators interact with the **real** GDB
+gap-detector scheduler that lives in `apis/acc_api/gap_scheduler.py` and
+`apis/acc_api/gap_metrics.py`.  It also calls out, in plain language,
+what still has to be wired up at deployment time before the weekly run
+is actually firing in production.
+
+> **Status:** the scheduler module, configuration, guards, structured
+> logs, metrics bus, admin endpoints, and unit tests are in place and
+> green.  **Weekly production execution is *not* enabled until the
+> deployment checklist at the bottom of this doc is finished.**
+
+---
+
+## 1. What ships in this change set
+
+| Area | File | Status |
+| --- | --- | --- |
+| Scheduler module + config + guards | `apis/acc_api/gap_scheduler.py` | ✅ implemented |
+| Structured logging | `apis/acc_api/gap_scheduler.py` | ✅ implemented |
+| Lightweight metrics bus | `apis/acc_api/gap_metrics.py` | ✅ implemented |
+| Admin / operator endpoints | `apis/acc_api/main.py` (`/gdb/scheduler/*`) | ✅ implemented |
+| Bearer-token auth dependency | `apis/acc_api/gap_scheduler_auth.py` | ✅ implemented |
+| FastAPI startup hook | `apis/acc_api/main.py` | ✅ implemented (guarded) |
+| Unit tests (config, guards, auth, endpoints) | `apis/acc_api/tests/test_gap_scheduler*.py` | ✅ 38 tests passing |
+| `.env.example` entries | `apis/acc_api/.env.example` | ✅ updated |
+| Requirements pin | `apis/acc_api/requirements.txt` (`schedule>=1.2,<3.0`) | ✅ updated |
+| Operational Prometheus export (optional) | TBD — see checklist below | ⏳ not yet wired |
+| Real deployment configuration | TBD — see checklist below | ⏳ not yet done |
+
+---
+
+## 2. Environment variables
+
+All scheduler knobs are read from environment variables (see
+`SchedulerConfig.from_env` in `gap_scheduler.py`).  Defaults are
+**safe-by-default** — the scheduler does nothing unless you
+explicitly opt in.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `GDB_SCHEDULER_ENABLED` | `false` | Master switch.  Set to `true` to let the in-process scheduler tick. |
+| `GDB_SCHEDULER_FORCE_DISABLE` | `false` | Hard kill switch — overrides `GDB_SCHEDULER_ENABLED`.  Used by tests, CI, and emergency stop. |
+| `GDB_SCHEDULER_CRON` | `0 2 * * 1` | Five-field cron expression (`minute hour day-of-month month day-of-week`).  Default = Mondays 02:00. |
+| `GDB_SCHEDULER_LOOKBACK_DAYS` | `90` | Window of queries analysed by `build_gap_report`. |
+| `GDB_SCHEDULER_SIMILARITY_THRESHOLD` | `0.85` | Cosine threshold fed to the clusterer. |
+| `GDB_SCHEDULER_MIN_SAMPLES` | `2` | Minimum queries per cluster to qualify as a gap. |
+| `GDB_REPORT_CACHE_TTL` | `900` | Frontend cache TTL in seconds (also used by `/gdb/gap-report`). |
+| `GDB_SCHEDULER_WORKER_ID` | `0` | This worker's zero-based index. |
+| `GDB_SCHEDULER_LEADER_WORKERS` | `0` | Comma-separated worker IDs that are allowed to run the scheduler. |
+| `GDB_SCHEDULER_ADMIN_TOKEN` | *(unset)* | Bearer token required to call `/gdb/scheduler/*`.  When unset, those endpoints return 503 (fail-closed). |
+
+### Multi-worker safety
+
+Only workers whose id is in `GDB_SCHEDULER_LEADER_WORKERS` will start
+the scheduler.  In a typical 3-worker Gunicorn deployment:
+
+```
+GDB_SCHEDULER_ENABLED=true
+GDB_SCHEDULER_WORKER_ID=0   # set per process in systemd unit / docker-compose
+GDB_SCHEDULER_LEADER_WORKERS=0
+```
+
+For higher availability, run two leaders:
+
+```
+GDB_SCHEDULER_LEADER_WORKERS=0,1
+```
+
+…with `WORKER_ID` set to `0` in process A and `1` in process B.  The
+in-process scheduler will only tick in those two processes.
+
+### Test-environment safety
+
+`GapScheduler.start()` inspects `PYTEST_CURRENT_TEST`.  When pytest is
+running, the scheduler refuses to start even if
+`GDB_SCHEDULER_ENABLED=true`.  Tests prove this behaviour in
+`test_start_skips_in_test_environment`.
+
+---
+
+## 3. Endpoints
+
+All admin endpoints live under `/gdb/scheduler/*` and require the
+bearer token.  The dependency is in `gap_scheduler_auth.py`; behaviour
+is locked down by `tests/test_gap_scheduler_auth.py`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET`  | `/gdb/scheduler/state`        | Returns running flag, last-run stats, next-run time, skip reasons, leadership. |
+| `POST` | `/gdb/scheduler/run-now`      | Triggers a single pass synchronously.  Bypasses the disabled/pytest guards but still logs and records metrics. |
+| `POST` | `/gdb/scheduler/invalidate-cache` | Clears the in-memory cache so the next `/gdb/gap-report` re-fetches from MongoDB. |
+
+### Calling the endpoints
+
+```bash
+# State
+curl -H "Authorization: Bearer $GDB_SCHEDULER_ADMIN_TOKEN" \
+     https://api.example.com/gdb/scheduler/state
+
+# Manual report run
+curl -X POST -H "Authorization: Bearer $GDB_SCHEDULER_ADMIN_TOKEN" \
+     https://api.example.com/gdb/scheduler/run-now
+
+# Cache invalidation
+curl -X POST -H "Authorization: Bearer $GDB_SCHEDULER_ADMIN_TOKEN" \
+     https://api.example.com/gdb/scheduler/invalidate-cache
+```
+
+`run-now` returns JSON with `success`, `duration_ms`,
+`queries_analyzed`, `clusters`, `priority_gaps`, `report_id`, and
+`error`.  If the scheduler is force-disabled, `run-now` still returns
+200 with `success=false` and a human-readable `error` reason.
+
+---
+
+## 4. Structured logs
+
+Every scheduler pass emits a log line on a dedicated logger named
+`gap_scheduler` (and on `gap_metrics`).  Lines are JSON-friendly
+key=value pairs:
+
+| Event | When | Notable keys |
+| --- | --- | --- |
+| `gap_scheduler.start` | `start()` called | `enabled`, `pytest_detected`, `is_leader`, `force_disable`, `cron`, `worker_id` |
+| `gap_scheduler.skip` | A tick is skipped | `reason` |
+| `gap_scheduler.run.start` | Beginning a pass | `trigger` (`scheduled` / `manual`), `lookback_days`, `similarity_threshold`, `min_samples` |
+| `gap_scheduler.run.success` | Pass succeeded | `trigger`, `duration_ms`, `queries_analyzed`, `clusters`, `priority_gaps`, `report_id` |
+| `gap_scheduler.run.failure` | Pass raised | `trigger`, `duration_ms`, `error` |
+| `gap_scheduler.stop` | `stop()` called | `running` |
+
+Inspecting logs in production:
+
+```bash
+# Last 100 scheduler events
+journalctl -u acc-api -n 1000 | grep gap_scheduler
+
+# All runs since boot
+journalctl -u acc-api --since today | grep gap_scheduler.run
+```
+
+---
+
+## 5. Metrics
+
+`gap_metrics.py` is a tiny in-process bus.  Each scheduler pass fires
+the following metric names:
+
+- `gap_report_start`
+- `gap_report_skip`
+- `gap_report_run`
+- `gap_report_failure`
+
+Payloads always include `duration_ms` and `trigger`.  Successful runs
+add `queries_analyzed`, `clusters`, and `priority_gaps.{critical,high,medium,low}`.
+
+### Integrating with the existing monitoring stack
+
+The repo's monitoring stack lives in `monitoring/` (Prometheus +
+Grafana).  The scheduler's metrics are intentionally backend-agnostic
+— wire them in by registering an exporter on startup.  Suggested
+approach (not yet wired — see checklist below):
+
+```python
+from gap_metrics import register_backend
+
+def prometheus_backend(name, payload):
+    if name == "gap_report_run":
+        REPORT_DURATION.observe(payload["duration_ms"] / 1000)
+        REPORT_QUERIES.set(payload["queries_analyzed"])
+        REPORT_CLUSTERS.set(payload["clusters"])
+        # ... map priority gaps to labelled counters ...
+
+register_backend(prometheus_backend)
+```
+
+Until that wiring is added, the JSON log lines from §4 are the
+authoritative source of truth.
+
+---
+
+## 6. Running a report manually
+
+There are three options, listed from most to least recommended.
+
+1. **Production API** (no downtime, audit-friendly):
+
+   ```bash
+   curl -X POST -H "Authorization: Bearer $TOKEN" \
+        https://api.example.com/gdb/scheduler/run-now
+   ```
+
+2. **Inside the running container** (use sparingly; bypasses the
+   token gate):
+
+   ```bash
+   docker exec -it acc-api python -c "
+     import asyncio, gap_scheduler
+     from main import reviewer_client  # imported by the app
+     print(asyncio.run(gap_scheduler.run_once.__wrapped__('manual', ...)))"
+   ```
+
+   In practice prefer the endpoint.
+
+3. **One-off CLI** (used during bring-up; needs `MONGO_URI`):
+
+   ```bash
+   MONGO_URI=... python -c "
+   import asyncio, gap_scheduler
+   asyncio.run(gap_scheduler.run_once(
+       trigger='manual',
+       collection_provider=lambda: (
+           reviewer_client['ajrasakha']['answer_reviews'],
+           reviewer_client['ajrasakha']['golden_faqs'],
+           reviewer_client['ajrasakha']['queries'],
+       ),
+       embed_fn=embed_fn,
+   ))"
+   ```
+
+---
+
+## 7. Invalidating the cache
+
+The frontend reads the gap report from `/gdb/gap-report`, which
+caches results in memory for `GDB_REPORT_CACHE_TTL` seconds.  To force
+a re-fetch after a manual run:
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+     https://api.example.com/gdb/scheduler/invalidate-cache
+```
+
+The endpoint is also called automatically after a successful
+scheduled run.
+
+---
+
+## 8. Enabling scheduled runs
+
+Two conditions must both be true:
+
+1. **`GDB_SCHEDULER_ENABLED=true`** in the deployed `.env` /
+   `docker-compose.yml` / k8s `ConfigMap`.
+2. **`GDB_SCHEDULER_FORCE_DISABLE` is unset or `false`.**
+
+Additionally:
+
+- The process must be running under **pytest-free** conditions
+  (production, staging).
+- The process's `WORKER_ID` must be in `LEADER_WORKERS`.
+
+`start()` logs the final decision (`gap_scheduler.start` /
+`gap_scheduler.skip`).  If you don't see a `start` line within a
+minute of boot, inspect the `skip` reason — it will be one of:
+
+- `enabled=false`
+- `force_disable=true`
+- `pytest detected`
+- `worker_id=N not in leaders (...)`
+- `similarity_threshold out of range`
+- `min_samples out of range`
+- `lookback_days out of range`
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `gap_scheduler.start` line never appears | env vars not propagated to the running process | `docker exec acc-api env | grep GDB_` |
+| `skip reason="force_disable=true"` | Hard kill switch is on | unset `GDB_SCHEDULER_FORCE_DISABLE` and restart |
+| `skip reason="pytest detected"` | Running under pytest (should never happen in prod) | verify your process manager isn't running tests at boot |
+| `skip reason="worker_id=N not in leaders (...)"` | Wrong worker index | set `GDB_SCHEDULER_WORKER_ID` per process |
+| `failure error="SentenceTransformer must not be instantiated in tests…"` | Test harness reached prod code path | confirm you're not booting the API under pytest |
+| `failure error="model not loaded"` / similar | Embedding model download/cache missing | ensure `sentence-transformers` cache dir is mounted |
+| `/gdb/scheduler/state` returns 503 | `GDB_SCHEDULER_ADMIN_TOKEN` not set on the server | set the env var on the **server** (not the caller) |
+| `/gdb/scheduler/state` returns 401 | Caller token mismatch | re-check the bearer token; query-string `?token=...` works as a fallback |
+| Dashboard still shows stale data after `run-now` | Cache not invalidated | call `/gdb/scheduler/invalidate-cache` |
+| Weekly run did not appear in logs at the expected time | Wrong timezone on host | cron is evaluated in the **process** timezone — set `TZ=UTC` for predictability |
+| All queries `0`, clusters `0`, gaps `0` | `lookback_days` is too short, or `queries` collection is empty | bump `GDB_SCHEDULER_LOOKBACK_DAYS` and verify Mongo data |
+
+### Quick health check
+
+```bash
+TOKEN=$GDB_SCHEDULER_ADMIN_TOKEN
+API=https://api.example.com
+curl -fsS -H "Authorization: Bearer $TOKEN" $API/gdb/scheduler/state | jq .
+curl -fsS -X POST -H "Authorization: Bearer $TOKEN" $API/gdb/scheduler/invalidate-cache
+curl -fsS -X POST -H "Authorization: Bearer $TOKEN" $API/gdb/scheduler/run-now | jq .
+```
+
+If `/state` returns `running: true` and `last_run.success: true`, the
+scheduler is healthy.
+
+---
+
+## 10. Deployment checklist (still required before weekly production runs are real)
+
+The code is **operationally ready** but it is **not yet deployed**.
+Before you flip the weekly switch in production, the operator on call
+must complete every item below.
+
+- [ ] Set `GDB_SCHEDULER_ADMIN_TOKEN` in the production secrets store
+      (long random string, kept secret from the frontend).
+- [ ] Decide leader topology (typically worker 0 only, or workers 0+1
+      for redundancy) and set `GDB_SCHEDULER_LEADER_WORKERS` plus per-
+      process `GDB_SCHEDULER_WORKER_ID` in systemd unit /
+      docker-compose / k8s Deployment.
+- [ ] Set `GDB_SCHEDULER_ENABLED=true` and **remove**
+      `GDB_SCHEDULER_FORCE_DISABLE` from the production environment.
+- [ ] Confirm `MONGO_URI` is reachable from the API process and that
+      the Mongo user has read access to `answer_reviews`, `golden_faqs`,
+      and `queries`.
+- [ ] Confirm the `sentence-transformers` model cache is provisioned
+      (either pre-baked into the container image or mounted from a
+      shared volume).  The first run will fail if the model cannot be
+      downloaded.
+- [ ] Set `TZ=UTC` on the API process so cron evaluations are
+      timezone-stable.
+- [ ] Wire the Prometheus exporter described in §5 (or accept the JSON
+      log lines as the source of truth — either is fine, but pick one
+      and document it).
+- [ ] Add log shipping for the `gap_scheduler` logger to your log
+      aggregator with the same fields shown in §4.
+- [ ] Configure an external alerting rule: "no `gap_scheduler.run.success`
+      line in the last 7 days" → page on-call.
+- [ ] Run `curl POST /gdb/scheduler/run-now` once after deploy and
+      confirm a 200 response with non-zero `queries_analyzed`.
+- [ ] Verify the dashboard at `/gdb-gap-report` renders the new data
+      after `/gdb/scheduler/invalidate-cache`.
+- [ ] Remove `GDB_SCHEDULER_FORCE_DISABLE` from `.env.example` defaults
+      if and only if you decide weekly runs should be on-by-default
+      for *all* environments (current default is intentionally
+      off-by-default).
+
+Until every box above is ticked, the scheduler will log
+`skip reason="enabled=false"` (or `"force_disable=true"`) and produce
+no reports.  That is the correct, safe behaviour.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -16,6 +16,14 @@ VITE_API_BASE_URL=http://localhost:3141/api
 VITE_IS_DEVELOPMENT=true
 
 # ===================
+# ACC (Agri-Call-Centre) API
+# ===================
+# Base URL for the ACC service that exposes /gdb/gap-report and related
+# coverage-gap analytics endpoints. When unset, requests go to `/api/acc`
+# (handled by the Vite proxy in dev, or the reverse proxy in production).
+# VITE_ACC_API_BASE_URL=http://localhost:3141/api/acc
+
+# ===================
 # Firebase (Client-side)
 # ===================
 # Get these from Firebase Console > Project Settings > General > Your apps

--- a/frontend/src/components/mobile-sidebar.tsx
+++ b/frontend/src/components/mobile-sidebar.tsx
@@ -83,6 +83,8 @@ export const MobileSidebar = ({
       navigate({ to: "/chatbot" });
     } else if (value === "whatsapp_history") {
       navigate({ to: "/whatsapp-history" });
+    } else if (value === "gdb_gap_report") {
+      navigate({ to: "/gdb-gap-report" });
     } else {
       setTab(value);
       setActiveTab(value);
@@ -157,6 +159,16 @@ export const MobileSidebar = ({
 
     ...(user && user.role === "admin"
       ? [{ id: "data_processing", label: "Data Processing", icon: Database }]
+      : []),
+
+    ...(user && user.role === "admin"
+      ? [
+          {
+            id: "gdb_gap_report",
+            label: "GDB Gap Report",
+            icon: TrendingUp,
+          },
+        ]
       : []),
 
     ...(user && !isCoordinator && user.role !== "call_agent"

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -38,7 +38,10 @@ type EnvKey =
   | `VITE_PLIVO_${string}_PASSWORD`
   // FAQ / POP processing servers
   | "VITE_FAQ_API_URL"
-  | "VITE_POP_API_URL";
+  | "VITE_POP_API_URL"
+
+  // ACC API (gap-report + analytics)
+  | "VITE_ACC_API_BASE_URL";
 
 /**
  * Internal getter (single source of truth)
@@ -101,6 +104,11 @@ export const env = {
   // instead of JSON. Only an explicit VITE_FAQ_API_URL / VITE_POP_API_URL overrides this.
   faqApiUrl: () => getEnv("VITE_FAQ_API_URL", false, "") || `${apiBase()}/faq`,
   popApiUrl: () => getEnv("VITE_POP_API_URL", false, "") || `${apiBase()}/pop`,
+
+  // ACC (Agri-Call-Centre) API — provides the GDB coverage gap-report endpoint.
+  // Falls back to same-origin /api/acc so dev can proxy through Vite.
+  accApiBaseUrl: () =>
+    getEnv("VITE_ACC_API_BASE_URL", false, "/api/acc").replace(/\/$/, ""),
 };
 
 /** API base URL without a trailing slash, e.g. "https://…run.app/api". */

--- a/frontend/src/features/gdb-gap-dashboard/GapDashboardPage.tsx
+++ b/frontend/src/features/gdb-gap-dashboard/GapDashboardPage.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useMemo, useState } from "react";
+import { AlertTriangle, RefreshCw, BarChart3 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/atoms/card";
+import { Button } from "@/components/atoms/button";
+import { Skeleton } from "@/components/atoms/skeleton";
+import { KpiCards } from "./components/KpiCards";
+import { PriorityGapTable } from "./components/PriorityGapTable";
+import { TopGrowingTopicsChart } from "./components/TopGrowingTopicsChart";
+import { CoverageExplorer } from "./components/CoverageExplorer";
+import { Recommendations } from "./components/Recommendations";
+import { useGapReport } from "./hooks/useGapReport";
+import type { GapClusterItem, GapReportFilters } from "./types";
+
+/**
+ * Top-level page for the `/gdb/gap-report` dashboard.
+ *
+ * Responsibilities:
+ *  - Pull the report via TanStack Query (`useGapReport`)
+ *  - Manage the `refresh=true` body flag (default off → cached report)
+ *  - Manage the (crop, state, domain) facets for the client-side
+ *    coverage explorer (the backend ignores these)
+ *  - Render the loading / empty / error states the spec calls for
+ *
+ * The page is intentionally framework-light: every visual concern lives
+ * in its own sub-component so they can be unit-tested in isolation.
+ */
+export function GapDashboardPage() {
+  const [refresh, setRefresh] = useState(false);
+  const [crop, setCrop] = useState<string | undefined>();
+  const [stateFilter, setStateFilter] = useState<string | undefined>();
+  const [domain, setDomain] = useState<string | undefined>();
+
+  const filters: GapReportFilters = useMemo(
+    () => ({
+      ...(crop ? { crop } : {}),
+      ...(stateFilter ? { state: stateFilter } : {}),
+      ...(domain ? { domain } : {}),
+    }),
+    [crop, stateFilter, domain],
+  );
+
+  const { data, isLoading, isFetching, isError, error, refetch } = useGapReport({
+    refresh,
+    filters,
+  });
+
+  const handleRefresh = useCallback(() => {
+    setRefresh(true);
+    // Force the request to refetch immediately with `refresh=true` in
+    // the body so the backend drops its in-process cache.
+    refetch();
+  }, [refetch]);
+
+  const isInitialLoad = isLoading && !data;
+
+  // Flatten the gap table rows from either `top_gaps` (preferred) or a
+  // sweep across every `gaps_by_priority` bucket.
+  const priorityGapRows: GapClusterItem[] = useMemo(() => {
+    if (data?.top_gaps && data.top_gaps.length > 0) return data.top_gaps;
+    if (data?.gaps_by_priority && typeof data.gaps_by_priority === "object") {
+      const flat: GapClusterItem[] = [];
+      for (const bucket of Object.values(data.gaps_by_priority)) {
+        if (Array.isArray(bucket)) {
+          for (const item of bucket) {
+            if (item) flat.push(item);
+          }
+        }
+      }
+      return flat;
+    }
+    return [];
+  }, [data]);
+
+  const hasData =
+    !!data &&
+    ((data.clusters?.length ?? 0) > 0 ||
+      priorityGapRows.length > 0 ||
+      (data.recommendations?.length ?? 0) > 0 ||
+      (data.coverage_bands ? Object.keys(data.coverage_bands).length > 0 : false));
+
+  const generatedAt = data?.generated_at
+    ? new Date(data.generated_at).toLocaleString()
+    : null;
+
+  const windowLabel =
+    data?.window?.start && data?.window?.end
+      ? `${data.window.start} → ${data.window.end}` +
+        (data.window.days ? ` (${data.window.days} days)` : "")
+      : null;
+
+  return (
+    <main
+      className="min-h-screen bg-background"
+      aria-labelledby="gdb-gap-dashboard-title"
+    >
+      <div className="mx-auto flex max-w-7xl flex-col gap-6 p-4 sm:p-6">
+        {/* Header */}
+        <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1
+              id="gdb-gap-dashboard-title"
+              className="flex items-center gap-2 text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
+            >
+              <BarChart3 aria-hidden="true" className="h-6 w-6 text-primary" />
+              GDB Coverage Gap Report
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Demand-side signals vs. Golden Dataset coverage, refreshed from
+              the ACC{" "}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                /gdb/gap-report
+              </code>{" "}
+              endpoint.
+              {generatedAt ? ` Last generated ${generatedAt}.` : ""}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {windowLabel && (
+              <span className="inline-flex items-center rounded-md border bg-card px-2 py-1 text-xs text-muted-foreground">
+                Window: {windowLabel}
+              </span>
+            )}
+            <Button
+              type="button"
+              onClick={handleRefresh}
+              disabled={isFetching}
+              aria-label="Refresh gap report from the server"
+              data-testid="gap-report-refresh"
+            >
+              <RefreshCw
+                aria-hidden="true"
+                className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+              />
+              {isFetching ? "Refreshing…" : "Refresh"}
+            </Button>
+          </div>
+        </header>
+
+        {/* Body */}
+        {isError ? (
+          <ErrorState
+            message={
+              error instanceof Error
+                ? error.message
+                : "Unable to load the gap report."
+            }
+            onRetry={handleRefresh}
+          />
+        ) : isInitialLoad ? (
+          <LoadingState />
+        ) : !hasData ? (
+          <EmptyState onRefresh={handleRefresh} isFetching={isFetching} />
+        ) : (
+          <div
+            className="grid gap-6"
+            data-testid="gap-report-content"
+            aria-busy={isFetching}
+          >
+            <KpiCards report={data} />
+
+            <div className="grid gap-6 lg:grid-cols-3">
+              <Card className="lg:col-span-2">
+                <CardHeader>
+                  <CardTitle>Priority gaps</CardTitle>
+                  <CardDescription>
+                    Searchable and sortable list of the most urgent
+                    (crop × state × domain) coverage gaps surfaced by the
+                    pipeline. Expand a row to inspect sample farmer questions.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <PriorityGapTable gaps={priorityGapRows} />
+                </CardContent>
+              </Card>
+              <div className="space-y-6">
+                <TopGrowingTopicsChart clusters={data?.clusters} />
+                <Recommendations report={data} />
+              </div>
+            </div>
+
+            <CoverageExplorer
+              clusters={data?.clusters ?? []}
+              bands={data?.coverage_bands}
+              crop={crop}
+              state={stateFilter}
+              domain={domain}
+              onCropChange={setCrop}
+              onStateChange={setStateFilter}
+              onDomainChange={setDomain}
+            />
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+/* ----------------------------- sub-components ----------------------------- */
+
+function LoadingState() {
+  return (
+    <div
+      className="grid gap-6"
+      role="status"
+      aria-live="polite"
+      aria-label="Loading gap report"
+      data-testid="gap-report-loading"
+    >
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 w-full" />
+        ))}
+      </div>
+      <Skeleton className="h-64 w-full" />
+      <Skeleton className="h-96 w-full" />
+    </div>
+  );
+}
+
+function EmptyState({
+  onRefresh,
+  isFetching,
+}: {
+  onRefresh: () => void;
+  isFetching: boolean;
+}) {
+  return (
+    <Card data-testid="gap-report-empty" role="status">
+      <CardHeader>
+        <CardTitle>No gap report yet</CardTitle>
+        <CardDescription>
+          The pipeline has not produced any data for this account. This
+          usually resolves itself once the cron job has had a chance to run
+          after the first day of activity.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          type="button"
+          onClick={onRefresh}
+          disabled={isFetching}
+          aria-label="Trigger a fresh gap-report fetch"
+        >
+          <RefreshCw
+            aria-hidden="true"
+            className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+          />
+          {isFetching ? "Refreshing…" : "Refresh"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <Card
+      data-testid="gap-report-error"
+      role="alert"
+      className="border-red-200 bg-red-50"
+    >
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-red-700">
+          <AlertTriangle aria-hidden="true" className="h-5 w-5" />
+          Could not load the gap report
+        </CardTitle>
+        <CardDescription className="text-red-700/80">
+          {message}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button type="button" variant="outline" onClick={onRetry}>
+          <RefreshCw aria-hidden="true" className="h-4 w-4" />
+          Retry
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default GapDashboardPage;

--- a/frontend/src/features/gdb-gap-dashboard/__tests__/api.test.ts
+++ b/frontend/src/features/gdb-gap-dashboard/__tests__/api.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for the low-level `fetchGapReport` client.
+ *
+ * The contract under test:
+ *   POST {accApiBaseUrl}/gdb/gap-report
+ *   Content-Type: application/json
+ *   Body: { similarity_threshold, min_samples, lookback_days, refresh }
+ *
+ * We assert:
+ *   - the URL composition (just the path, no query string)
+ *   - that `refresh=true` is sent in the JSON body when the user opts in
+ *   - that the request uses POST (not GET) and includes a JSON body
+ *   - that non-2xx responses throw with the server-provided message when
+ *     available, and a useful fallback message otherwise
+ */
+
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildGapReportBody, buildGapReportUrl, fetchGapReport } from "../api";
+import type { GapReport } from "../types";
+
+// Hoisted mocks so we can manipulate them per-test.
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+type MockResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+function buildResponse(body: unknown, ok = true, status = 200): MockResponse {
+  const text = JSON.stringify(body);
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => text,
+  };
+}
+
+const MOCK_REPORT: GapReport = {
+  report_id: "test-report",
+  generated_at: "2026-07-28T12:00:00Z",
+  window: { start: "2026-07-01", end: "2026-07-28", days: 28 },
+  total_queries_analyzed: 240,
+  total_clusters_found: 12,
+  gaps_by_priority: {
+    critical: [
+      {
+        cluster_id: "cotton-punjab-pest",
+        theme: "Pest control in cotton",
+        query_count: 12,
+        recent_query_count: 9,
+        previous_query_count: 3,
+        total_query_count: 12,
+        avg_weekly_growth_pct: 0.38,
+        domain: "pest",
+        crops: ["cotton"],
+        states: ["Punjab"],
+        top_crop: "cotton",
+        top_state: "Punjab",
+        priority: "critical",
+        priority_score: 0.91,
+        gdb_coverage_band: "GAP",
+        gdb_coverage_hits: 0,
+        gdb_coverage_score: 0,
+        suggested_action: "Author pest/cotton/Punjab Q&A",
+        sample_queries: ["Why are leaves turning yellow?"],
+      },
+    ],
+    high: [],
+    medium: [],
+    low: [],
+  },
+  coverage_bands: { STRONG: 4, PARTIAL: 5, GAP: 3 },
+  top_gaps: [
+    {
+      cluster_id: "cotton-punjab-pest",
+      theme: "Pest control in cotton",
+      query_count: 12,
+      recent_query_count: 9,
+      previous_query_count: 3,
+      total_query_count: 12,
+      avg_weekly_growth_pct: 0.38,
+      domain: "pest",
+      crops: ["cotton"],
+      states: ["Punjab"],
+      top_crop: "cotton",
+      top_state: "Punjab",
+      priority: "critical",
+      priority_score: 0.91,
+      gdb_coverage_band: "GAP",
+      gdb_coverage_hits: 0,
+      gdb_coverage_score: 0,
+      suggested_action: "Author pest/cotton/Punjab Q&A",
+      sample_queries: ["Why are leaves turning yellow?"],
+    },
+  ],
+  clusters: [
+    {
+      cluster_id: "cotton-punjab-pest",
+      theme: "Pest control in cotton",
+      query_count: 12,
+      recent_query_count: 9,
+      previous_query_count: 3,
+      total_query_count: 12,
+      avg_weekly_growth_pct: 0.38,
+      domain: "pest",
+      crops: ["cotton"],
+      states: ["Punjab"],
+      top_crop: "cotton",
+      top_state: "Punjab",
+      priority: "critical",
+      priority_score: 0.91,
+      gdb_coverage_band: "GAP",
+      gdb_coverage_hits: 0,
+      gdb_coverage_score: 0,
+      suggested_action: "Author pest/cotton/Punjab Q&A",
+      sample_queries: ["Why are leaves turning yellow?"],
+    },
+  ],
+  recommendations: ["Prioritise pest/cotton/Punjab Q&A authoring."],
+};
+
+describe("buildGapReportUrl", () => {
+  it("returns the canonical endpoint (no query string)", () => {
+    const url = buildGapReportUrl();
+    expect(url).toContain("/gdb/gap-report");
+    expect(url).not.toContain("?");
+  });
+});
+
+describe("buildGapReportBody", () => {
+  it("defaults refresh to false and uses backend defaults for tuning knobs", () => {
+    const body = buildGapReportBody();
+    expect(body.refresh).toBe(false);
+    expect(body.similarity_threshold).toBe(0.85);
+    expect(body.min_samples).toBe(2);
+    expect(body.lookback_days).toBeNull();
+  });
+
+  it("honours refresh=true when the caller asks for a refresh", () => {
+    const body = buildGapReportBody({ refresh: true });
+    expect(body.refresh).toBe(true);
+  });
+
+  it("ignores UI-only filters (they are applied client-side)", () => {
+    const body = buildGapReportBody({
+      filters: { crop: "wheat", state: "Punjab", domain: "pest" },
+    });
+    expect(body).not.toHaveProperty("crop");
+    expect(body).not.toHaveProperty("state");
+    expect(body).not.toHaveProperty("domain");
+  });
+});
+
+describe("fetchGapReport", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("POSTs to /gdb/gap-report and returns the parsed report", async () => {
+    fetchMock.mockResolvedValueOnce(buildResponse(MOCK_REPORT));
+
+    const report = await fetchGapReport({ refresh: false, filters: {} });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/gdb/gap-report");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({
+      similarity_threshold: 0.85,
+      min_samples: 2,
+      lookback_days: null,
+      refresh: false,
+    });
+    expect(report.total_queries_analyzed).toBe(240);
+    expect(report.clusters?.[0].theme).toBe("Pest control in cotton");
+  });
+
+  it("sends refresh=true in the body when refresh is requested", async () => {
+    fetchMock.mockResolvedValueOnce(buildResponse(MOCK_REPORT));
+
+    await fetchGapReport({ refresh: true });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body).refresh).toBe(true);
+  });
+
+  it("throws the server's error message when the request fails", async () => {
+    fetchMock.mockResolvedValueOnce(
+      buildResponse(
+        { message: "pipeline not ready" },
+        false,
+        503,
+      ),
+    );
+
+    await expect(
+      fetchGapReport({ refresh: false, filters: {} }),
+    ).rejects.toThrow(/pipeline not ready/);
+  });
+
+  it("falls back to a sensible message when the error body is empty", async () => {
+    fetchMock.mockResolvedValueOnce(buildResponse({}, false, 500));
+
+    await expect(
+      fetchGapReport({ refresh: false, filters: {} }),
+    ).rejects.toThrow();
+  });
+});

--- a/frontend/src/features/gdb-gap-dashboard/api.ts
+++ b/frontend/src/features/gdb-gap-dashboard/api.ts
@@ -1,0 +1,78 @@
+import { apiFetch } from "@/hooks/api/api-fetch";
+import { env } from "@/config/env";
+import type {
+  GapReport,
+  GapReportFilters,
+  GapReportRequestBody,
+} from "./types";
+
+/**
+ * Builds the absolute URL for the ACC `/gdb/gap-report` endpoint.
+ *
+ * The base URL is sourced from `VITE_ACC_API_BASE_URL` (falling back to
+ * same-origin `/api/acc` so Vite/nginx can proxy through). The path is
+ * hard-coded so the dashboard never drifts from the API contract.
+ *
+ * NOTE: this endpoint is `POST`, so no filters are appended to the URL.
+ * Filters (`crop`, `state`, `domain`) are applied client-side in the
+ * Coverage Explorer because the backend does not honour them.
+ */
+export function buildGapReportUrl(): string {
+  const base = env.accApiBaseUrl();
+  return `${base}/gdb/gap-report`;
+}
+
+/**
+ * Builds the JSON request body for `POST /gdb/gap-report`.
+ *
+ * The body mirrors the FastAPI `GapReportRequest` Pydantic model — every
+ * field is optional and defaults to the server-side defaults
+ * (similarity_threshold=0.85, min_samples=2, lookback_days=None,
+ * refresh=False).
+ *
+ * `refresh=true` drops the in-process cache before rebuilding the report
+ * from MongoDB.
+ */
+export function buildGapReportBody(opts: {
+  refresh?: boolean;
+  filters?: GapReportFilters;
+} = {}): GapReportRequestBody {
+  // The backend does not currently accept crop/state/domain filters in
+  // the request body — they are intentionally omitted. The dashboard
+  // exposes them as a client-side facet on the response.
+  void opts.filters;
+  return {
+    similarity_threshold: 0.85,
+    min_samples: 2,
+    lookback_days: null,
+    refresh: Boolean(opts.refresh),
+  };
+}
+
+/**
+ * Fetches the full GDB gap-report payload from the ACC API via POST.
+ *
+ * Uses the project's existing `apiFetch` helper for auth headers, JSON
+ * content-type, timeout handling, and 401 → /auth redirect semantics.
+ * The helper already parses JSON and surfaces non-2xx responses as a
+ * thrown `Error`, so we simply narrow the result and let React Query
+ * handle retry / error rendering.
+ */
+export async function fetchGapReport(opts: {
+  refresh?: boolean;
+  filters?: GapReportFilters;
+  signal?: AbortSignal;
+} = {}): Promise<GapReport> {
+  const url = buildGapReportUrl();
+  const body = buildGapReportBody(opts);
+  const data = await apiFetch<GapReport>(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: opts.signal,
+  });
+  if (!data) {
+    throw new Error("Gap report response was empty");
+  }
+  return data;
+}

--- a/frontend/src/features/gdb-gap-dashboard/components/CoverageExplorer.tsx
+++ b/frontend/src/features/gdb-gap-dashboard/components/CoverageExplorer.tsx
@@ -1,0 +1,253 @@
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/atoms/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/atoms/select";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/atoms/card";
+import type { CoverageState, GapClusterItem } from "../types";
+
+function coverageClasses(state?: CoverageState) {
+  const value = (state ?? "").toUpperCase();
+  if (value === "STRONG") return "bg-emerald-100 text-emerald-900 border-emerald-300";
+  if (value === "PARTIAL") return "bg-amber-100 text-amber-900 border-amber-300";
+  if (value === "GAP") return "bg-red-100 text-red-900 border-red-300";
+  return "bg-muted text-muted-foreground border-border";
+}
+
+/**
+ * Compute coverage-band counts from either:
+ *   - the backend's pre-aggregated `coverage_bands` summary map, or
+ *   - a fresh roll-up across the cluster list when the map is missing.
+ */
+function bandCounts(
+  bands: Partial<Record<CoverageState, number | GapClusterItem[]>> | null | undefined,
+  clusters: GapClusterItem[],
+) {
+  const out = { STRONG: 0, PARTIAL: 0, GAP: 0, OTHER: 0 };
+  if (bands && typeof bands === "object") {
+    for (const [k, v] of Object.entries(bands)) {
+      const key = k.toUpperCase();
+      if (key === "STRONG" || key === "PARTIAL" || key === "GAP") {
+        out[key as "STRONG" | "PARTIAL" | "GAP"] = Array.isArray(v) ? v.length : (v ?? 0);
+      } else if (typeof v === "number" || Array.isArray(v)) {
+        out.OTHER += Array.isArray(v) ? v.length : (v ?? 0);
+      }
+    }
+    return out;
+  }
+  for (const c of clusters) {
+    const k = (c.gdb_coverage_band ?? "").toUpperCase();
+    if (k === "STRONG" || k === "PARTIAL" || k === "GAP") {
+      out[k as "STRONG" | "PARTIAL" | "GAP"] += 1;
+    } else {
+      out.OTHER += 1;
+    }
+  }
+  return out;
+}
+
+export interface CoverageExplorerProps {
+  clusters: GapClusterItem[];
+  bands?: Partial<Record<CoverageState, number | GapClusterItem[]>> | null;
+  crop?: string;
+  state?: string;
+  domain?: string;
+  onCropChange: (v: string | undefined) => void;
+  onStateChange: (v: string | undefined) => void;
+  onDomainChange: (v: string | undefined) => void;
+}
+
+/**
+ * Drill-down explorer for the (crop × state × domain) coverage space.
+ *
+ * The backend does not currently accept these filters in the request
+ * body, so the explorer applies them on the client over the full
+ * cluster list.  Every cell is colour-coded by its coverage band:
+ *
+ *   - STRONG  → solid coverage, no action needed
+ *   - PARTIAL → partial coverage, optional follow-up
+ *   - GAP     → no coverage, candidate for outreach
+ */
+export function CoverageExplorer({
+  clusters,
+  bands,
+  crop,
+  state,
+  domain,
+  onCropChange,
+  onStateChange,
+  onDomainChange,
+}: CoverageExplorerProps) {
+  const crops = useMemo(
+    () =>
+      Array.from(
+        new Set(clusters.flatMap((c) => c.crops ?? [])),
+      ).filter(Boolean).sort() as string[],
+    [clusters],
+  );
+  const states = useMemo(
+    () =>
+      Array.from(
+        new Set(clusters.flatMap((c) => c.states ?? [])),
+      ).filter(Boolean).sort() as string[],
+    [clusters],
+  );
+  const domains = useMemo(
+    () =>
+      Array.from(
+        new Set(clusters.map((c) => c.domain).filter(Boolean)),
+      ).sort() as string[],
+    [clusters],
+  );
+
+  const filtered = useMemo(() => {
+    return clusters.filter((c) => {
+      if (crop && !(c.crops ?? []).includes(crop)) return false;
+      if (state && !(c.states ?? []).includes(state)) return false;
+      if (domain && c.domain !== domain) return false;
+      return true;
+    });
+  }, [clusters, crop, state, domain]);
+
+  const counts = useMemo(() => bandCounts(bands, filtered), [bands, filtered]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Coverage explorer</CardTitle>
+        <CardDescription>
+          Drill into (crop × state × domain) coverage cells. Use the filters to
+          narrow down to a specific audience.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <FacetSelect
+            label="Crop"
+            value={crop}
+            options={crops}
+            onChange={onCropChange}
+          />
+          <FacetSelect
+            label="State"
+            value={state}
+            options={states}
+            onChange={onStateChange}
+          />
+          <FacetSelect
+            label="Domain"
+            value={domain}
+            options={domains}
+            onChange={onDomainChange}
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-2 text-xs">
+          <Badge className="bg-emerald-100 text-emerald-900 border-emerald-300">
+            STRONG: {counts.STRONG}
+          </Badge>
+          <Badge className="bg-amber-100 text-amber-900 border-amber-300">
+            PARTIAL: {counts.PARTIAL}
+          </Badge>
+          <Badge className="bg-red-100 text-red-900 border-red-300">
+            GAP: {counts.GAP}
+          </Badge>
+          {counts.OTHER > 0 && (
+            <Badge variant="outline">Other: {counts.OTHER}</Badge>
+          )}
+        </div>
+
+        {filtered.length === 0 ? (
+          <p
+            className="rounded-md border border-dashed p-4 text-sm text-muted-foreground"
+            role="status"
+          >
+            No coverage cells match the current filters.
+          </p>
+        ) : (
+          <div
+            className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3"
+            role="list"
+            aria-label="Coverage cells"
+          >
+            {filtered.map((c, idx) => (
+              <div
+                role="listitem"
+                key={`${c.cluster_id ?? c.theme}-${idx}`}
+                className={cn(
+                  "rounded-md border p-3 text-sm",
+                  coverageClasses(c.gdb_coverage_band),
+                )}
+              >
+                <p className="font-medium">
+                  {c.top_crop || "—"} · {c.top_state || "—"}
+                </p>
+                <p className="text-xs opacity-80">{c.domain || "—"}</p>
+                <p className="mt-1 text-xs">
+                  Theme: <span className="font-medium">{c.theme || "—"}</span>
+                </p>
+                <p className="mt-1 text-xs tabular-nums">
+                  Queries: {c.query_count ?? "—"}
+                  {c.gdb_coverage_score !== undefined
+                    ? ` · coverage score ${c.gdb_coverage_score.toFixed(2)}`
+                    : ""}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <p className="text-xs text-muted-foreground">
+          Showing {filtered.length} of {clusters.length} cells.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FacetSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value?: string;
+  options: string[];
+  onChange: (v: string | undefined) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs font-medium text-muted-foreground" htmlFor={`facet-${label}`}>
+        {label}
+      </label>
+      <Select
+        value={value ?? "__all__"}
+        onValueChange={(v) => onChange(v === "__all__" ? undefined : v)}
+      >
+        <SelectTrigger id={`facet-${label}`} className="w-full">
+          <SelectValue placeholder={`All ${label.toLowerCase()}s`} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="__all__">All {label.toLowerCase()}s</SelectItem>
+          {options.map((opt) => (
+            <SelectItem key={opt} value={opt}>
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/frontend/src/features/gdb-gap-dashboard/components/KpiCards.tsx
+++ b/frontend/src/features/gdb-gap-dashboard/components/KpiCards.tsx
@@ -1,0 +1,135 @@
+import { AlertTriangle, HelpCircle, MapPin, Sprout } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/atoms/card";
+import type { GapClusterItem, GapReport } from "../types";
+
+/**
+ * Derives the four top-level KPIs directly from the backend response.
+ *
+ * Because the backend ships a *raw* gap-report (not a pre-computed KPI
+ * block), every metric is computed on the client from `clusters`,
+ * `total_queries_analyzed`, and `gaps_by_priority`.  The values are
+ * intentionally defensive — each one falls back to `—` (em dash) when
+ * the input data is missing so the UI never shows a stale number.
+ */
+export function deriveKpis(report?: GapReport) {
+  const clusters: GapClusterItem[] = report?.clusters ?? [];
+
+  // Unanswered demand = total farmer queries that fell through to a gap
+  // inside the current demand window. The backend already pre-aggregates
+  // this in `total_queries_analyzed`; we also derive from clusters as a
+  // fallback when the aggregate is absent.
+  const unansweredDemand =
+    report?.total_queries_analyzed ??
+    clusters.reduce((sum, c) => sum + (c.query_count ?? 0), 0);
+
+  // Priority gaps = sum of clusters in the "critical" / "high" buckets
+  // (falls back to total clusters when the bucket map is missing).
+  const priorityBuckets = report?.gaps_by_priority;
+  let priorityGaps: number | undefined;
+  if (priorityBuckets && typeof priorityBuckets === "object") {
+    const critical = priorityBuckets.critical?.length ?? 0;
+    const high = priorityBuckets.high?.length ?? 0;
+    priorityGaps = critical + high;
+  }
+  if (priorityGaps === undefined || priorityGaps === 0) {
+    priorityGaps = report?.total_clusters_found ?? clusters.length;
+  }
+
+  // Fastest-growing topic = the cluster with the highest growth ratio.
+  // When the report is missing or empty we fall back to `null`.
+  const fastestGrowing =
+    clusters.length === 0
+      ? null
+      : clusters.reduce((best, c) =>
+          (c.avg_weekly_growth_pct ?? 0) > (best.avg_weekly_growth_pct ?? 0)
+            ? c
+            : best,
+        );
+
+  // Regions with gaps = the union of `states` across all clusters.
+  const regionSet = new Set<string>();
+  for (const c of clusters) {
+    for (const s of c.states ?? []) {
+      if (s) regionSet.add(s);
+    }
+  }
+
+  return {
+    unanswered_demand: unansweredDemand,
+    priority_gaps: priorityGaps,
+    fastest_growing_topic: fastestGrowing?.theme ?? null,
+    regions_with_gaps: regionSet.size,
+  };
+}
+
+/**
+ * Renders the four KPI cards. Each value is independently rendered so
+ * the grid still shows partial data when the backend omits one field.
+ */
+export function KpiCards({ report }: { report?: GapReport }) {
+  const kpis = deriveKpis(report);
+
+  const items = [
+    {
+      key: "unanswered_demand",
+      label: "Unanswered demand",
+      value: kpis.unanswered_demand,
+      icon: HelpCircle,
+      accent: "text-amber-500",
+    },
+    {
+      key: "priority_gaps",
+      label: "Priority gaps",
+      value: kpis.priority_gaps,
+      icon: AlertTriangle,
+      accent: "text-red-500",
+    },
+    {
+      key: "fastest_growing_topic",
+      label: "Fastest-growing topic",
+      value: kpis.fastest_growing_topic ?? "—",
+      icon: Sprout,
+      accent: "text-emerald-500",
+    },
+    {
+      key: "regions_with_gaps",
+      label: "Regions with gaps",
+      value: kpis.regions_with_gaps,
+      icon: MapPin,
+      accent: "text-sky-500",
+    },
+  ] as const;
+
+  return (
+    <ul
+      className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+      aria-label="Gap-report key performance indicators"
+    >
+      {items.map(({ key, label, value, icon: Icon, accent }) => (
+        <li key={key}>
+          <Card aria-label={`${label} KPI`}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {label}
+              </CardTitle>
+              <Icon aria-hidden="true" className={`h-4 w-4 ${accent}`} />
+            </CardHeader>
+            <CardContent>
+              <p
+                data-testid={`kpi-${key}`}
+                className="text-2xl font-semibold tabular-nums"
+              >
+                {value === undefined || value === null ? "—" : String(value)}
+              </p>
+            </CardContent>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/features/gdb-gap-dashboard/components/PriorityGapTable.tsx
+++ b/frontend/src/features/gdb-gap-dashboard/components/PriorityGapTable.tsx
@@ -1,0 +1,340 @@
+import { Fragment, useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown, ChevronDown, ChevronRight } from "lucide-react";
+import { Badge } from "@/components/atoms/badge";
+import { Button } from "@/components/atoms/button";
+import { Input } from "@/components/atoms/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/atoms/table";
+import { cn } from "@/lib/utils";
+import type { CoverageState, GapClusterItem, PriorityBucket } from "../types";
+
+/**
+ * Priority ordering used by the table sort.  Anything not listed falls
+ * to the end of the ordering.
+ */
+const PRIORITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+function priorityVariant(priority?: PriorityBucket) {
+  switch ((priority ?? "").toLowerCase()) {
+    case "critical":
+      return "destructive" as const;
+    case "high":
+      return "default" as const;
+    case "medium":
+      return "secondary" as const;
+    case "low":
+      return "outline" as const;
+    default:
+      return "outline" as const;
+  }
+}
+
+function priorityLabel(priority?: PriorityBucket) {
+  if (!priority) return "—";
+  const v = String(priority).toUpperCase();
+  return v.length > 0 ? v : "—";
+}
+
+function formatPct(ratio?: number) {
+  if (ratio === undefined || ratio === null || Number.isNaN(ratio)) return "—";
+  const pct = ratio * 100;
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct.toFixed(1)}%`;
+}
+
+function formatGrowthIndicator(ratio?: number) {
+  if (ratio === undefined || ratio === null) return null;
+  if (ratio > 0.05) {
+    return { color: "text-emerald-600", Icon: ArrowUp, label: "growing" };
+  }
+  if (ratio < -0.05) {
+    return { color: "text-red-600", Icon: ArrowDown, label: "shrinking" };
+  }
+  return { color: "text-muted-foreground", Icon: ArrowUpDown, label: "stable" };
+}
+
+function coverageBadge(state?: CoverageState) {
+  const value = (state ?? "").toUpperCase();
+  if (value === "STRONG") return "bg-emerald-100 text-emerald-800 border-emerald-200";
+  if (value === "PARTIAL") return "bg-amber-100 text-amber-800 border-amber-200";
+  if (value === "GAP") return "bg-red-100 text-red-800 border-red-200";
+  return "bg-muted text-muted-foreground border-border";
+}
+
+type SortKey =
+  | "priority"
+  | "query_count"
+  | "avg_weekly_growth_pct"
+  | "theme"
+  | "top_crop"
+  | "top_state";
+type SortDir = "asc" | "desc";
+
+export interface PriorityGapTableProps {
+  gaps: GapClusterItem[];
+  /** Optional id used for tests / a11y labelling. */
+  ariaLabelledBy?: string;
+}
+
+/**
+ * Searchable, sortable, expandable priority-gap table.
+ *
+ * The rows are the clusters returned by the GDB detector, displayed in
+ * priority order.  The sort headers let product owners flip the table
+ * by demand volume, growth, crop, state, or theme.  Each row is
+ * expandable to reveal the sample farmer questions captured by the
+ * pipeline.
+ */
+export function PriorityGapTable({ gaps, ariaLabelledBy }: PriorityGapTableProps) {
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("priority");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return gaps;
+    return gaps.filter((g) => {
+      return (
+        g.theme?.toLowerCase().includes(q) ||
+        g.domain?.toLowerCase().includes(q) ||
+        g.crops?.some((c) => c?.toLowerCase().includes(q)) ||
+        g.states?.some((s) => s?.toLowerCase().includes(q))
+      );
+    });
+  }, [gaps, query]);
+
+  const sorted = useMemo(() => {
+    const dir = sortDir === "asc" ? 1 : -1;
+    return [...filtered].sort((a, b) => {
+      switch (sortKey) {
+        case "priority": {
+          const av = PRIORITY_ORDER[(a.priority ?? "").toLowerCase()] ?? 99;
+          const bv = PRIORITY_ORDER[(b.priority ?? "").toLowerCase()] ?? 99;
+          return (av - bv) * dir;
+        }
+        case "query_count":
+        case "avg_weekly_growth_pct": {
+          const av = (a[sortKey] ?? 0) as number;
+          const bv = (b[sortKey] ?? 0) as number;
+          return (av - bv) * dir;
+        }
+        case "theme":
+        case "top_crop":
+        case "top_state": {
+          const av = ((a[sortKey] ?? "") as string).toLowerCase();
+          const bv = ((b[sortKey] ?? "") as string).toLowerCase();
+          if (av < bv) return -1 * dir;
+          if (av > bv) return 1 * dir;
+          return 0;
+        }
+        default:
+          return 0;
+      }
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
+
+  const toggleRow = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const renderSortHeader = (key: SortKey, label: string, className?: string) => (
+    <TableHead className={className}>
+      <button
+        type="button"
+        onClick={() => toggleSort(key)}
+        className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground hover:text-foreground"
+        aria-label={`Sort by ${label} (${
+          sortKey === key && sortDir === "asc" ? "descending" : "ascending"
+        })`}
+      >
+        {label}
+        {sortKey === key ? (
+          sortDir === "asc" ? (
+            <ArrowUp aria-hidden="true" className="h-3 w-3" />
+          ) : (
+            <ArrowDown aria-hidden="true" className="h-3 w-3" />
+          )
+        ) : (
+          <ArrowUpDown aria-hidden="true" className="h-3 w-3 opacity-50" />
+        )}
+      </button>
+    </TableHead>
+  );
+
+  if (gaps.length === 0) {
+    return (
+      <div
+        className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground"
+        role="status"
+      >
+        No priority gaps detected for the current filters.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <Input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search by theme, crop, state, or domain"
+          aria-label="Search priority gaps"
+          className="max-w-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          {sorted.length} of {gaps.length} shown
+        </p>
+      </div>
+
+      <div className="rounded-md border">
+        <Table aria-labelledby={ariaLabelledBy}>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10" aria-label="Expand" />
+              {renderSortHeader("priority", "Priority")}
+              {renderSortHeader("theme", "Theme")}
+              {renderSortHeader("top_crop", "Crop")}
+              {renderSortHeader("top_state", "State")}
+              <TableHead>Domain</TableHead>
+              {renderSortHeader("query_count", "Unanswered", "text-right")}
+              {renderSortHeader("avg_weekly_growth_pct", "Growth", "text-right")}
+              <TableHead>Coverage</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sorted.map((gap, idx) => {
+              const rowId = gap.cluster_id ?? `${gap.theme}-${idx}`;
+              const isOpen = expanded.has(rowId);
+              const growth = formatGrowthIndicator(gap.avg_weekly_growth_pct);
+              return (
+                <Fragment key={rowId}>
+                  <TableRow data-state={isOpen ? "selected" : undefined}>
+                    <TableCell>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6"
+                        aria-expanded={isOpen}
+                        aria-controls={`samples-${rowId}`}
+                        aria-label={
+                          isOpen ? "Collapse sample questions" : "Expand sample questions"
+                        }
+                        onClick={() => toggleRow(rowId)}
+                      >
+                        {isOpen ? (
+                          <ChevronDown aria-hidden="true" className="h-4 w-4" />
+                        ) : (
+                          <ChevronRight aria-hidden="true" className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={priorityVariant(gap.priority)}>
+                        {priorityLabel(gap.priority)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-medium">{gap.theme || "—"}</TableCell>
+                    <TableCell>{gap.top_crop || "—"}</TableCell>
+                    <TableCell>{gap.top_state || "—"}</TableCell>
+                    <TableCell>{gap.domain || "—"}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {gap.query_count ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {growth ? (
+                        <span
+                          className={cn(
+                            "inline-flex items-center gap-1 text-sm tabular-nums",
+                            growth.color,
+                          )}
+                          aria-label={`Growth ${formatPct(
+                            gap.avg_weekly_growth_pct,
+                          )} (${growth.label})`}
+                        >
+                          <growth.Icon aria-hidden="true" className="h-3 w-3" />
+                          {formatPct(gap.avg_weekly_growth_pct)}
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={cn(
+                          "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
+                          coverageBadge(gap.gdb_coverage_band),
+                        )}
+                      >
+                        {(gap.gdb_coverage_band ?? "UNKNOWN").toString()}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                  {isOpen && (
+                    <TableRow
+                      id={`samples-${rowId}`}
+                      className="bg-muted/40 hover:bg-muted/40"
+                    >
+                      <TableCell />
+                      <TableCell colSpan={8}>
+                        <div className="space-y-2 py-2">
+                          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            Sample questions
+                          </p>
+                          {gap.sample_queries && gap.sample_queries.length > 0 ? (
+                            <ul className="list-disc space-y-1 pl-5 text-sm">
+                              {gap.sample_queries.map((q, i) => (
+                                <li key={i}>{q}</li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <p className="text-sm text-muted-foreground">
+                              No sample questions captured for this gap.
+                            </p>
+                          )}
+                          {gap.suggested_action && (
+                            <p className="text-xs text-muted-foreground">
+                              Suggested action: {gap.suggested_action}
+                            </p>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/gdb-gap-dashboard/components/Recommendations.tsx
+++ b/frontend/src/features/gdb-gap-dashboard/components/Recommendations.tsx
@@ -1,0 +1,74 @@
+import { Badge } from "@/components/atoms/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/atoms/card";
+import type { GapReport } from "../types";
+
+/**
+ * Renders the outreach-recommendations block.
+ *
+ * The backend currently emits plain-text recommendations (strings) but
+ * the response schema also tolerates `{title, description}` objects, so
+ * this component handles both.
+ */
+export function Recommendations({ report }: { report?: GapReport }) {
+  const items = report?.recommendations ?? [];
+
+  if (!items || items.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Outreach recommendations</CardTitle>
+          <CardDescription>
+            The pipeline has not surfaced any explicit recommendations for this
+            report.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground" role="status">
+            Try refreshing the report once the gap detector has run again.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Outreach recommendations</CardTitle>
+        <CardDescription>
+          Actionable next steps generated from the current gap report.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3" aria-label="Outreach recommendations">
+          {items.map((rec, idx) => {
+            const title =
+              typeof rec === "string" ? rec : rec?.title ?? "Untitled recommendation";
+            const description =
+              typeof rec === "string" ? undefined : rec?.description;
+            return (
+              <li
+                key={`${title}-${idx}`}
+                className="rounded-md border p-3"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <p className="font-medium">{title}</p>
+                  <Badge variant="outline">Auto-generated</Badge>
+                </div>
+                {description && (
+                  <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/gdb-gap-dashboard/components/TopGrowingTopicsChart.tsx
+++ b/frontend/src/features/gdb-gap-dashboard/components/TopGrowingTopicsChart.tsx
@@ -1,0 +1,115 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/atoms/card";
+import type { GapClusterItem } from "../types";
+
+export interface TopGrowingTopicsChartProps {
+  /** Full cluster list — we sort and pick the top growers on the client. */
+  clusters?: GapClusterItem[];
+  /** Maximum number of bars to render. */
+  limit?: number;
+}
+
+/**
+ * Horizontal bar chart of the fastest-growing gap clusters.
+ *
+ * The backend returns growth in the cluster entries
+ * (`avg_weekly_growth_pct`) so the dashboard just sorts the list and
+ * slices the top N — no extra server round-trip required.
+ */
+export function TopGrowingTopicsChart({
+  clusters,
+  limit = 10,
+}: TopGrowingTopicsChartProps) {
+  const data = (clusters ?? [])
+    .filter((c) => typeof c.theme === "string" && c.theme.length > 0)
+    .slice()
+    .sort(
+      (a, b) =>
+        (b.avg_weekly_growth_pct ?? 0) - (a.avg_weekly_growth_pct ?? 0),
+    )
+    .slice(0, limit)
+    .map((c) => ({
+      topic: c.theme,
+      growth_pct: Math.round((c.avg_weekly_growth_pct ?? 0) * 1000) / 10,
+      question_volume: c.query_count ?? 0,
+    }));
+
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Fastest-growing topics</CardTitle>
+          <CardDescription>No growth signal reported yet.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground" role="status">
+            Once farmers start asking new questions, the top movers will appear here.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Fastest-growing topics</CardTitle>
+        <CardDescription>
+          Top {data.length} clusters by period-over-period growth.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="h-64 w-full" aria-label="Bar chart of fastest-growing topics">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={data}
+              layout="vertical"
+              margin={{ top: 5, right: 16, left: 8, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+              <XAxis
+                type="number"
+                tickFormatter={(v) => `${v}%`}
+                stroke="hsl(var(--muted-foreground))"
+                fontSize={12}
+              />
+              <YAxis
+                type="category"
+                dataKey="topic"
+                width={120}
+                stroke="hsl(var(--muted-foreground))"
+                fontSize={12}
+              />
+              <Tooltip
+                formatter={(value: number) => [`${value}%`, "Growth"]}
+                labelStyle={{ color: "hsl(var(--foreground))" }}
+              />
+              <Bar
+                dataKey="growth_pct"
+                fill="hsl(var(--primary))"
+                radius={[0, 4, 4, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Growth % is computed against the previous reporting window.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/gdb-gap-dashboard/hooks/useGapReport.ts
+++ b/frontend/src/features/gdb-gap-dashboard/hooks/useGapReport.ts
@@ -1,0 +1,42 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { fetchGapReport } from "../api";
+import type { GapReport, GapReportFilters } from "../types";
+
+export const gapReportQueryKey = (opts: {
+  refresh?: boolean;
+  filters?: GapReportFilters;
+}) =>
+  [
+    "gdb-gap-report",
+    {
+      refresh: opts.refresh ?? false,
+      crop: opts.filters?.crop ?? null,
+      state: opts.filters?.state ?? null,
+      domain: opts.filters?.domain ?? null,
+    },
+  ] as const;
+
+/**
+ * React-Query hook for the `POST /gdb/gap-report` endpoint.
+ *
+ * The Refresh button flips `refresh` to `true`, which both:
+ *  - sends `refresh=true` in the JSON request body (forcing the backend
+ *    to drop its in-process cache), and
+ *  - changes the query key so the cached result is bypassed.
+ *
+ * `filters` are kept in the query key for client-side memoisation in the
+ * Coverage Explorer; the backend does not currently accept them.
+ */
+export function useGapReport(opts: {
+  refresh?: boolean;
+  filters?: GapReportFilters;
+  enabled?: boolean;
+} = {}): UseQueryResult<GapReport, Error> {
+  return useQuery<GapReport, Error>({
+    queryKey: gapReportQueryKey(opts),
+    queryFn: ({ signal }) => fetchGapReport({ ...opts, signal }),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    enabled: opts.enabled ?? true,
+  });
+}

--- a/frontend/src/features/gdb-gap-dashboard/types.ts
+++ b/frontend/src/features/gdb-gap-dashboard/types.ts
@@ -1,0 +1,138 @@
+/**
+ * Typed contract for the ACC `POST /gdb/gap-report` endpoint.
+ *
+ * The response shape mirrors `gdb_gap_detector.GapReport.to_dict()` and
+ * `GapCluster.to_dict()` — see `apis/acc_api/gdb_gap_detector.py`. Every
+ * field is intentionally optional so the dashboard degrades gracefully
+ * when the backend omits a key (e.g. an empty `recommendations` list).
+ *
+ * Endpoint:    POST {accApiBaseUrl}/gdb/gap-report
+ * Body schema: GapReportRequest = {
+ *                similarity_threshold?: float  (0..1, default 0.85),
+ *                min_samples?:          int    (1..50, default 2),
+ *                lookback_days?:        int | null,
+ *                refresh?:              bool   (default false),
+ *              }
+ *
+ * Setting `refresh=true` in the body drops the server-side cache before
+ * rebuilding the report from MongoDB. The backend does **not** honour
+ * filter parameters (crop, state, domain) on the wire — the Coverage
+ * Explorer therefore applies those facets on the client.
+ */
+
+export type CoverageState = "STRONG" | "PARTIAL" | "GAP" | string;
+
+/** Priority bucket used by the backend's `gaps_by_priority` map. */
+export type PriorityBucket = "critical" | "high" | "medium" | "low" | string;
+
+/**
+ * One cluster entry — matches `GapCluster.to_dict()` from the backend.
+ *
+ * The dashboard treats the *shape* of this object as the source of truth
+ * for the Priority Gap table, KPI cards, Top Growing Topics chart, and
+ * the Coverage Explorer.
+ */
+export interface GapClusterItem {
+  cluster_id: string;
+  theme: string;
+
+  /** Unanswered farmer queries inside the current demand window. */
+  query_count: number;
+  recent_query_count: number;
+  previous_query_count: number;
+  total_query_count: number;
+
+  /** Period-over-period growth (e.g. 0.42 == +42%). */
+  avg_weekly_growth_pct: number;
+
+  domain: string;
+  crops: string[];
+  states: string[];
+  top_crop: string;
+  top_state: string;
+
+  priority: PriorityBucket;
+  priority_score: number;
+
+  gdb_coverage_band: CoverageState;
+  gdb_coverage_hits: number;
+  gdb_coverage_score: number;
+
+  suggested_action: string;
+  sample_queries: string[];
+}
+
+/**
+ * Time window covered by the report. The backend currently returns a
+ * `{start, end, days}` dict (ISO-8601 strings).
+ */
+export interface GapReportWindow {
+  start?: string;
+  end?: string;
+  days?: number;
+  [extra: string]: unknown;
+}
+
+/**
+ * The full response of `POST /gdb/gap-report`.
+ *
+ * Modeled against `GapReport.to_dict()` — every field is optional so the
+ * UI can render partial data if the backend ever returns a slimmed-down
+ * payload.
+ */
+export interface GapReport {
+  report_id?: string;
+  generated_at?: string;
+
+  window?: GapReportWindow;
+
+  total_queries_analyzed?: number;
+  total_clusters_found?: number;
+
+  /**
+   * Map keyed by priority bucket. The backend currently returns either:
+   *   { "critical": ClusterSummary[], "high": [...], ... }
+   * or `null` for empty buckets. The dashboard flattens this into the
+   * priority gap table.
+   */
+  gaps_by_priority?: Partial<Record<PriorityBucket, GapClusterItem[]>> | null;
+
+  /**
+   * Coverage-band summary, keyed by band label
+   * (`STRONG` | `PARTIAL` | `GAP`). Used by the Coverage Explorer header.
+   */
+  coverage_bands?: Partial<Record<CoverageState, number | GapClusterItem[]>> | null;
+
+  /**
+   * Top clusters ranked by demand + growth (the table data source).
+   */
+  top_gaps?: GapClusterItem[];
+
+  /** Optional heatmap; the dashboard does not currently render it. */
+  coverage_heatmap?: unknown;
+
+  /**
+   * Plain-text outreach recommendations.  The backend currently returns
+   * strings, but the dashboard also accepts structured objects if the
+   * shape evolves.
+   */
+  recommendations?: (string | { title?: string; description?: string })[] | null;
+
+  /** Full cluster list — the source for KPI derivations and the chart. */
+  clusters?: GapClusterItem[];
+}
+
+/** Body shape accepted by the POST endpoint. */
+export interface GapReportRequestBody {
+  similarity_threshold?: number;
+  min_samples?: number;
+  lookback_days?: number | null;
+  refresh?: boolean;
+}
+
+/** Optional UI-side facets (applied client-side; the backend ignores them). */
+export interface GapReportFilters {
+  crop?: string;
+  state?: string;
+  domain?: string;
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WhatsappHistoryRouteImport } from './routes/whatsapp-history'
+import { Route as GdbGapReportRouteImport } from './routes/gdb-gap-report'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProfileIndexRouteImport } from './routes/profile/index'
 import { Route as PaeExpertIndexRouteImport } from './routes/pae-expert/index'
@@ -28,6 +29,11 @@ import { Route as CoordinatorProfileRouteImport } from './routes/coordinator/pro
 const WhatsappHistoryRoute = WhatsappHistoryRouteImport.update({
   id: '/whatsapp-history',
   path: '/whatsapp-history',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GdbGapReportRoute = GdbGapReportRouteImport.update({
+  id: '/gdb-gap-report',
+  path: '/gdb-gap-report',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -103,6 +109,7 @@ const CoordinatorProfileRoute = CoordinatorProfileRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/gdb-gap-report': typeof GdbGapReportRoute
   '/whatsapp-history': typeof WhatsappHistoryRoute
   '/coordinator/profile': typeof CoordinatorProfileRoute
   '/user-history/$userId': typeof UserHistoryUserIdRoute
@@ -120,6 +127,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/gdb-gap-report': typeof GdbGapReportRoute
   '/whatsapp-history': typeof WhatsappHistoryRoute
   '/coordinator/profile': typeof CoordinatorProfileRoute
   '/user-history/$userId': typeof UserHistoryUserIdRoute
@@ -138,6 +146,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/gdb-gap-report': typeof GdbGapReportRoute
   '/whatsapp-history': typeof WhatsappHistoryRoute
   '/coordinator/profile': typeof CoordinatorProfileRoute
   '/user-history/$userId': typeof UserHistoryUserIdRoute
@@ -157,6 +166,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/gdb-gap-report'
     | '/whatsapp-history'
     | '/coordinator/profile'
     | '/user-history/$userId'
@@ -174,6 +184,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/gdb-gap-report'
     | '/whatsapp-history'
     | '/coordinator/profile'
     | '/user-history/$userId'
@@ -191,6 +202,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/gdb-gap-report'
     | '/whatsapp-history'
     | '/coordinator/profile'
     | '/user-history/$userId'
@@ -209,6 +221,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  GdbGapReportRoute: typeof GdbGapReportRoute
   WhatsappHistoryRoute: typeof WhatsappHistoryRoute
   CoordinatorProfileRoute: typeof CoordinatorProfileRoute
   UserHistoryUserIdRoute: typeof UserHistoryUserIdRoute
@@ -232,6 +245,13 @@ declare module '@tanstack/react-router' {
       path: '/whatsapp-history'
       fullPath: '/whatsapp-history'
       preLoaderRoute: typeof WhatsappHistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/gdb-gap-report': {
+      id: '/gdb-gap-report'
+      path: '/gdb-gap-report'
+      fullPath: '/gdb-gap-report'
+      preLoaderRoute: typeof GdbGapReportRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -337,6 +357,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  GdbGapReportRoute: GdbGapReportRoute,
   WhatsappHistoryRoute: WhatsappHistoryRoute,
   CoordinatorProfileRoute: CoordinatorProfileRoute,
   UserHistoryUserIdRoute: UserHistoryUserIdRoute,

--- a/frontend/src/routes/gdb-gap-report.tsx
+++ b/frontend/src/routes/gdb-gap-report.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { GapDashboardPage } from "@/features/gdb-gap-dashboard/GapDashboardPage";
+
+/**
+ * `/gdb-gap-report` — production-integrated dashboard for the ACC
+ * `GET /gdb/gap-report` endpoint. The page itself lives in
+ * `src/features/gdb-gap-dashboard/GapDashboardPage.tsx`; this file is
+ * only the thin TanStack-Router glue so the route registration can be
+ * code-split / lazy if desired.
+ */
+export const Route = createFileRoute("/gdb-gap-report")({
+  component: GapDashboardPage,
+});


### PR DESCRIPTION
﻿This PR ships the GDB Coverage Gap Detector as an integrated module inside the existing ajrasakha monorepo: it clusters farmer queries semantically, cross-references them against the Golden Q&A Database (GDB), and surfaces a prioritized list of coverage gaps plus an admin-only dashboard.

## Key Features

- [x] **Semantic clustering pipeline**: Normalizes raw farmer queries, embeds them with `sentence-transformers/all-MiniLM-L6-v2`, clusters via DBSCAN, and cross-references each cluster with GDB entries to assign coverage bands (`STRONG / PARTIAL / GAP`).
- [x] **Multi-factor scoring**: Each cluster is scored as `(recency x size x trend x coverage-gap)` and bucketed into `critical / high / medium / low` priority -- surfacing both emerging topics and stale dead-weight GDB entries.
- [x] **Lazy-loaded embedding model**: The `sentence-transformers` model is loaded on first request, not at import time, so unit tests and module imports stay fast and offline-friendly.
- [x] **Cron-style scheduler**: Background scheduler with single-instance leader election, structured JSON logs, Prometheus-style metrics, and an admin token guard. Configurable via `GDB_SCHEDULE_*` env vars.
- [x] **FastAPI endpoints**: Four new routes under `/gdb/*` --
    1. `GET  /gdb/gap-report`
    2. `POST /gdb/scheduler/run-now`
    3. `POST /gdb/scheduler/invalidate-cache`
    4. `GET  /gdb/scheduler/state`
- [x] **Admin dashboard**: React page at `/gdb-gap-report` with KPI cards, priority buckets, and a sortable coverage-gap table. Gated to the admin role in the sidebar.

## Testing Phase Summary

- [x] **106/106 automated unit and integration tests passing cleanly** (`pytest apis/acc_api/tests/`).
- [x] **No Mongo, no model download in CI**: A deterministic fake embedder fixture keeps the suite offline-friendly and under 1sec.
- [x] **Pipeline coverage end-to-end**: normalize, embed, cluster, coverage bands, scoring, ranking, scheduler lifecycle, leader election, cache invalidation, admin auth, and endpoint contracts -- all exercised.
- [x] **Frontend typed fetcher verified** via Vitest for both happy path and error handling.

## Deployment & Next Steps

- [x] **Read-only on existing collections**: No new Mongo collections or indexes are introduced; the gap detector consumes whatever shape the existing query log already has.
- [x] **Configuration via env vars**: All knobs are documented in `.env.example` -- `GDB_SCHEDULER_ENABLED`, `GDB_ADMIN_TOKEN`, `GDB_SCHEDULE_*`, etc.
- [x] **Operational runbook**: `docs/GDB_GAP_DETECTOR_OPERATIONS.md` covers env vars, schedule config, cache invalidation, deployment checklist, and rollback plan.
- [x] **Known follow-up**: `score_to_priority()` currently only consults score, but its docstring says "score OR size OR growth" -- the unused `size` / `growth_pct` parameters land small emerging topics at `low` instead of `high`. Tracked as Issue #1 in the design doc; the fix is a ~5-line patch and is a strong candidate for a follow-up PR.



