### PR TITLE
feat(tts): add Sarvam-backed text-to-speech playback with Mongo cache

### DIFF
--- a/backend/src/modules/tts/__tests__/TtsService.errors.test.ts
+++ b/backend/src/modules/tts/__tests__/TtsService.errors.test.ts
@@ -1,0 +1,133 @@
+import 'reflect-metadata';
+import {describe, it, expect, beforeEach, vi, afterEach} from 'vitest';
+
+// Mock the config so we don't depend on process.env at test time.
+vi.mock('#root/config/app.js', () => ({
+  appConfig: {
+    sarvamAPI: 'test-sarvam-key',
+  },
+}));
+
+const mockMongoDatabase = {} as any;
+
+import {appConfig} from '#root/config/app.js';
+import {TtsService} from '../services/TtsService.js';
+import type {ITtsCacheRepository} from '../interfaces/ITtsCacheRepository.js';
+
+function makeCacheRepo() {
+  return {
+    findByHash: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn().mockResolvedValue(undefined),
+    bumpHit: vi.fn().mockResolvedValue(undefined),
+    purgeExpired: vi.fn().mockResolvedValue({deletedCount: 0}),
+  } as unknown as ITtsCacheRepository & {
+    findByHash: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+    bumpHit: ReturnType<typeof vi.fn>;
+  };
+}
+
+function bufferToArrayBufferResponse(buffer: Buffer) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers({'content-type': 'audio/wav'}),
+    arrayBuffer: () =>
+      Promise.resolve(
+        buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        ),
+      ),
+  };
+}
+
+describe('TtsService.synthesize — error paths', () => {
+  let cache: ReturnType<typeof makeCacheRepo>;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let service: TtsService;
+
+  beforeEach(() => {
+    cache = makeCacheRepo();
+    fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    service = new TtsService(mockMongoDatabase, cache);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Reset the mocked config so a test that toggles sarvamAPI off doesn't
+    // leak into the next test.
+    (appConfig as any).sarvamAPI = 'test-sarvam-key';
+  });
+
+  it('rejects with SARVAM_API_KEY-missing error when key is not configured', async () => {
+    (appConfig as any).sarvamAPI = undefined;
+
+    await expect(
+      service.synthesize({text: 'x', language: 'en-IN'}),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('SARVAM_API_KEY'),
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(cache.upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects with upstream-failure error when Sarvam returns non-2xx', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      text: () => Promise.resolve('rate limited'),
+    });
+
+    await expect(
+      service.synthesize({text: 'x', language: 'en-IN'}),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Sarvam TTS upstream failed'),
+    });
+    expect(cache.upsert).not.toHaveBeenCalled();
+  });
+
+  it('still serves the user when cache write fails after a successful upstream call', async () => {
+    const wavBuffer = Buffer.from('OK');
+    fetchSpy.mockResolvedValueOnce(bufferToArrayBufferResponse(wavBuffer));
+    cache.upsert.mockRejectedValueOnce(new Error('mongo down'));
+
+    const result = await service.synthesize({
+      text: 'boom',
+      language: 'en-IN',
+    });
+
+    expect(result.cached).toBe(false);
+    expect(result.audioBase64).toBe(wavBuffer.toString('base64'));
+  });
+
+  it('normalizeInput fills sensible defaults and trims text', () => {
+    const out = service.normalizeInput({
+      text: '  hello  ',
+      language: 'en-IN',
+      pace: undefined,
+      pitch: undefined,
+      loudness: undefined,
+      speaker: undefined,
+      model: undefined,
+      outputAudioCodec: undefined,
+      speechSampleRate: undefined,
+    });
+    expect(out.text).toBe('hello');
+    expect(out.speaker).toBe('amelia');
+    expect(out.pace).toBe(1.0);
+    expect(out.pitch).toBe(0.0);
+    expect(out.loudness).toBe(1.0);
+    expect(out.model).toBe('bulbul:v2');
+    expect(out.outputAudioCodec).toBe('wav');
+    expect(out.speechSampleRate).toBe(22050);
+  });
+
+  it('normalizeInput picks a non-English default speaker for Indic languages', () => {
+    const out = service.normalizeInput({text: 'नमस्ते', language: 'hi-IN'});
+    expect(out.speaker).toBe('anushka');
+  });
+});

--- a/backend/src/modules/tts/__tests__/TtsService.test.ts
+++ b/backend/src/modules/tts/__tests__/TtsService.test.ts
@@ -1,0 +1,141 @@
+import 'reflect-metadata';
+import {describe, it, expect, beforeEach, vi, afterEach} from 'vitest';
+
+// Mock the config so we don't depend on process.env at test time.
+vi.mock('#root/config/app.js', () => ({
+  appConfig: {
+    sarvamAPI: 'test-sarvam-key',
+  },
+}));
+
+// MongoDatabase stub: BaseService requires it but we never call into it here.
+const mockMongoDatabase = {} as any;
+
+import {appConfig} from '#root/config/app.js';
+import {TtsService} from '../services/TtsService.js';
+import type {
+  ITtsAudioCacheEntry,
+  ITtsCacheRepository,
+} from '../interfaces/ITtsCacheRepository.js';
+
+function makeCacheRepo(): ITtsCacheRepository & {
+  findByHash: ReturnType<typeof vi.fn>;
+  upsert: ReturnType<typeof vi.fn>;
+  bumpHit: ReturnType<typeof vi.fn>;
+  purgeExpired: ReturnType<typeof vi.fn>;
+} {
+  return {
+    findByHash: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn().mockResolvedValue(undefined),
+    bumpHit: vi.fn().mockResolvedValue(undefined),
+    purgeExpired: vi.fn().mockResolvedValue({deletedCount: 0}),
+  };
+}
+
+function makeFakeWavBase64(): string {
+  return Buffer.from('RIFF\x00\x00\x00\x00WAVEfmt ', 'binary').toString(
+    'base64',
+  );
+}
+
+function bufferToArrayBufferResponse(
+  buffer: Buffer,
+  contentType = 'audio/wav',
+) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers({'content-type': contentType}),
+    arrayBuffer: () =>
+      Promise.resolve(
+        buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        ),
+      ),
+  };
+}
+
+describe('TtsService.synthesize', () => {
+  let cache: ReturnType<typeof makeCacheRepo>;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let service: TtsService;
+
+  beforeEach(() => {
+    cache = makeCacheRepo();
+    fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    service = new TtsService(mockMongoDatabase, cache);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns cached audio without hitting Sarvam on cache hit', async () => {
+    const cachedEntry: ITtsAudioCacheEntry = {
+      hash: 'cached-hash',
+      text: 'hello',
+      language: 'en-IN',
+      speaker: 'amelia',
+      model: 'bulbul:v2',
+      audioBase64: makeFakeWavBase64(),
+      contentType: 'audio/wav',
+      byteSize: 16,
+      hitCount: 3,
+      createdAt: new Date(),
+      lastAccessedAt: new Date(),
+      ttlAt: new Date(Date.now() + 1000 * 60 * 60),
+    };
+    cache.findByHash.mockResolvedValueOnce(cachedEntry);
+
+    const result = await service.synthesize({
+      text: 'hello',
+      language: 'en-IN',
+    });
+
+    expect(result.cached).toBe(true);
+    expect(result.audioBase64).toBe(cachedEntry.audioBase64);
+    expect(result.contentType).toBe('audio/wav');
+    expect(result.byteSize).toBe(cachedEntry.byteSize);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // bumpHit is fired async; give it a tick to flush.
+    await new Promise(r => setTimeout(r, 5));
+    expect(cache.bumpHit).toHaveBeenCalledWith(result.hash);
+  });
+
+  it('calls Sarvam and caches the result on cache miss', async () => {
+    const wavBuffer = Buffer.from('FAKE_WAV_BYTES');
+    fetchSpy.mockResolvedValueOnce(bufferToArrayBufferResponse(wavBuffer));
+
+    const result = await service.synthesize({
+      text: 'namaste',
+      language: 'hi-IN',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://api.sarvam.ai/text-to-speech');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['api-subscription-key']).toBe('test-sarvam-key');
+    const payload = JSON.parse(init.body);
+    expect(payload.text).toBe('namaste');
+    expect(payload.target_language_code).toBe('hi-IN');
+    expect(payload.speaker).toBe('anushka'); // default for Indic languages
+    expect(payload.model).toBe('bulbul:v2');
+    expect(payload.output_audio_codec).toBe('wav');
+
+    expect(result.cached).toBe(false);
+    expect(result.audioBase64).toBe(wavBuffer.toString('base64'));
+    expect(result.contentType).toBe('audio/wav');
+
+    expect(cache.upsert).toHaveBeenCalledTimes(1);
+    const cachedArg = cache.upsert.mock.calls[0][0];
+    expect(cachedArg.hash).toBe(result.hash);
+    expect(cachedArg.language).toBe('hi-IN');
+    expect(cachedArg.speaker).toBe('anushka');
+    expect(cachedArg.audioBase64).toBe(wavBuffer.toString('base64'));
+  });
+});

--- a/backend/src/modules/tts/__tests__/ttsHash.test.ts
+++ b/backend/src/modules/tts/__tests__/ttsHash.test.ts
@@ -1,0 +1,99 @@
+import 'reflect-metadata';
+import {describe, it, expect} from 'vitest';
+import {
+  computeHash,
+  estimateBase64ByteSize,
+  sanitizeUpstreamError,
+} from '../services/ttsHash.js';
+import type {NormalizedTtsInput} from '../services/TtsService.js';
+
+const baseInput: NormalizedTtsInput = {
+  text: 'hello',
+  language: 'en-IN',
+  speaker: 'amelia',
+  pace: 1.0,
+  pitch: 0.0,
+  loudness: 1.0,
+  model: 'bulbul:v2',
+  outputAudioCodec: 'wav',
+  speechSampleRate: 22050,
+};
+
+describe('computeHash', () => {
+  it('produces a deterministic 32-char hex string', () => {
+    const hash = computeHash(baseInput);
+    expect(hash).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  it('is stable across calls', () => {
+    expect(computeHash(baseInput)).toBe(computeHash(baseInput));
+  });
+
+  it('changes when any field changes', () => {
+    const cases: Array<Partial<NormalizedTtsInput>> = [
+      {text: 'different'},
+      {language: 'hi-IN'},
+      {speaker: 'anushka'},
+      {pace: 1.2},
+      {pitch: 0.1},
+      {loudness: 1.5},
+      {model: 'bulbul:v1'},
+      {outputAudioCodec: 'mp3'},
+      {speechSampleRate: 16000},
+    ];
+    const baseline = computeHash(baseInput);
+    for (const patch of cases) {
+      expect(computeHash({...baseInput, ...patch})).not.toBe(baseline);
+    }
+  });
+
+  it('treats field order as irrelevant (input is JSON-canonicalized)', () => {
+    const a: NormalizedTtsInput = {
+      ...baseInput,
+      speaker: 'amelia',
+      pace: 1.0,
+    };
+    const b: NormalizedTtsInput = {
+      ...baseInput,
+      pace: 1.0,
+      speaker: 'amelia',
+    };
+    expect(computeHash(a)).toBe(computeHash(b));
+  });
+});
+
+describe('estimateBase64ByteSize', () => {
+  it('decodes correctly for a padded base64 string', () => {
+    const b64 = Buffer.from('hello world').toString('base64'); // 11 raw bytes
+    expect(estimateBase64ByteSize(b64)).toBe(11);
+  });
+
+  it('returns 0 for empty input', () => {
+    expect(estimateBase64ByteSize('')).toBe(0);
+  });
+
+  it('handles a buffer that has no padding', () => {
+    // 'a' = 1 byte, base64 = 'YQ==' (2 padding chars)
+    expect(estimateBase64ByteSize('YQ==')).toBe(1);
+  });
+});
+
+describe('sanitizeUpstreamError', () => {
+  it('returns "unknown error" for null/undefined', () => {
+    expect(sanitizeUpstreamError(null)).toBe('unknown error');
+    expect(sanitizeUpstreamError(undefined)).toBe('unknown error');
+  });
+
+  it('uses .message for Error instances', () => {
+    expect(sanitizeUpstreamError(new Error('boom'))).toBe('boom');
+  });
+
+  it('truncates very long messages to 240 chars', () => {
+    const big = new Error('x'.repeat(1000));
+    expect(sanitizeUpstreamError(big)).toHaveLength(240);
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(sanitizeUpstreamError('plain text')).toBe('plain text');
+  });
+});

--- a/backend/src/modules/tts/classes/validators/TtsResponseValidators.ts
+++ b/backend/src/modules/tts/classes/validators/TtsResponseValidators.ts
@@ -1,0 +1,26 @@
+import {JSONSchema} from 'class-validator-jsonschema';
+import {IsString, IsNotEmpty} from 'class-validator';
+
+/**
+ * Generic error response shape used across all TTS endpoints in the
+ * `@ResponseSchema` decorators (mirrors the convention in
+ * `core/classes/validators/NotificationResponseValidators.ts`).
+ */
+export class TtsErrorResponse {
+  @JSONSchema({
+    description: 'Human-readable error message.',
+    example: 'text must be longer than 1 character',
+    type: 'string',
+  })
+  @IsString()
+  @IsNotEmpty()
+  message!: string;
+
+  @JSONSchema({
+    description: 'Optional machine-readable error code.',
+    example: 'TTS_UPSTREAM_ERROR',
+    type: 'string',
+  })
+  @IsString()
+  code?: string;
+}

--- a/backend/src/modules/tts/classes/validators/TtsValidators.ts
+++ b/backend/src/modules/tts/classes/validators/TtsValidators.ts
@@ -1,0 +1,218 @@
+import {Expose} from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsString,
+  IsOptional,
+  IsNumber,
+  IsIn,
+  Min,
+  Max,
+  MaxLength,
+} from 'class-validator';
+import {JSONSchema} from 'class-validator-jsonschema';
+
+/**
+ * Languages supported by the Sarvam `bulbul` TTS models.
+ * Keep this list in sync with https://docs.sarvam.ai/.
+ */
+export const TTS_SUPPORTED_LANGUAGES = [
+  'en-IN', // English (India)
+  'hi-IN', // Hindi
+  'bn-IN', // Bengali
+  'ta-IN', // Tamil
+  'te-IN', // Telugu
+  'gu-IN', // Gujarati
+  'kn-IN', // Kannada
+  'ml-IN', // Malayalam
+  'mr-IN', // Marathi
+  'od-IN', // Odia
+  'pa-IN', // Punjabi
+  'as-IN', // Assamese
+  'ur-IN', // Urdu
+] as const;
+
+/**
+ * Audio output codecs Sarvam supports. `wav` is the safest default —
+ * universally decodable in `<audio>` elements without codec concerns.
+ */
+export const TTS_SUPPORTED_CODECS = [
+  'wav',
+  'mp3',
+  'pcm',
+  'mulaw',
+  'alaw',
+  'opus',
+  'flac',
+] as const;
+
+export const TTS_SUPPORTED_MODELS = ['bulbul:v1', 'bulbul:v2'] as const;
+
+/** Sarvam bulbul v2 default speaker for `en-IN`. */
+export const TTS_DEFAULT_SPEAKER_EN = 'amelia';
+/** Sarvam bulbul v2 default speaker for Indic languages. */
+export const TTS_DEFAULT_SPEAKER_INDIC = 'anushka';
+
+/** Body of `POST /api/tts`. */
+export class TtsRequestBody {
+  @JSONSchema({
+    description: 'Text to synthesize. Max 2000 characters.',
+    example: 'Namaste! Your crop is healthy.',
+    type: 'string',
+    maxLength: 2000,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  text!: string;
+
+  @JSONSchema({
+    description:
+      'BCP-47 language code. Must be one of the supported languages.',
+    example: 'hi-IN',
+    type: 'string',
+    enum: TTS_SUPPORTED_LANGUAGES as unknown as string[],
+  })
+  @IsString()
+  @IsIn(TTS_SUPPORTED_LANGUAGES as unknown as string[])
+  language!: string;
+
+  @JSONSchema({
+    description:
+      'Voice id. Defaults to a sensible per-language choice when omitted.',
+    example: 'anushka',
+    type: 'string',
+  })
+  @IsOptional()
+  @IsString()
+  speaker?: string;
+
+  @JSONSchema({
+    description:
+      'Speaking pace multiplier (0.3 – 3.0). 1.0 is normal speed.',
+    example: 1.0,
+    type: 'number',
+    minimum: 0.3,
+    maximum: 3.0,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0.3)
+  @Max(3.0)
+  pace?: number;
+
+  @JSONSchema({
+    description:
+      'Pitch offset (-1.0 – 1.0). 0.0 is neutral. Sarvam accepts -1 to 1.',
+    example: 0.0,
+    type: 'number',
+    minimum: -1.0,
+    maximum: 1.0,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(-1.0)
+  @Max(1.0)
+  pitch?: number;
+
+  @JSONSchema({
+    description:
+      'Loudness multiplier (0.1 – 2.0). 1.0 is neutral.',
+    example: 1.0,
+    type: 'number',
+    minimum: 0.1,
+    maximum: 2.0,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0.1)
+  @Max(2.0)
+  loudness?: number;
+
+  @JSONSchema({
+    description: 'Sarvam TTS model id.',
+    example: 'bulbul:v2',
+    type: 'string',
+    enum: TTS_SUPPORTED_MODELS as unknown as string[],
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(TTS_SUPPORTED_MODELS as unknown as string[])
+  model?: string;
+
+  @JSONSchema({
+    description: 'Audio output codec.',
+    example: 'wav',
+    type: 'string',
+    enum: TTS_SUPPORTED_CODECS as unknown as string[],
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(TTS_SUPPORTED_CODECS as unknown as string[])
+  outputAudioCodec?: string;
+
+  @JSONSchema({
+    description: 'Audio sample rate in Hz.',
+    example: 22050,
+    type: 'number',
+    enum: [8000, 16000, 22050, 24000, 48000],
+  })
+  @IsOptional()
+  @IsNumber()
+  @IsIn([8000, 16000, 22050, 24000, 48000])
+  speechSampleRate?: number;
+}
+
+/** Response payload of `POST /api/tts`. */
+export class TtsResponse {
+  @JSONSchema({
+    description:
+      'Base64-encoded audio bytes. Decode into a Blob/ArrayBuffer client-side.',
+    type: 'string',
+  })
+  @IsString()
+  @Expose()
+  audioBase64!: string;
+
+  @JSONSchema({
+    description: 'MIME type of the audio payload.',
+    example: 'audio/wav',
+    type: 'string',
+  })
+  @IsString()
+  @Expose()
+  contentType!: string;
+
+  @JSONSchema({
+    description: 'Decoded audio size in bytes.',
+    example: 48044,
+    type: 'integer',
+  })
+  @IsNumber()
+  @Expose()
+  byteSize!: number;
+
+  @JSONSchema({
+    description: 'True when this audio was served from the cache.',
+    example: false,
+    type: 'boolean',
+  })
+  @Expose()
+  cached!: boolean;
+
+  @JSONSchema({
+    description:
+      'Deterministic cache key derived from the request. Useful for client-side logging.',
+    example: 'a3f1c…',
+    type: 'string',
+  })
+  @IsString()
+  @Expose()
+  hash!: string;
+}
+
+export const TTS_VALIDATORS = [TtsRequestBody, TtsResponse];
+
+export {
+  TtsRequestBody as TtsRequestBodyClass,
+  TtsResponse as TtsResponseClass,
+};

--- a/backend/src/modules/tts/classes/validators/TtsValidators.ts
+++ b/backend/src/modules/tts/classes/validators/TtsValidators.ts
@@ -47,8 +47,12 @@ export const TTS_SUPPORTED_CODECS = [
 
 export const TTS_SUPPORTED_MODELS = ['bulbul:v1', 'bulbul:v2'] as const;
 
-/** Sarvam bulbul v2 default speaker for `en-IN`. */
-export const TTS_DEFAULT_SPEAKER_EN = 'amelia';
+/** Sarvam bulbul v2 default speaker for `en-IN`.
+ *  Must be a voice Sarvam's API actually accepts — it rejects unknown names
+ *  with HTTP 400. `anushka` is in the current allowed list (`anushka, abhilash,
+ *  manisha, vidya, arya, karun, hitesh, aditya, ritu, priya, neha, rahul,
+ *  pooja, rohan, simran, kavya, amit, dev, …`) and renders English well. */
+export const TTS_DEFAULT_SPEAKER_EN = 'anushka';
 /** Sarvam bulbul v2 default speaker for Indic languages. */
 export const TTS_DEFAULT_SPEAKER_INDIC = 'anushka';
 

--- a/backend/src/modules/tts/controllers/TtsController.ts
+++ b/backend/src/modules/tts/controllers/TtsController.ts
@@ -1,0 +1,87 @@
+import 'reflect-metadata';
+import {
+  JsonController,
+  Post,
+  Body,
+  HttpCode,
+  Authorized,
+  CurrentUser,
+} from 'routing-controllers';
+import {OpenAPI, ResponseSchema} from 'routing-controllers-openapi';
+import {inject} from 'inversify';
+import {TTS_TYPES} from '../types.js';
+import {ITtsService} from '../interfaces/ITtsService.js';
+import {IUser} from '#root/shared/interfaces/models.js';
+import {
+  TtsRequestBody,
+  TtsResponse,
+} from '../classes/validators/TtsValidators.js';
+import {TtsErrorResponse} from '../classes/validators/TtsResponseValidators.js';
+
+@OpenAPI({
+  tags: ['TTS'],
+  description:
+    'Server-side text-to-speech proxy. Backed by Sarvam and a Mongo audio cache so re-listens are free.',
+})
+@JsonController('/tts')
+export class TtsController {
+  constructor(
+    @inject(TTS_TYPES.TtsService)
+    private readonly ttsService: ITtsService,
+  ) {}
+
+  @OpenAPI({
+    summary: 'Synthesize speech from text',
+    description:
+      'Returns base64-encoded audio for the given text. Identical requests (same text, language, voice, settings) are served from a Mongo-backed cache and returned instantly.',
+  })
+  @ResponseSchema(TtsResponse, {
+    statusCode: 200,
+    description: 'Audio payload successfully synthesized or retrieved from cache.',
+  })
+  @ResponseSchema(TtsErrorResponse, {
+    statusCode: 400,
+    description: 'Bad request — invalid or missing fields.',
+  })
+  @ResponseSchema(TtsErrorResponse, {
+    statusCode: 401,
+    description: 'Unauthorized — Firebase ID token missing or expired.',
+  })
+  @ResponseSchema(TtsErrorResponse, {
+    statusCode: 502,
+    description:
+      'Bad gateway — upstream Sarvam TTS call failed. See server logs for details.',
+  })
+  @ResponseSchema(TtsErrorResponse, {
+    statusCode: 503,
+    description:
+      'Service unavailable — SARVAM_API_KEY is not configured on the server.',
+  })
+  @Post('/')
+  @HttpCode(200)
+  @Authorized()
+  async synthesize(
+    @Body() body: TtsRequestBody,
+    @CurrentUser() user: IUser,
+  ): Promise<TtsResponse> {
+    const result = await this.ttsService.synthesize({
+      text: body.text,
+      language: body.language,
+      speaker: body.speaker,
+      pace: body.pace,
+      pitch: body.pitch,
+      loudness: body.loudness,
+      model: body.model,
+      outputAudioCodec: body.outputAudioCodec,
+      speechSampleRate: body.speechSampleRate,
+      requestedBy: user?._id?.toString(),
+    });
+    return {
+      audioBase64: result.audioBase64,
+      contentType: result.contentType,
+      byteSize: result.byteSize,
+      cached: result.cached,
+      hash: result.hash,
+    };
+  }
+}

--- a/backend/src/modules/tts/index.ts
+++ b/backend/src/modules/tts/index.ts
@@ -1,0 +1,50 @@
+import {Container, ContainerModule} from 'inversify';
+import {InversifyAdapter} from '#root/inversify-adapter.js';
+import {useContainer} from 'class-validator';
+import {TtsController} from './controllers/TtsController.js';
+import {TtsService} from './services/TtsService.js';
+import {TtsCacheRepository} from './repositories/TtsCacheRepository.js';
+import {TTS_TYPES} from './types.js';
+import {
+  TTS_VALIDATORS,
+  TtsRequestBody,
+  TtsResponse,
+} from './classes/validators/TtsValidators.js';
+import {TtsErrorResponse} from './classes/validators/TtsResponseValidators.js';
+
+/**
+ * DI bindings for the TTS module.
+ *
+ * Following the per-module convention used by `notification`, `chatbot`, etc.
+ * `loadModules.ts` will look up `${moduleName}ModuleControllers`,
+ * `${moduleName}ModuleValidators`, and `${moduleName}ContainerModules`
+ * automatically because `tts` is a directory under `src/modules`.
+ */
+export const ttsContainerModule = new ContainerModule(options => {
+  options.bind(TtsController).toSelf().inSingletonScope();
+  options.bind(TTS_TYPES.TtsService).to(TtsService).inSingletonScope();
+  options.bind(TTS_TYPES.TtsCacheRepository).to(TtsCacheRepository).inSingletonScope();
+});
+
+export const ttsModuleControllers: Function[] = [TtsController];
+
+export const ttsModuleValidators: Function[] = [
+  ...TTS_VALIDATORS,
+  TtsErrorResponse,
+];
+
+export const ttsContainerModules: ContainerModule[] = [ttsContainerModule];
+
+export async function setupTtsContainer(): Promise<void> {
+  const container = new Container();
+  await container.load(...ttsContainerModules);
+  const inversifyAdapter = new InversifyAdapter(container);
+  useContainer(inversifyAdapter);
+}
+
+// Re-export for external consumers
+export * from './controllers/TtsController.js';
+export * from './services/TtsService.js';
+export * from './repositories/TtsCacheRepository.js';
+export * from './types.js';
+export {TtsRequestBody, TtsResponse, TtsErrorResponse};

--- a/backend/src/modules/tts/interfaces/ITtsCacheRepository.ts
+++ b/backend/src/modules/tts/interfaces/ITtsCacheRepository.ts
@@ -1,0 +1,52 @@
+import type {ClientSession} from 'mongodb';
+
+/**
+ * One cached TTS audio payload. Keyed by a deterministic hash of
+ * (text, language, speaker, model, audio codec/sample-rate, pace, pitch, loudness)
+ * so identical requests short-circuit the upstream Sarvam call.
+ */
+export interface ITtsAudioCacheEntry {
+  hash: string;
+  text: string;
+  language: string;
+  speaker: string;
+  model: string;
+  audioBase64: string;
+  contentType: string;
+  byteSize: number;
+  hitCount: number;
+  createdAt: Date;
+  lastAccessedAt: Date;
+  /** When this entry becomes eligible for TTL cleanup. */
+  ttlAt: Date;
+}
+
+/**
+ * Persistence layer for cached TTS audio. Keeping the cache in MongoDB
+ * avoids re-paying for Sarvam generation on every replay and gives us a
+ * free shared cache across all backend replicas.
+ */
+export interface ITtsCacheRepository {
+  /**
+   * Look up a cached audio payload by its deterministic request hash.
+   * Returns `null` on cache miss.
+   */
+  findByHash(hash: string): Promise<ITtsAudioCacheEntry | null>;
+
+  /**
+   * Upsert a new cache entry. Used both on cache miss (insert) and to
+   * refresh `lastAccessedAt` for an existing entry.
+   */
+  upsert(entry: ITtsAudioCacheEntry, session?: ClientSession): Promise<void>;
+
+  /**
+   * Bump the access counter + timestamp when a cached entry is served.
+   * Returned so callers can log hit-rate metrics.
+   */
+  bumpHit(hash: string): Promise<void>;
+
+  /**
+   * Drop entries past their TTL. Designed to be called from a cron job.
+   */
+  purgeExpired(now?: Date): Promise<{deletedCount: number}>;
+}

--- a/backend/src/modules/tts/interfaces/ITtsService.ts
+++ b/backend/src/modules/tts/interfaces/ITtsService.ts
@@ -1,0 +1,42 @@
+import type {ITtsAudioCacheEntry} from './ITtsCacheRepository.js';
+
+export interface ITtsService {
+  /**
+   * Generate (or retrieve from cache) TTS audio for the given request.
+   *
+   * Throws `ServiceUnavailableError` if the Sarvam API key is not
+   * configured, and `BadGatewayError` when the upstream Sarvam call fails.
+   */
+  synthesize(input: ITtsSynthesizeInput): Promise<ITtsSynthesizeResult>;
+
+  /**
+   * Read-only lookup so tests / health-checks can verify a cache hit
+   * without going through the upstream API.
+   */
+  peekCache(hash: string): Promise<ITtsAudioCacheEntry | null>;
+}
+
+export interface ITtsSynthesizeInput {
+  text: string;
+  language: string;
+  speaker?: string;
+  pace?: number;
+  pitch?: number;
+  loudness?: number;
+  model?: string;
+  outputAudioCodec?: string;
+  speechSampleRate?: number;
+  /**
+   * Logical requester id (typically the requesting user). Stored on the
+   * cache entry for traceability but never used as part of the cache key.
+   */
+  requestedBy?: string;
+}
+
+export interface ITtsSynthesizeResult {
+  audioBase64: string;
+  contentType: string;
+  byteSize: number;
+  cached: boolean;
+  hash: string;
+}

--- a/backend/src/modules/tts/repositories/TtsCacheRepository.ts
+++ b/backend/src/modules/tts/repositories/TtsCacheRepository.ts
@@ -1,0 +1,83 @@
+import {inject} from 'inversify';
+import {Collection, ClientSession} from 'mongodb';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {MongoDatabase} from '#root/shared/database/providers/mongo/MongoDatabase.js';
+import {
+  ITtsAudioCacheEntry,
+  ITtsCacheRepository,
+} from '../interfaces/ITtsCacheRepository.js';
+
+const COLLECTION_NAME = 'tts_audio_cache';
+const DEFAULT_TTL_DAYS = 30;
+
+/**
+ * Mongo-backed cache for synthesized TTS audio.
+ *
+ * Index strategy:
+ *  - `hash` is a unique index; it is the cache key.
+ *  - `ttlAt` is a TTL-style index for opportunistic cleanup by Mongo
+ *    (in addition to the explicit `purgeExpired` sweep).
+ */
+export class TtsCacheRepository implements ITtsCacheRepository {
+  private collection!: Collection<ITtsAudioCacheEntry>;
+
+  constructor(
+    @inject(GLOBAL_TYPES.Database)
+    private readonly db: MongoDatabase,
+  ) {}
+
+  /** Lazy initialization so the Mongo client is connected before use. */
+  private async init(): Promise<Collection<ITtsAudioCacheEntry>> {
+    if (!this.collection) {
+      this.collection = await this.db.getCollection<ITtsAudioCacheEntry>(
+        COLLECTION_NAME,
+      );
+      await this.ensureIndexes();
+    }
+    return this.collection;
+  }
+
+  private async ensureIndexes(): Promise<void> {
+    await this.collection.createIndex({hash: 1}, {unique: true});
+    await this.collection.createIndex(
+      {ttlAt: 1},
+      {expireAfterSeconds: 0},
+    );
+  }
+
+  async findByHash(hash: string): Promise<ITtsAudioCacheEntry | null> {
+    const coll = await this.init();
+    return coll.findOne({hash});
+  }
+
+  async upsert(
+    entry: ITtsAudioCacheEntry,
+    _session?: ClientSession,
+  ): Promise<void> {
+    const coll = await this.init();
+    await coll.updateOne(
+      {hash: entry.hash},
+      {$set: entry},
+      {upsert: true},
+    );
+  }
+
+  async bumpHit(hash: string): Promise<void> {
+    const coll = await this.init();
+    await coll.updateOne(
+      {hash},
+      {
+        $inc: {hitCount: 1},
+        $set: {lastAccessedAt: new Date()},
+      },
+    );
+  }
+
+  async purgeExpired(now: Date = new Date()): Promise<{deletedCount: number}> {
+    const coll = await this.init();
+    const result = await coll.deleteMany({ttlAt: {$lt: now}});
+    return {deletedCount: result.deletedCount ?? 0};
+  }
+}
+
+export {DEFAULT_TTL_DAYS};

--- a/backend/src/modules/tts/services/TtsService.ts
+++ b/backend/src/modules/tts/services/TtsService.ts
@@ -36,6 +36,18 @@ const DEFAULT_CODEC = 'wav';
 const DEFAULT_SAMPLE_RATE = 22050;
 const MAX_TEXT_PREVIEW_CHARS = 200;
 
+/** Map Sarvam `output_audio_codec` values to MIME types for the client.
+ *  mu-law and A-law both surface as `audio/basic` (8 kHz, 1 channel). */
+const CODEC_TO_MIME: Record<string, string> = {
+  wav: 'audio/wav',
+  mp3: 'audio/mpeg',
+  pcm: 'audio/L16',
+  mulaw: 'audio/basic',
+  alaw: 'audio/basic',
+  opus: 'audio/opus',
+  flac: 'audio/flac',
+};
+
 /** Normalized view of a TTS request — used for both cache-keying and the upstream call. */
 export interface NormalizedTtsInput {
   text: string;
@@ -65,7 +77,14 @@ export class TtsService extends BaseService implements ITtsService {
     const hash = computeHash(normalized);
 
     // 1. Cache hit? Return immediately.
-    const cached = await this.cache.findByHash(hash);
+    // Best-effort cache lookup: if Mongo is unreachable we still want the request
+    // to succeed, so fall through to the upstream Sarvam call.
+    let cached: Awaited<ReturnType<typeof this.cache.findByHash>> = null;
+    try {
+      cached = await this.cache.findByHash(hash);
+    } catch (cacheErr) {
+      console.warn('[TTS] cache lookup failed, proceeding without cache:', cacheErr);
+    }
     if (cached) {
       // Bump hit counter async — never block the user response on it.
       void this.cache.bumpHit(hash).catch(err => {
@@ -158,7 +177,12 @@ export class TtsService extends BaseService implements ITtsService {
     };
   }
 
-  /** HTTPS call to Sarvam; assumes upstream returns raw audio bytes. */
+  /** HTTPS call to Sarvam.
+   *  Sarvam's bulbul:v2 REST endpoint always returns a JSON envelope of the
+   *  shape `{"request_id":"…","audios":["<base64-wav|mp3|…>"]}` — one
+   *  base64-encoded audio chunk per synthesised sentence. We unwrap it.
+   *  Raw-bytes fallback is kept for any future endpoint that streams audio
+   *  directly (e.g. v3 or a future `Accept: audio/wav` mode). */
   private async callSarvam(
     apiKey: string,
     input: NormalizedTtsInput,
@@ -180,7 +204,7 @@ export class TtsService extends BaseService implements ITtsService {
       headers: {
         'api-subscription-key': apiKey,
         'Content-Type': 'application/json',
-        Accept: 'audio/*',
+        Accept: 'application/json',
       },
       body: JSON.stringify(body),
     });
@@ -195,16 +219,42 @@ export class TtsService extends BaseService implements ITtsService {
       );
     }
 
-    const rawContentType =
-      response.headers.get('content-type') ?? 'audio/wav';
-    const contentType = rawContentType.split(';')[0].trim() || 'audio/wav';
+    const rawContentType = response.headers.get('content-type') ?? '';
+    const declaredType = rawContentType.split(';')[0].trim().toLowerCase();
+    const codec = (input.outputAudioCodec || DEFAULT_CODEC).toLowerCase();
+    const mimeFromCodec = CODEC_TO_MIME[codec] ?? `audio/${codec}`;
+
+    // Primary path — Sarvam JSON envelope.
+    if (
+      declaredType.startsWith('application/json') ||
+      declaredType.endsWith('+json')
+    ) {
+      const envelope = (await response.json()) as {
+        audios?: string[];
+        request_id?: string;
+      };
+      const firstAudio = envelope?.audios?.[0];
+      if (!firstAudio) {
+        throw new InternalServerError(
+          `Sarvam returned JSON without an 'audios' array: ${JSON.stringify(
+            envelope,
+          ).slice(0, 200)}`,
+        );
+      }
+      return {
+        audioBase64: firstAudio,
+        contentType: mimeFromCodec,
+      };
+    }
+
+    // Fallback — raw audio bytes (defensive; not currently exercised by v2).
     const buffer = Buffer.from(await response.arrayBuffer());
     if (buffer.length === 0) {
       throw new InternalServerError('Sarvam returned an empty audio body.');
     }
     return {
       audioBase64: buffer.toString('base64'),
-      contentType,
+      contentType: declaredType || mimeFromCodec,
     };
   }
 }

--- a/backend/src/modules/tts/services/TtsService.ts
+++ b/backend/src/modules/tts/services/TtsService.ts
@@ -1,0 +1,210 @@
+import {inject, injectable} from 'inversify';
+import {
+  HttpError,
+  InternalServerError,
+} from 'routing-controllers';
+import {appConfig} from '#root/config/app.js';
+import {GLOBAL_TYPES} from '#root/types.js';
+import {BaseService} from '#shared/classes/BaseService.js';
+import {MongoDatabase} from '#shared/database/providers/mongo/MongoDatabase.js';
+
+import {TTS_TYPES} from '../types.js';
+import {
+  TTS_DEFAULT_SPEAKER_EN,
+  TTS_DEFAULT_SPEAKER_INDIC,
+} from '../classes/validators/TtsValidators.js';
+import {
+  ITtsService,
+  ITtsSynthesizeInput,
+  ITtsSynthesizeResult,
+} from '../interfaces/ITtsService.js';
+import {
+  ITtsAudioCacheEntry,
+  ITtsCacheRepository,
+} from '../interfaces/ITtsCacheRepository.js';
+import {DEFAULT_TTL_DAYS} from '../repositories/TtsCacheRepository.js';
+import {
+  computeHash,
+  estimateBase64ByteSize,
+  sanitizeUpstreamError,
+} from './ttsHash.js';
+
+/** Public Sarvam TTS endpoint (bulbul v1/v2). */
+const SARVAM_TTS_URL = 'https://api.sarvam.ai/text-to-speech';
+const DEFAULT_MODEL = 'bulbul:v2';
+const DEFAULT_CODEC = 'wav';
+const DEFAULT_SAMPLE_RATE = 22050;
+const MAX_TEXT_PREVIEW_CHARS = 200;
+
+/** Normalized view of a TTS request — used for both cache-keying and the upstream call. */
+export interface NormalizedTtsInput {
+  text: string;
+  language: string;
+  speaker: string;
+  pace: number;
+  pitch: number;
+  loudness: number;
+  model: string;
+  outputAudioCodec: string;
+  speechSampleRate: number;
+}
+
+@injectable()
+export class TtsService extends BaseService implements ITtsService {
+  constructor(
+    @inject(GLOBAL_TYPES.Database)
+    private readonly mongoDatabase: MongoDatabase,
+    @inject(TTS_TYPES.TtsCacheRepository)
+    private readonly cache: ITtsCacheRepository,
+  ) {
+    super(mongoDatabase);
+  }
+
+  async synthesize(input: ITtsSynthesizeInput): Promise<ITtsSynthesizeResult> {
+    const normalized = this.normalizeInput(input);
+    const hash = computeHash(normalized);
+
+    // 1. Cache hit? Return immediately.
+    const cached = await this.cache.findByHash(hash);
+    if (cached) {
+      // Bump hit counter async — never block the user response on it.
+      void this.cache.bumpHit(hash).catch(err => {
+        console.warn('[TTS] failed to bump cache hit', err);
+      });
+      return {
+        audioBase64: cached.audioBase64,
+        contentType: cached.contentType,
+        byteSize: cached.byteSize,
+        cached: true,
+        hash,
+      };
+    }
+
+    // 2. Cache miss — call Sarvam.
+    const apiKey = appConfig.sarvamAPI;
+    if (!apiKey) {
+      throw new HttpError(
+        503,
+        'SARVAM_API_KEY is not configured on the server.',
+      );
+    }
+
+    let upstream: {audioBase64: string; contentType: string};
+    try {
+      upstream = await this.callSarvam(apiKey, normalized);
+    } catch (error: any) {
+      throw new HttpError(
+        502,
+        `Sarvam TTS upstream failed: ${sanitizeUpstreamError(error)}`,
+      );
+    }
+
+    const byteSize = estimateBase64ByteSize(upstream.audioBase64);
+    const now = new Date();
+    const ttlAt = new Date(
+      now.getTime() + DEFAULT_TTL_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    const entry: ITtsAudioCacheEntry = {
+      hash,
+      text: normalized.text.slice(0, MAX_TEXT_PREVIEW_CHARS),
+      language: normalized.language,
+      speaker: normalized.speaker,
+      model: normalized.model,
+      audioBase64: upstream.audioBase64,
+      contentType: upstream.contentType,
+      byteSize,
+      hitCount: 0,
+      createdAt: now,
+      lastAccessedAt: now,
+      ttlAt,
+    };
+
+    // 3. Best-effort cache write — never fail the user request here.
+    try {
+      await this.cache.upsert(entry);
+    } catch (error: any) {
+      console.warn('[TTS] cache upsert failed', error);
+    }
+
+    return {
+      audioBase64: upstream.audioBase64,
+      contentType: upstream.contentType,
+      byteSize,
+      cached: false,
+      hash,
+    };
+  }
+
+  async peekCache(hash: string): Promise<ITtsAudioCacheEntry | null> {
+    return this.cache.findByHash(hash);
+  }
+
+  /** Fill in defaults, normalize text, pick a sensible speaker for the language. */
+  normalizeInput(input: ITtsSynthesizeInput): NormalizedTtsInput {
+    const isEnglish = input.language === 'en-IN';
+    return {
+      text: input.text.trim(),
+      language: input.language,
+      speaker:
+        input.speaker ??
+        (isEnglish ? TTS_DEFAULT_SPEAKER_EN : TTS_DEFAULT_SPEAKER_INDIC),
+      pace: input.pace ?? 1.0,
+      pitch: input.pitch ?? 0.0,
+      loudness: input.loudness ?? 1.0,
+      model: input.model ?? DEFAULT_MODEL,
+      outputAudioCodec: input.outputAudioCodec ?? DEFAULT_CODEC,
+      speechSampleRate: input.speechSampleRate ?? DEFAULT_SAMPLE_RATE,
+    };
+  }
+
+  /** HTTPS call to Sarvam; assumes upstream returns raw audio bytes. */
+  private async callSarvam(
+    apiKey: string,
+    input: NormalizedTtsInput,
+  ): Promise<{audioBase64: string; contentType: string}> {
+    const body: Record<string, unknown> = {
+      text: input.text,
+      target_language_code: input.language,
+      speaker: input.speaker,
+      model: input.model,
+      pace: input.pace,
+      pitch: input.pitch,
+      loudness: input.loudness,
+      output_audio_codec: input.outputAudioCodec,
+      speech_sample_rate: input.speechSampleRate,
+    };
+
+    const response = await fetch(SARVAM_TTS_URL, {
+      method: 'POST',
+      headers: {
+        'api-subscription-key': apiKey,
+        'Content-Type': 'application/json',
+        Accept: 'audio/*',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => '');
+      throw new InternalServerError(
+        `Sarvam TTS ${response.status} ${response.statusText}: ${errText.slice(
+          0,
+          300,
+        )}`,
+      );
+    }
+
+    const rawContentType =
+      response.headers.get('content-type') ?? 'audio/wav';
+    const contentType = rawContentType.split(';')[0].trim() || 'audio/wav';
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.length === 0) {
+      throw new InternalServerError('Sarvam returned an empty audio body.');
+    }
+    return {
+      audioBase64: buffer.toString('base64'),
+      contentType,
+    };
+  }
+}

--- a/backend/src/modules/tts/services/ttsHash.ts
+++ b/backend/src/modules/tts/services/ttsHash.ts
@@ -1,0 +1,38 @@
+import {createHash} from 'crypto';
+import type {NormalizedTtsInput} from './TtsService.js';
+
+/** 128 bits is more than enough for a request-level cache key. */
+export const CACHE_HASH_LENGTH = 32;
+
+/** Approximate decoded byte size from a base64 string (4 chars → 3 bytes). */
+export function estimateBase64ByteSize(base64: string): number {
+  const padding = (base64.match(/=+$/)?.[0].length) ?? 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+/** Deterministic 128-bit cache key from the normalized request. */
+export function computeHash(input: NormalizedTtsInput): string {
+  // Order matters: must be stable across versions and runtimes.
+  const canonical = JSON.stringify({
+    text: input.text,
+    language: input.language,
+    speaker: input.speaker,
+    pace: input.pace,
+    pitch: input.pitch,
+    loudness: input.loudness,
+    model: input.model,
+    outputAudioCodec: input.outputAudioCodec,
+    speechSampleRate: input.speechSampleRate,
+  });
+  return createHash('sha256').update(canonical).digest('hex').slice(
+    0,
+    CACHE_HASH_LENGTH,
+  );
+}
+
+/** Trim verbose upstream error text to keep 502 responses readable. */
+export function sanitizeUpstreamError(error: unknown): string {
+  if (!error) return 'unknown error';
+  if (error instanceof Error) return error.message.slice(0, 240);
+  return String(error).slice(0, 240);
+}

--- a/backend/src/modules/tts/types.ts
+++ b/backend/src/modules/tts/types.ts
@@ -1,0 +1,16 @@
+/**
+ * TTS module dependency-injection symbols.
+ *
+ * Following the per-module convention used by `notification`, `chatbot`, etc.
+ * See `backend/src/bootstrap/loadModules.ts` for how these are resolved.
+ */
+export const TTS_TYPES = {
+  // Controllers
+  TtsController: Symbol.for('TtsController'),
+
+  // Services
+  TtsService: Symbol.for('TtsService'),
+
+  // Repositories
+  TtsCacheRepository: Symbol.for('TtsCacheRepository'),
+};

--- a/frontend/src/components/AiGeneratedAnswerCard.tsx
+++ b/frontend/src/components/AiGeneratedAnswerCard.tsx
@@ -5,13 +5,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "./atoms/tooltip";
-import type { SourceItem } from "@/types";
+import type { SourceItem, SupportedLanguage } from "@/types";
 import { cn } from "@/lib/utils";
 import { ChevronDown, Info, Sparkles } from "lucide-react";
 import { ScrollArea } from "./atoms/scroll-area";
 import { Button } from "./atoms/button";
-
-
+import { AudioPlayerButton } from "./audio/AudioPlayerButton";
 
 type Props = {
   aiApprovedAnswer?: string;
@@ -25,6 +24,12 @@ type Props = {
   onCancel?: () => void;
   isGenerating?: boolean;
   isApproving?: boolean;
+  /**
+   * BCP-47 language code used for TTS playback. Defaults to `en-IN`
+   * when omitted. `"auto"` is also coerced to `en-IN` since the
+   * backend TTS endpoint requires a specific code.
+   */
+  language?: SupportedLanguage | string;
 };
 
 export const AiGeneratedAnswerCard = ({
@@ -38,8 +43,11 @@ export const AiGeneratedAnswerCard = ({
   onApprove,
   onCancel,
   isGenerating,
-  isApproving
+  isApproving,
+  language = "en-IN",
 }: Props) => {
+  const resolvedLanguage =
+    !language || language === "auto" ? "en-IN" : language;
   const [expanded, setExpanded] = useState(false);
 
   const hasSources = Array.isArray(aiApprovedSources) && aiApprovedSources.length > 0;
@@ -117,6 +125,17 @@ export const AiGeneratedAnswerCard = ({
         <div className="overflow-hidden">
           <ScrollArea className="h-[200px]">
             <div className="px-6 py-5 text-sm leading-7 text-foreground/80 space-y-4">
+              {hasAIAnswer && (
+                <div className="flex items-center justify-end -mt-2 mb-1">
+                  <AudioPlayerButton
+                    text={tempAiAnswer || aiInitialAnswer || aiApprovedAnswer || ""}
+                    language={resolvedLanguage}
+                    variant="icon"
+                    disabled={isGenerating}
+                    tooltip="Listen to this AI-generated answer"
+                  />
+                </div>
+              )}
               {isEligibleSource ? (
                 !hasAIAnswer ? (
                   <>

--- a/frontend/src/components/audio/AudioPlayerButton.tsx
+++ b/frontend/src/components/audio/AudioPlayerButton.tsx
@@ -1,0 +1,275 @@
+import {useEffect, useRef, useState} from "react";
+import {Pause, Play, Loader2, AlertCircle, Volume2} from "lucide-react";
+import {Button} from "../atoms/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../atoms/tooltip";
+import {useFetchTtsAudio} from "@/hooks/api/tts/useFetchTtsAudio";
+import type {TtsRequestPayload} from "@/hooks/services/ttsService";
+import {cn} from "@/lib/utils";
+import {base64ToBlobUrl, revokeBlobUrl} from "./audioUtils";
+
+type PlayerState = "idle" | "loading" | "playing" | "paused" | "error";
+
+export interface AudioPlayerButtonProps {
+  /** The text to speak. */
+  text: string;
+  /** BCP-47 language code, e.g. "en-IN" or "hi-IN". */
+  language: string;
+  /** Optional voice id (Sarvam speaker). */
+  speaker?: string;
+  /** Optional override for pace multiplier (0.3 – 3.0). */
+  pace?: number;
+  /** Optional override for pitch (-1.0 – 1.0). */
+  pitch?: number;
+  /** Optional override for loudness (0.1 – 2.0). */
+  loudness?: number;
+  /** Optional override for the Sarvam model id. */
+  model?: string;
+  /** Disable the button (e.g. while the answer is still loading). */
+  disabled?: boolean;
+  /** Optional className passthrough for layout. */
+  className?: string;
+  /** Override the icon tooltip. */
+  tooltip?: string;
+  /** Render compact (icon-only) or with a label. */
+  variant?: "icon" | "compact" | "full";
+}
+
+/**
+ * Plays back server-generated TTS audio for the supplied text.
+ *
+ * State machine:
+ *   idle → click → loading → playing
+ *                        ↓
+ *                     paused ← (click) ← playing
+ *
+ *   error → click → loading (retry)
+ */
+export const AudioPlayerButton = ({
+  text,
+  language,
+  speaker,
+  pace,
+  pitch,
+  loudness,
+  model,
+  disabled = false,
+  className,
+  tooltip = "Listen to this answer",
+  variant = "compact",
+}: AudioPlayerButtonProps) => {
+  const [state, setState] = useState<PlayerState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
+
+  const {mutate: fetchAudio, reset} = useFetchTtsAudio();
+
+  // Stop and reset on unmount.
+  useEffect(() => {
+    return () => {
+      revokeBlobUrl(blobUrlRef.current);
+      blobUrlRef.current = null;
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.src = "";
+      }
+    };
+  }, []);
+
+  // If the text/language/speaker changes after we've already loaded audio, reset.
+  useEffect(() => {
+    revokeBlobUrl(blobUrlRef.current);
+    blobUrlRef.current = null;
+    audioRef.current?.pause();
+    setState("idle");
+    setErrorMessage(null);
+    reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, language, speaker]);
+
+  const handleClick = () => {
+    if (disabled) return;
+
+    if (state === "playing") {
+      audioRef.current?.pause();
+      setState("paused");
+      return;
+    }
+
+    if (state === "paused") {
+      void audioRef.current?.play().catch(err => {
+        console.warn("[AudioPlayer] resume failed", err);
+        setState("error");
+        setErrorMessage("Audio playback was blocked.");
+      });
+      setState("playing");
+      return;
+    }
+
+    if (state === "error") {
+      setErrorMessage(null);
+    }
+
+    // idle OR error → fetch fresh audio.
+    setState("loading");
+    const payload: TtsRequestPayload = {
+      text,
+      language,
+      ...(speaker !== undefined ? {speaker} : {}),
+      ...(pace !== undefined ? {pace} : {}),
+      ...(pitch !== undefined ? {pitch} : {}),
+      ...(loudness !== undefined ? {loudness} : {}),
+      ...(model !== undefined ? {model} : {}),
+    };
+
+    fetchAudio(payload, {
+      onSuccess: response => {
+        if (!response) {
+          setState("error");
+          setErrorMessage("Empty TTS response.");
+          return;
+        }
+        try {
+          revokeBlobUrl(blobUrlRef.current);
+          const url = base64ToBlobUrl(response.audioBase64, response.contentType);
+          blobUrlRef.current = url;
+          if (!audioRef.current) {
+            audioRef.current = new Audio();
+          }
+          const audio = audioRef.current;
+          audio.src = url;
+          audio.onended = () => setState("idle");
+          audio.onerror = () => {
+            setState("error");
+            setErrorMessage("Failed to play audio.");
+          };
+          void audio.play().catch(err => {
+            console.warn("[AudioPlayer] play() failed", err);
+            setState("error");
+            setErrorMessage("Audio playback was blocked by the browser.");
+          });
+          setState("playing");
+        } catch (err: any) {
+          console.error("[AudioPlayer] decode error", err);
+          setState("error");
+          setErrorMessage(err?.message ?? "Failed to decode audio.");
+        }
+      },
+      onError: (err: any) => {
+        setState("error");
+        setErrorMessage(
+          err instanceof Error ? err.message : "Failed to synthesize audio.",
+        );
+      },
+    });
+  };
+
+  // — Render below is appended by the next edit —
+  return renderPlayerUi({
+    state,
+    errorMessage,
+    variant,
+    tooltip,
+    disabled,
+    className,
+    handleClick,
+  });
+};
+
+/** Pure renderer — extracted so the component body stays small in source. */
+function renderPlayerUi(params: {
+  state: PlayerState;
+  errorMessage: string | null;
+  variant: "icon" | "compact" | "full";
+  tooltip: string;
+  disabled: boolean;
+  className: string | undefined;
+  handleClick: () => void;
+}) {
+  const {
+    state,
+    errorMessage,
+    variant,
+    tooltip,
+    disabled,
+    className,
+    handleClick,
+  } = params;
+
+  const isLoading = state === "loading";
+  const isPlaying = state === "playing";
+  const isError = state === "error";
+
+  const Icon = isLoading
+    ? Loader2
+    : isError
+      ? AlertCircle
+      : isPlaying
+        ? Pause
+        : Play;
+
+  const label = isLoading
+    ? "Generating…"
+    : isError
+      ? "Retry audio"
+      : isPlaying
+        ? "Pause"
+        : state === "paused"
+          ? "Resume"
+          : "Listen";
+
+  const button = (
+    <Button
+      type="button"
+      variant={isError ? "outline" : isPlaying ? "secondary" : "ghost"}
+      size={variant === "icon" ? "icon" : "sm"}
+      disabled={disabled || isLoading}
+      onClick={handleClick}
+      className={cn(
+        "transition-colors",
+        isError && "border-destructive text-destructive hover:bg-destructive/10",
+        isPlaying && "bg-primary/10 text-primary",
+        className,
+      )}
+      aria-label={label}
+      aria-pressed={isPlaying}
+    >
+      <Icon
+        className={cn(
+          variant === "icon" ? "h-4 w-4" : "h-3.5 w-3.5",
+          isLoading && "animate-spin",
+        )}
+      />
+      {variant === "full" && (
+        <>
+          <Volume2 className="ml-1.5 h-3.5 w-3.5 opacity-70" />
+          <span className="ml-1.5">{label}</span>
+        </>
+      )}
+      {variant === "compact" && (
+        <span className="ml-1.5 text-xs">{label}</span>
+      )}
+    </Button>
+  );
+
+  if (variant === "icon") {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{button}</TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            {isError && errorMessage ? errorMessage : tooltip}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return button;
+}

--- a/frontend/src/components/audio/__tests__/audioUtils.test.ts
+++ b/frontend/src/components/audio/__tests__/audioUtils.test.ts
@@ -1,0 +1,67 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from "vitest";
+import {base64ToBlobUrl, revokeBlobUrl} from "../audioUtils";
+
+describe("base64ToBlobUrl", () => {
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+  let created: Array<{blob: Blob; url: string}>;
+  let revoked: string[];
+
+  beforeEach(() => {
+    created = [];
+    revoked = [];
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      const url = `blob:test-${created.length}`;
+      created.push({blob, url});
+      return url;
+    }) as any;
+    URL.revokeObjectURL = vi.fn((url: string) => {
+      revoked.push(url);
+    }) as any;
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreate;
+    URL.revokeObjectURL = originalRevoke;
+  });
+
+  it("produces a URL for a known input", () => {
+    const b64 = Buffer.from("hello").toString("base64");
+    const url = base64ToBlobUrl(b64, "audio/wav");
+    expect(url).toMatch(/^blob:test-\d+$/);
+    expect(created).toHaveLength(1);
+    expect(created[0].blob.type).toBe("audio/wav");
+    expect(created[0].blob.size).toBe(5);
+  });
+
+  it("preserves an empty-string audio payload without throwing", () => {
+    const url = base64ToBlobUrl("", "audio/wav");
+    expect(url).toMatch(/^blob:test-\d+$/);
+    expect(created[0].blob.size).toBe(0);
+  });
+
+  it("honors the provided MIME type", () => {
+    base64ToBlobUrl(Buffer.from("x").toString("base64"), "audio/mp3");
+    expect(created[0].blob.type).toBe("audio/mp3");
+  });
+});
+
+describe("revokeBlobUrl", () => {
+  it("does nothing when passed null", () => {
+    const spy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    revokeBlobUrl(null);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when passed an empty string", () => {
+    const spy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    revokeBlobUrl("");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("calls URL.revokeObjectURL when given a real URL", () => {
+    const spy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    revokeBlobUrl("blob:abc-123");
+    expect(spy).toHaveBeenCalledWith("blob:abc-123");
+  });
+});

--- a/frontend/src/components/audio/audioUtils.ts
+++ b/frontend/src/components/audio/audioUtils.ts
@@ -1,0 +1,26 @@
+/**
+ * Convert a base64 string + MIME type into a playable Blob URL.
+ * Caller is responsible for revoking the URL with `URL.revokeObjectURL`.
+ */
+export function base64ToBlobUrl(
+  audioBase64: string,
+  contentType: string,
+): string {
+  const binary = atob(audioBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const blob = new Blob([bytes], {type: contentType});
+  return URL.createObjectURL(blob);
+}
+
+/**
+ * Revoke a blob URL we created via `base64ToBlobUrl`. Safe to call with
+ * null/undefined — no-ops.
+ */
+export function revokeBlobUrl(url: string | null): void {
+  if (url) {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/frontend/src/hooks/api/tts/useFetchTtsAudio.ts
+++ b/frontend/src/hooks/api/tts/useFetchTtsAudio.ts
@@ -1,0 +1,36 @@
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  TtsService,
+  type TtsRequestPayload,
+  type TtsResponse,
+} from "../../services/ttsService";
+
+const ttsService = new TtsService();
+
+/**
+ * TanStack Query mutation for synthesizing (or fetching from cache) TTS audio.
+ *
+ * We use `useMutation` rather than `useQuery` so the request fires only when
+ * the user clicks the speaker button — the audio is not pre-fetched.
+ */
+export const useFetchTtsAudio = () => {
+  return useMutation<TtsResponse | null, Error, TtsRequestPayload>({
+    mutationKey: ["tts", "synthesize"],
+    mutationFn: async (payload: TtsRequestPayload) => {
+      try {
+        return await ttsService.synthesize(payload);
+      } catch (error) {
+        throw error instanceof Error ? error : new Error("Unknown TTS error");
+      }
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to synthesize audio. Please try again.",
+      );
+      console.error("[TTS] useFetchTtsAudio error:", error);
+    },
+  });
+};

--- a/frontend/src/hooks/services/ttsService.ts
+++ b/frontend/src/hooks/services/ttsService.ts
@@ -1,0 +1,46 @@
+import { apiFetch } from "../api/api-fetch";
+import { env } from "@/config/env";
+
+const API_BASE_URL = env.apiBaseUrl();
+
+export interface TtsRequestPayload {
+  text: string;
+  language: string;
+  speaker?: string;
+  pace?: number;
+  pitch?: number;
+  loudness?: number;
+  model?: string;
+  outputAudioCodec?: string;
+  speechSampleRate?: number;
+}
+
+export interface TtsResponse {
+  audioBase64: string;
+  contentType: string;
+  byteSize: number;
+  cached: boolean;
+  hash: string;
+}
+
+/**
+ * Client for the backend TTS proxy. We deliberately go through the backend —
+ * not the Sarvam REST API directly — so the API key stays server-side and
+ * every audio payload is cached in Mongo for replay reuse.
+ */
+export class TtsService {
+  private _baseUrl = `${API_BASE_URL}/tts`;
+
+  /** Synthesize (or fetch from cache) audio for the given text. */
+  async synthesize(payload: TtsRequestPayload): Promise<TtsResponse | null> {
+    try {
+      return await apiFetch<TtsResponse>(this._baseUrl, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      console.error(`[TTS] synthesize failed for language=${payload.language}:`, error);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## feat(tts): add Sarvam-backed text-to-speech playback with Mongo cache

Adds a single `POST /api/tts` endpoint that proxies Sarvam's `bulbul:v2`
text-to-speech and caches the synthesized audio in MongoDB so replays are
free. The frontend gets an `AudioPlayerButton` component + TanStack-Query
hook that drop into `AiGeneratedAnswerCard` with one prop.

### Why
Experts reviewing AI-generated answers often want to *listen* to the
answer instead of reading it — especially on mobile and in low-literacy
contexts. Right now there is no TTS path in the codebase. The Sarvam
SDK is already declared in `backend/package.json` and the
`SARVAM_API_KEY` is already wired into `appConfig`, but neither is
actually used anywhere in TS code, so this PR also makes good on that
declared capability.

### Backend — `backend/src/modules/tts/`
- `POST /api/tts` — `routing-controllers` controller with full
  `@OpenAPI` / `@ResponseSchema` decorators for the existing
  auto-generated spec.
- **InversifyJS wiring** mirrors the per-module convention used by
  `notification`, `chatbot`, etc. — `ttsContainerModule`,
  `ttsModuleControllers`, `ttsModuleValidators`, `setupTtsContainer`.
  Auto-discovered by `bootstrap/loadModules.ts` because the directory
  lives under `src/modules`.
- **`TtsService`** normalizes inputs (trims, defaults speaker by
  language, defaults model to `bulbul:v2`, codec to `wav`, sample rate
  to 22050), derives a deterministic 128-bit SHA-256 cache key, and
  falls back to a direct HTTPS call to `https://api.sarvam.ai/text-to-speech`.
- **`TtsCacheRepository`** writes to a new `tts_audio_cache` collection
  with a unique index on `hash` and a TTL index on `ttlAt` (30-day
  default). Cache writes are best-effort — a Mongo blip never breaks a
  user request.
- Surfaces three response paths:
  - `200` `{ audioBase64, contentType, byteSize, cached, hash }`
  - `400` invalid body
  - `401` unauthenticated
  - `502` Sarvam upstream failure (sanitized message)
  - `503` `SARVAM_API_KEY` not configured
- **Tests:** 18 vitest cases in `__tests__/` covering cache hit/miss,
  hash determinism across all fields, key sensitivity to each
  individual field, ordering, `SARVAM_API_KEY` missing, upstream
  failure, cache-write failures (graceful degradation), and
  default-fill logic. All pass with `pnpm vitest run src/modules/tts`.

### Frontend
- `src/hooks/services/ttsService.ts` + `src/hooks/api/tts/useFetchTtsAudio.ts`
  follow the existing pattern (e.g. `notificationService`,
  `useGetNotifications`).
- `src/components/audio/AudioPlayerButton.tsx`:
  - Idle / loading / playing / paused / error state machine.
  - Base64 → `Blob` → `URL.createObjectURL` decoding isolated in
    `audioUtils.ts` for unit-testability.
  - Blob URLs revoked on unmount, on text/language change, and on
    re-fetch — no leaks.
  - Three variants: `icon` (tooltip-only, used in `AiGeneratedAnswerCard`),
    `compact` (icon + label), `full` (icon + label + speaker glyph).
- `AiGeneratedAnswerCard.tsx` gains an optional `language` prop
  (defaults to `en-IN`, coerces `"auto"` to `en-IN`) and renders the
  icon variant above the answer body when an AI answer exists.
- **Tests:** `audioUtils.test.ts` (6 cases) covers the Blob URL
  decoder and revoke helper.

### Out of scope / non-goals
- No rate limiting on `/api/tts` — Sarvam's quotas apply. We can add
  per-user throttling later if abuse appears.
- No streaming response — base64 in JSON keeps the contract simple
  and matches how the rest of the codebase handles binary payloads.
  Replays are instant from the cache anyway.
- No UI changes outside the AI answer card. `voice-recorder-card.tsx`
  is the natural next integration point if you want speech-to-text
  answers too, but that's a separate PR.

### How to test locally
```sh
# Backend (port 4100 to avoid clashing with the default 3141)
cd backend
PORT=4100 SARVAM_API_KEY=<your-key> pnpm dev

# Frontend (port 5273)
cd frontend
VITE_PORT=5273 VITE_API_BASE_URL=http://localhost:4100/api pnpm dev
```

Open any question with an AI-generated answer → click the speaker
glyph in the card body. First click synthesizes (a few hundred ms),
subsequent clicks are served from Mongo instantly.

### Notes for reviewers
- This is my first contribution — happy to iterate on naming,
  defaults, or error UX based on your team's conventions.
- I considered a frontend-direct Sarvam call but kept the key
  server-side for the same reason `plivo` and `openai` keys are
  server-side: abuse-resistance and centralized rate limiting.
- `BaseService` and `MongoDatabase` are imported from their direct
  file paths (`#shared/classes/BaseService.js`,
  `#shared/database/providers/mongo/MongoDatabase.js`) rather than the
  umbrella `#shared/index.js`. The umbrella re-exports `notification`
  which has a module-load side-effect on `web-push` requiring VAPID
  keys, which broke unit tests for unrelated modules.