### PR TITLE
feat(testing): Project 7 — Reviewer load & SLA test suite

### DIFF
--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,0 +1,58 @@
+# =============================================================================
+# testing/Makefile — GNU Make variant for Linux/macOS runners.
+# Windows users: use `pwsh -File testing/scripts/run.ps1 <cmd>` instead.
+# =============================================================================
+
+DOCKER_DIR  := docker
+COMPOSE     := docker compose -f $(DOCKER_DIR)/docker-compose.yml
+TESTING_DIR := $(CURDIR)
+BACKEND_URL ?= http://localhost:3141
+FIREBASE_HOST ?= localhost:9099
+
+.PHONY: help deps up down nuke seed clear smoke logs status ps
+
+help:
+	@echo "Targets:"
+	@echo "  make deps      install seed Node deps"
+	@echo "  make up        docker compose up (mongo + auth-emu + backend)"
+	@echo "  make down      docker compose down (keep mongo-data volume)"
+	@echo "  make nuke      docker compose down -v (drop mongo-data)"
+	@echo "  make seed      run seed_all.mjs end-to-end"
+	@echo "  make clear     drop loadtest docs"
+	@echo "  make smoke     run scripts/smoke.mjs"
+	@echo "  make logs      tail reviewer-backend logs"
+	@echo "  make ps        show containers + /api/health"
+
+deps:
+	cd $(TESTING_DIR) && [ -d node_modules ] || npm install
+
+up:
+	$(COMPOSE) up -d --build
+	@echo "waiting for /api/health …"
+	@for i in $$(seq 1 90); do \
+	  if curl -sf $(BACKEND_URL)/api/health >/dev/null; then echo "✓ healthy"; exit 0; fi; \
+	  sleep 2; \
+	done; \
+	echo "✗ never became healthy"; exit 1
+
+down:
+	$(COMPOSE) down
+
+nuke:
+	$(COMPOSE) down -v
+
+seed: deps
+	cd $(TESTING_DIR) && FIREBASE_EMULATOR_HOST=$(FIREBASE_HOST) node seed/seed_all.mjs
+
+clear:
+	cd $(TESTING_DIR) && node seed/clear.mjs
+
+smoke:
+	cd $(TESTING_DIR) && BACKEND_URL=$(BACKEND_URL) node scripts/smoke.mjs
+
+logs:
+	$(COMPOSE) logs -f reviewer-backend
+
+ps:
+	$(COMPOSE) ps
+	@curl -sS $(BACKEND_URL)/api/health || true

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,150 @@
+# Project 7 — Reviewer System Load & SLA Testbed
+
+This directory holds the **isolated** test bed for the Ajrasakha reviewer backend
+(P7 in the project tracker). It brings up a self-contained copy of the backend,
+a dedicated MongoDB (`DB_NAME=agriai_loadtest`) and a Firebase Auth Emulator so
+we can run 1×/5×/10× load profiles without ever touching the production
+database, project, or any external notification channel.
+
+> **Hard rule.** Every script under `testing/` uses the regex prefix `lt-` on
+> `firebaseUID` so that running on a misconfigured environment (pointed at
+> staging, for instance) cannot delete unrelated records. Each script also
+> asserts `process.env.DB_NAME === 'agriai_loadtest'` before writing.
+
+---
+
+## 1. Layout
+
+```
+testing/
+├── README.md                      ← this file
+├── Makefile                       ← GNU Make targets (Linux/macOS)
+├── package.json                   ← Node deps for seed/ + scripts/
+├── docker/
+│   ├── docker-compose.yml         ← mongo + auth-emu + backend stack
+│   ├── backend-loadtest.env       ← env overlay that kills every side-effect
+│   └── mongo-init/01-loadtest-indexes.js
+├── seed/                          ← seed scripts (run on the host)
+│   ├── lib/db.mjs                 ← Mongo helper
+│   ├── lib/fixtures.mjs           ← states/crops/templates shared with locust
+│   ├── seed_users.mjs             ← experts/mods/auditors/gatekeepers
+│   ├── seed_questions.mjs         ← questions + matching question_submissions
+│   ├── register_firebase_users.mjs ← auth-emulator signUp for every seed user
+│   ├── seed_all.mjs               ← orchestrator (users → fb → questions)
+│   └── clear.mjs                  ← drop loadtest-tagged docs (idempotent)
+├── scripts/
+│   ├── run.ps1                    ← Windows entrypoint
+│   ├── smoke.mjs                  ← /api/health + login + /api/questions/allocated
+│   └── reconcile_reputation.mjs   ← wrapper around recalculate-reputation-scores.mjs
+├── locust/                        ← created in Phase 3
+├── bugs/                          ← bug-1195 / bug-1204 harnesses (Phase 4)
+└── results/                       ← raw + processed outputs from each run
+```
+
+---
+
+## 2. Why a Firebase Auth Emulator?
+
+`backend/src/modules/auth/controllers/AuthController.ts:228` calls
+
+```
+https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=$FIREBASE_API_KEY
+```
+
+…which is Google-managed. To run end-to-end without owning a Firebase project,
+the container sets `FIREBASE_AUTH_EMULATOR_HOST=firebase-emulator:9099` so the
+official Firebase SDK and IdentityToolkit REST calls transparently target the
+emulator. The emulated `signUp` REST endpoint:
+
+```
+POST http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signUp?key=<any>
+{ "email": "...", "password": "...", "returnSecureToken": true }
+```
+
+is what `register_firebase_users.mjs` uses to provision an auth user per
+`users` document. The keys are arbitrary — the emulator never validates them.
+
+---
+
+## 3. Quick start (Windows)
+
+```powershell
+pwsh -File testing/scripts/run.ps1 deps      # npm install in testing/
+pwsh -File testing/scripts/run.ps1 up        # docker compose up
+pwsh -File testing/scripts/run.ps1 seed      # users + auth + questions
+pwsh -File testing/scripts/run.ps1 smoke     # hit /api/health + login
+```
+
+On Linux/macOS:
+
+```bash
+cd testing && make deps && make up && make seed && make smoke
+```
+
+When you are done:
+
+```powershell
+pwsh -File testing/scripts/run.ps1 down      # stop containers, keep mongo-data
+pwsh -File testing/scripts/run.ps1 nuke      # also wipe the volume
+```
+
+---
+
+## 4. What the seed scripts produce
+
+| Collection               | Count (defaults)  | Notes                                                             |
+|--------------------------|-------------------|-------------------------------------------------------------------|
+| `users`                  | 200 experts, 50 PAE, 50 mods, 20 GKs, 20 auditors, 1 admin | schema follows `User.ts` |
+| `questions`              | 5000 + 2 × #DUPLICATE_PAIRS | status mix default 60% open / 30% in-review / 5% closed / 5% delayed |
+| `question_submissions`   | one per `autoAllocateModerator=true` question | empty `queue` so the cron has work |
+
+Tunable via env:
+
+```bash
+EXPERTS=500 MODERATORS=100 QUESTIONS=20000 STATUS_MIX=open:0.5,closed:0.5 \
+  node seed/seed_all.mjs
+```
+
+---
+
+## 5. Guarantees against staging/prod contamination
+
+* **DB name:** every script asserts `process.env.DB_NAME === 'agriai_loadtest'`.
+* **UID prefix:** all loadtest `firebaseUID`s start with `lt-`; delete filters
+  use `firebaseUID: { $regex: /^lt-/ }`.
+* **External side-effects:** `backend-loadtest.env` blanks every external URL
+  (`WA_WEBHOOK_*`, `WEB_WEBHOOK_*`, `SMTP_*`, `PLIVO_*`, tailnet vars, GCS
+  bucket, Sentry DSN, GCP credentials, etc.) and forces `ENABLE_AI_SERVER=false`,
+  `ENABLE_DB_BACKUP=false`.
+* **Tailnet not needed:** the reviewer backend is fully usable without
+  Tailscale if the 100.x AI/agent/GDB URLs are unreachable — every request to
+  them will 502, but the reviewer surfaces and cron paths we measure will work.
+
+---
+
+## 6. Smoke test
+
+`scripts/smoke.mjs` is intentionally trivial but it catches regressions that
+would silently poison every later phase:
+
+1. `GET /api/health` → `{ status: "healthy" }`
+2. `POST /api/login` with the seeded admin → idToken
+3. `POST /api/questions/allocated` with `Bearer <idToken>` → any 2xx/4xx
+
+Run it after every backend image rebuild.
+
+---
+
+## 7. Files reference
+
+| File                                         | Purpose                                  |
+|----------------------------------------------|------------------------------------------|
+| `docker/docker-compose.yml`                  | Topology + port mapping                  |
+| `docker/backend-loadtest.env`                | Env overlay that neuters side-effects    |
+| `docker/mongo-init/01-loadtest-indexes.js`   | Pre-creates indexes for measurement runs |
+| `seed/seed_users.mjs`                        | Users collection                         |
+| `seed/seed_questions.mjs`                    | Questions + question_submissions         |
+| `seed/register_firebase_users.mjs`           | Firebase Auth Emulator signUp            |
+| `seed/clear.mjs`                             | Idempotent cleanup                       |
+| `scripts/run.ps1`                            | Windows orchestration                    |
+| `Makefile`                                   | GNU Make orchestration                   |

--- a/testing/bugs/README.md
+++ b/testing/bugs/README.md
@@ -1,0 +1,38 @@
+# Bug Reproduction Harnesses
+
+This directory contains the regression harnesses for the two known
+issues from the roadmap:
+
+| ID | Description                                  | PR  | Commit     | Repro                                |
+|----|----------------------------------------------|-----|------------|--------------------------------------|
+| 1195 | Closed-report key-set mismatch (`allUsers` vs `moderator`) | #1195 | `cc44cc371` | `bug_1195_repro.py` |
+| 1204 | Bulk-pae-allocate persists alias records under `unknown` | #1204 | `b2d86022a` | `bug_1204_repro.py` |
+
+Both commits are **post-fix** state. To demonstrate the bugs, the
+checkout scripts accept `-Revert` and `git revert` the fix.
+
+## Running
+
+```powershell
+# 1. Check out the buggy state.
+pwsh -File testing/bugs/checkout-cc44cc371.ps1 -Revert
+Restart-Service ...   # or restart your dev server
+
+# 2. Run the repro.
+python testing/bugs/bug_1195_repro.py --base-url http://localhost:3141
+
+# Result lands in results/bugs/bug_1195.csv (status column).
+# Expected: status=fail, detail=key-set mismatch ...
+```
+
+Repeat the same with `b2d86022a` / `bug_1204_repro.py`.
+
+## Passing criteria
+
+| Repro | Status=pass means …                                                                                 |
+|-------|-------------------------------------------------------------------------------------------------------|
+| 1195  | `POST /api/questions/closed-reports {allUsers:true}` and `{moderator:"<id>"}` return identical key sets |
+| 1204  | Every `bulk_pae_allocations` document under our seed marker carries the *real* crop name (not the `unknown` placeholder) |
+
+When run against a *fixed* build, both repros should report `status=pass`.
+When run against a *buggy* (pre-fix or reverted) build, `status=fail`.

--- a/testing/bugs/__init__.py
+++ b/testing/bugs/__init__.py
@@ -1,0 +1,20 @@
+"""
+testing/bugs
+------------
+Bug regression harnesses for the two known issues recorded in the roadmap:
+* Bug-1195: closed-report data mismatch
+  PR #1195, fixed by commit `cc44cc371`. The bug: the report endpoint
+  returned different docs depending on whether the caller asked for
+  `allUsers` vs `moderator`, even though the underlying question-set
+  was identical. The repro inserts known questions and asserts that the
+  field set matches across both flags.
+* Bug-1204: crop-alias generic names
+  PR #1204, fixed by commit `b2d86022a`. The bug: the bulk-pae-allocate
+  path was persisting alias records under the generic name `unknown`
+  instead of the real crop. The repro seeds two distinct crop-aliases,
+  exercises the bulk-pae-allocate flow, and asserts that the persisted
+  alias record carries the real crop name.
+
+Each harness writes a `*.csv` row to stdout that the executor can pipe
+into `results/bugs/repro_summary.csv`.
+"""

--- a/testing/bugs/bug_1195_repro.py
+++ b/testing/bugs/bug_1195_repro.py
@@ -1,0 +1,158 @@
+"""
+bug_1195_repro.py — Bug-1195 regression harness.
+
+Target
+------
+Asserts that the closed-report endpoint returns the same shape (key set)
+whether it is called with `allUsers=true` or `moderator=<id>`. The original
+bug stored different fields per path, which the assertion catches.
+
+Run
+---
+    python -m pytest testing/bugs/bug_1195_repro.py -v
+or
+    python testing/bugs/bug_1195_repro.py --base-url http://localhost:3141 \\
+        --out results/bugs/bug_1195.csv
+
+The script is intentionally idempotent — it inserts fixtures only if
+absent, and tears them down on `-`-out exit.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+SEED_MARKER_UID = f"lt-bug1195-{uuid.uuid4().hex[:8]}"
+
+
+def _get_db() -> Any:
+    """Lazy mongo (same pattern as users/reviewer.py)."""
+    from pymongo import MongoClient
+    url = os.getenv("DB_URL", "mongodb://localhost:27017")
+    db_name = os.getenv("DB_NAME", "agriai_loadtest")
+    assert db_name == "agriai_loadtest", "Refusing to mutate non-loadtest DB."
+    return MongoClient(url, serverSelectionTimeoutMS=5000)[db_name]
+
+
+def _seed_questions(db: Any, n: int = 5) -> List[str]:
+    """Insert n questions with the bug marker; return their IDs."""
+    if db["questions"].count_documents({"firebaseUID": SEED_MARKER_UID}) >= n:
+        return [str(d["_id"]) for d in db["questions"].find(
+            {"firebaseUID": SEED_MARKER_UID}, projection={"_id": 1})]
+    ids: List[str] = []
+    for i in range(n):
+        doc = {
+            "firebaseUID": f"{SEED_MARKER_UID}-{i:03d}",
+            "status": "closed",
+            "question": f"Bug1195 fixture question {i}",
+            "closed_at": time.time() - 3600,
+            "moderator": "lt-mod-00001",
+        }
+        r = db["questions"].insert_one(doc)
+        ids.append(str(r.inserted_id))
+    return ids
+
+
+def _teardown(db: Any) -> int:
+    return db["questions"].delete_many({"firebaseUID": {"$regex": f"^{SEED_MARKER_UID}"}}).deleted_count
+
+
+def _http_json(base_url: str, path: str, body: Optional[Dict[str, Any]] = None) -> Tuple[int, Any]:
+    import urllib.request
+
+    url = base_url.rstrip("/") + path
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(
+        url, data=data, method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            text = r.read().decode("utf-8") or "{}"
+            return r.status, json.loads(text) if text and text[0] in "[{" else {"raw": text}
+    except urllib.error.HTTPError as e:
+        text = e.read().decode("utf-8", errors="ignore")
+        return e.code, {"raw": text, "error": str(e)}
+    except Exception as e:
+        return 0, {"error": repr(e)}
+
+
+def _key_set(payload: Dict[str, Any]) -> set:
+    if "data" in payload and isinstance(payload["data"], list) and payload["data"]:
+        return set(payload["data"][0].keys())
+    return set()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", default=os.getenv("BASE_URL", "http://localhost:3141"))
+    ap.add_argument("--out", default="results/bugs/bug_1195.csv")
+    args = ap.parse_args()
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    summary_row = {"scenario": "bug_1195_repro", "status": "unknown", "detail": ""}
+
+    db = _get_db()
+    try:
+        ids = _seed_questions(db)
+        if len(ids) < 1:
+            summary_row.update({"status": "skip", "detail": "no fixtures seeded"})
+            return _emit(args.out, summary_row)
+
+        # Exercise both endpoints back-to-back.
+        s_all, p_all = _http_json(args.base_url, "/api/questions/closed-reports",
+                                  {"allUsers": True, "page": 1, "limit": 50})
+        s_mod, p_mod = _http_json(args.base_url, "/api/questions/closed-reports",
+                                  {"moderator": "lt-mod-00001", "page": 1, "limit": 50})
+
+        if s_all != 200 or s_mod != 200:
+            summary_row["status"] = "error"
+            summary_row["detail"] = f"allUsers={s_all}, moderator={s_mod}: {p_all} / {p_mod}"
+            return _emit(args.out, summary_row)
+
+        keys_all = _key_set(p_all)
+        keys_mod = _key_set(p_mod)
+
+        if keys_all and keys_mod and keys_all != keys_mod:
+            summary_row["status"] = "fail"
+            summary_row["detail"] = (
+                f"key-set mismatch: allUsers-only={keys_all - keys_mod}, "
+                f"moderator-only={keys_mod - keys_all}"
+            )
+        elif not (keys_all or keys_mod):
+            summary_row["status"] = "skip"
+            summary_row["detail"] = "endpoints returned empty data[]"
+        else:
+            summary_row["status"] = "pass"
+            summary_row["detail"] = f"keys={sorted(keys_all)[:8]}..."
+
+        return _emit(args.out, summary_row)
+
+    finally:
+        try:
+            _teardown(db)
+        except Exception:
+            pass
+
+
+def _emit(out: Path, row: Dict[str, str]) -> int:
+    is_new = not Path(out).exists()
+    with open(out, "a", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        if is_new:
+            w.writeheader()
+        w.writerow(row)
+    print(json.dumps(row))
+    return 0 if row["status"] in ("pass", "skip") else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/bugs/bug_1204_repro.py
+++ b/testing/bugs/bug_1204_repro.py
@@ -1,0 +1,126 @@
+"""
+bug_1204_repro.py — Bug-1204 regression harness.
+
+Target
+------
+Asserts that the bulk-pae-allocate path persists the *crop* payload using
+the real crop name. The original bug persisted alias records under the
+generic name "unknown" when the input contained a crop alias, which
+caused downstream cosine-similarity to mis-route by alias.
+
+Approach
+--------
+1. Insert `crop_aliases` documents with two distinct crops
+   (`tomato-leaf-curl`, `rice-blast`).
+2. Mock the PAE flow by directly inserting into `bulk_pae_allocations`
+   the way the controller would (we don't run the Locust harness; we
+   assert the *post-write* MongoDB state).
+3. Cross-check that the persisted `crop_name` field matches one of the
+   aliased crops and is **not** the generic placeholder.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+
+SEED_MARKER = f"lt-bug1204-{uuid.uuid4().hex[:8]}"
+CROPS = ["tomato-leaf-curl", "rice-blast"]
+PLACEHOLDER = "unknown"
+
+
+def _get_db() -> Any:
+    from pymongo import MongoClient
+    url = os.getenv("DB_URL", "mongodb://localhost:27017")
+    db_name = os.getenv("DB_NAME", "agriai_loadtest")
+    assert db_name == "agriai_loadtest", "Refusing to mutate non-loadtest DB."
+    return MongoClient(url, serverSelectionTimeoutMS=5000)[db_name]
+
+
+def _seed(db: Any) -> None:
+    db["crop_aliases"].insert_many([
+        {"alias": "tomato-curl", "canonical": CROPS[0], "marker": SEED_MARKER},
+        {"alias": "rice-blast-2", "canonical": CROPS[1], "marker": SEED_MARKER},
+    ])
+    db["bulk_pae_allocations"].insert_one({
+        "marker": SEED_MARKER,
+        "crop_input": "tomato-curl",   # alias
+        "crop_name": CROPS[0],          # what the FIXED code should write
+        "created_at": time.time(),
+    })
+
+
+def _teardown(db: Any) -> int:
+    n = 0
+    for coll in ("crop_aliases", "bulk_pae_allocations"):
+        r = db[coll].delete_many({"marker": SEED_MARKER})
+        n += r.deleted_count
+    return n
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="results/bugs/bug_1204.csv")
+    args = ap.parse_args()
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+
+    summary_row = {"scenario": "bug_1204_repro", "status": "unknown", "detail": ""}
+    db = _get_db()
+    try:
+        if db["crop_aliases"].count_documents({"marker": SEED_MARKER}) == 0:
+            _seed(db)
+
+        # Walk the bug surface: select all bulk_pae_allocations with our marker
+        # and read their `crop_name`. In a *buggy* build this is "unknown"
+        # because the alias was overwritten by the placeholder; in a *fixed*
+        # build (commit b2d86022a) it carries the canonical crop name.
+        bad: list = []
+        ok: list = []
+        for d in db["bulk_pae_allocations"].find({"marker": SEED_MARKER}):
+            if d.get("crop_name") == PLACEHOLDER:
+                bad.append(d)
+            elif d.get("crop_name") in CROPS:
+                ok.append(d)
+
+        if bad and not ok:
+            summary_row["status"] = "fail"
+            summary_row["detail"] = f"placeholder persisted on {len(bad)} doc(s)"
+        elif ok and not bad:
+            summary_row["status"] = "pass"
+            summary_row["detail"] = f"{len(ok)} doc(s) carry canonical crop name"
+        elif ok and bad:
+            summary_row["status"] = "fail"
+            summary_row["detail"] = f"mixed: {len(bad)} placeholder, {len(ok)} canonical"
+        else:
+            summary_row["status"] = "skip"
+            summary_row["detail"] = "no bulk_pae_allocations with marker (run seed)"
+
+        return _emit(args.out, summary_row)
+
+    finally:
+        try:
+            _teardown(db)
+        except Exception:
+            pass
+
+
+def _emit(out: str, row: Dict[str, str]) -> int:
+    is_new = not Path(out).exists()
+    with open(out, "a", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=list(row.keys()))
+        if is_new:
+            w.writeheader()
+        w.writerow(row)
+    print(json.dumps(row))
+    return 0 if row["status"] in ("pass", "skip") else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/bugs/checkout-b2d86022a.ps1
+++ b/testing/bugs/checkout-b2d86022a.ps1
@@ -1,0 +1,50 @@
+<#
+checkout-b2d86022a.ps1 — Bug-1204 checkout.
+
+Use
+---
+This script checks out the backend at the buggy commit that PR #1204
+addresses. Run the bug repro with:
+
+    pwsh -File testing/bugs/checkout-b2d86022a.ps1 -Revert
+    python testing/bugs/bug_1204_repro.py
+
+Notes
+-----
+* `b2d86022a` IS the post-fix state. Pass `-Revert` to demonstrate the
+  bug (revert the fix commit, not the underlying regression).
+* Pauses for `npm install` if `node_modules` is absent.
+#>
+[CmdletBinding()]
+param(
+    [string]$BackendDir = $env:BACKEND_DIR,
+    [switch]$Revert
+)
+
+if (-not $BackendDir) {
+    $BackendDir = Join-Path $PSScriptRoot "..\..\ajrasakha\backend" | Resolve-Path
+}
+
+if (-not (Test-Path $BackendDir)) {
+    throw "Backend dir '$BackendDir' not found. Set BACKEND_DIR or pass -BackendDir."
+}
+
+Push-Location $BackendDir
+try {
+    Write-Host "[b2d86022a] before:" (git rev-parse --short HEAD)
+    git fetch --all --quiet | Out-Null
+    git checkout b2d86022a -- 2>&1 | Out-Null
+
+    if ($Revert) {
+        Write-Host "[b2d86022a] reverting fix to expose bug..."
+        git revert b2d86022a --no-edit 2>&1 | Out-Null
+    }
+
+    Write-Host "[b2d86022a] now at:" (git rev-parse --short HEAD)
+    if (-not (Test-Path "node_modules")) {
+        Write-Host "[b2d86022a] WARN: node_modules missing. Run 'npm install' before starting the backend."
+    }
+}
+finally {
+    Pop-Location
+}

--- a/testing/bugs/checkout-cc44cc371.ps1
+++ b/testing/bugs/checkout-cc44cc371.ps1
@@ -1,0 +1,52 @@
+<#
+checkout-cc44cc371.ps1 — Bug-1195 checkout.
+
+Use
+---
+This script checks out the backend at the buggy commit that PR #1195
+addresses. Run the bug repro with:
+
+    pwsh -File testing/bugs/checkout-cc44cc371.ps1
+    python testing/bugs/bug_1195_repro.py --base-url http://localhost:3141
+
+Notes
+-----
+* Reads the backend path from env var `BACKEND_DIR` (defaults to
+  `<repo>/ajrasakha/backend`).
+* The commit `cc44cc371` IS the post-fix state; for *demonstrating* the
+  bug, revert one commit further: `git revert cc44cc371 --no-edit`.
+* This script does NOT rebuild the backend. Run `npm install` and
+  restart the dev server before invoking the repro.
+#>
+[CmdletBinding()]
+param(
+    [string]$BackendDir = $env:BACKEND_DIR,
+    [switch]$Revert       # do `git revert cc44cc371 --no-edit` to expose the bug
+)
+
+if (-not $BackendDir) {
+    $BackendDir = Join-Path $PSScriptRoot "..\..\ajrasakha\backend" | Resolve-Path
+}
+
+if (-not (Test-Path $BackendDir)) {
+    throw "Backend dir '$BackendDir' not found. Set BACKEND_DIR or pass -BackendDir."
+}
+
+Push-Location $BackendDir
+try {
+    Write-Host "[cc44cc371] before:" (git rev-parse --short HEAD)
+    git fetch --all --quiet | Out-Null
+    git checkout cc44cc371 -- 2>&1 | Out-Null
+
+    if ($Revert) {
+        Write-Host "[cc44cc371] reverting fix to expose bug..."
+        git revert cc44cc371 --no-edit 2>&1 | Out-Null
+    }
+
+    Write-Host "[cc44cc371] now at:" (git rev-parse --short HEAD)
+    Write-Host "[cc44cc371] status:" (git status --porcelain)
+    Write-Host "Reminder: run 'npm install' and restart the backend before invoking bug_1195_repro.py"
+}
+finally {
+    Pop-Location
+}

--- a/testing/config/sla.yaml
+++ b/testing/config/sla.yaml
@@ -1,0 +1,75 @@
+# Single source of truth for SLA budgets consumed by
+# `testing/scripts/aggregate_results.py` and the performance report.
+#
+# These numbers mirror `results/sla_targets.md` (Project 7, §1 SLA targets).
+# If you change a budget here, mirror it in `sla_targets.md` (and vice-versa).
+# Scenario keys match the `results/<scenario>/` directory names emitted by
+# `testing/scripts/run-locust-{1x,5x,10x}.ps1`.
+version: 1
+
+# Per-scenario budgets. S5 (HTTP 5xx ratio) and S3 (queue-drained) relax as
+# load increases — this is the *stakeholder contract* and matches sla_targets.md.
+scenarios:
+  1x_locust:
+    s5_http_5xx_ratio_max: 0.005   # < 0.5 % at 1×
+    s3_end_queue_length_max: 100   # 1× scenario matrix: 100 open questions
+  5x_locust:
+    s5_http_5xx_ratio_max: 0.01    # < 1 % at 5×
+    s3_end_queue_length_max: 500   # 5× scenario matrix: 500 open questions
+  10x_locust:
+    s5_http_5xx_ratio_max: 0.02    # < 2 % at 10×
+    s3_end_queue_length_max: 1000  # 10× scenario matrix: 1000 open questions
+
+# Per-gate, per-scenario-independent budgets.
+sla_gates:
+  S1:
+    name: queue_wait_proxy
+    description: >
+      Queue-wait proxy derived from the maximum observed endpoint latency
+      across the run. sla_targets.md §S1 is defined per-multiplier
+      (≤90 s at 1×, ≤120 s at 5×, ≤180 s at 10×); we use the tightest
+      (60 s) as a sanity ceiling and report the observed max.
+    budget_ms: 60000
+
+  S2:
+    name: allocator_p95
+    description: "Allocator endpoint p95 ≤ 800 ms (matches sla_targets.md §S4 allocator row)."
+    budget_ms: 800
+
+  S3:
+    name: queue_drained
+    description: >
+      End-of-run queue length ≤ per-scenario threshold. Proxy for
+      sla_targets.md §S3 "0 availableWaiting > 60 s old at run end":
+      the cron must keep up with the load so the queue does not
+      grow unbounded. Threshold comes from `scenarios.<scenario>.s3_end_queue_length_max`.
+
+  S4:
+    name: per_endpoint_p95
+    description: >
+      Each reviewer endpoint's p95 must stay within its sla_targets.md §S4
+      budget. Match is substring on the human-readable `name` field in
+      `aggregated.csv` (e.g. `POST /api/questions/allocated` matches all
+      role variants `(admin)`, `(expert)`, `(moderator)` …).
+    endpoint_budgets_ms:
+      "POST /api/auth/login": 400
+      "GET /api/questions/queue-details": 500
+      "POST /api/questions/allocated": 600
+      "POST /:qid/feedback-reviewer": 800
+      "POST /api/answers/moderator/approve": 1200
+
+  S5:
+    name: http_5xx
+    description: >
+      Worst 5xx ratio across all reviewer endpoints must be ≤ the
+      per-scenario budget. Budget comes from `scenarios.<scenario>.s5_http_5xx_ratio_max`.
+
+  S6:
+    name: reputation_mismatches
+    description: "Stored reputation_score matches canonical recalc for every user (drift = 0)."
+    budget_drift: 0
+
+  S7:
+    name: cosine_p95
+    description: "Cosine-similarity duplicate-check p95 ≤ 1500 ms."
+    budget_ms: 1500

--- a/testing/docker/backend-loadtest.env
+++ b/testing/docker/backend-loadtest.env
@@ -1,0 +1,107 @@
+# =============================================================================
+# Load-test environment overlay for the reviewer backend container.
+# Loaded last by docker-compose via `env_file`, overrides the production
+# defaults from ajrasakha/backend/.env.example.
+#
+# HARD RULE: every value below must keep reviewers isolated from staging.
+# =============================================================================
+
+# â”€â”€â”€ Identifies this DB distinctly from agriai / agriai_staging â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+DB_URL=mongodb://mongo:27017/?ssl=false&tls=false
+DB_NAME=agriai_loadtest
+# Analytics + Annam connections also point at the same loadtest Mongo so
+# `AnalyticsMongoDatabase` + `AnnamDatabase` boot (otherwise constructor
+# receives `null` and the mongodb driver crashes). tls/ssl disabled: local
+# mongod is plaintext-only and the driver hardcodes tls=true (see
+# MongoDatabase.ts), which causes ECONNRESET during handshake.
+DB_URL_ANALYTICS=mongodb://mongo:27017/?ssl=false&tls=false
+DB_NAME_ANALYTICS=agriai_loadtest_analytics
+ANNAM_URL_ANALYTICS=mongodb://mongo:27017/?ssl=false&tls=false
+ANNAM_DB_ANALYTICS=agriai_loadtest_annam
+
+# â”€â”€â”€ Node framework â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+# NODE_ENV=staging (NOT development): with NODE_ENV=development, the runtime
+# resolves dynamic module loading from `./src/modules`, but the production
+# Dockerfile only ships `./build/`. staging gets us `./build/modules` and
+# remains close enough to production for a meaningful load test (no real
+# email-verification requirement, no signup-rate-limit, etc).
+NODE_ENV=staging
+PORT=3141
+APP_PORT=3141
+APP_MODULE=all
+APP_ROUTE_PREFIX=/api
+APP_URL=http://localhost:3141
+APP_ORIGINS=http://localhost:5173,http://localhost:5174,http://localhost:3141
+FRONTEND_URL=http://localhost:5173
+
+# â”€â”€â”€ Firebase: pointed at the Auth Emulator (NOT identitytoolkit.googleapis.com)
+# projectId is arbitrary for the emulator; apiKey is the well-known emulator key.
+FIREBASE_PROJECT_ID=ajrasakha-loadtest
+FIREBASE_API_KEY=AIzaSyDUMMY_emulator_only_key
+# These two are unused at runtime when the Auth Emulator is the identity
+# provider, but the app still reads them at boot, so we provide dummies.
+FIREBASE_CLIENT_EMAIL=emulator@ajrasakha-loadtest.iam.gserviceaccount.com
+FIREBASE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDB8u9IvEhw64Vd\ngzH2by/7lDC+jUibovOukIsygS8gKTOGuO/HIxjEcYJSQFrb2Bpjl9Hy2vBYOa2f\nUoayFN558rcTeLRheYlhmK+El1oNiBl595QkREmePiHyqWK+OSM6IirNON8/ddc4\nTol+9eX81oP++SPpRV3pdschhMSykSNc731ZrcRcXD82am4cFaWwITIWKdpIdjyC\n0As89Cp3WSqMtxReuUmyQP2ZuozAWK1xXbOmgK3jYwN2uXyDA5XBoYgdCvvgxio5\nydv6cVoxKdJr/Gql3CRepG4HNua+8WGY+3+A5K8lWG/g+79Ceq4tEePLj28s/K2t\nu4Bt1QD3AgMBAAECggEANliYbE02D04vpLBqg59MVraDoiF8wv+6QKQIHTLNvblN\n0uZnaemPuxwDZIDb9NZtLpMQJXjr+AzRdd9uFuB6Jrm4SyB7iwS/VjWumPzAIyKL\n4P1a6X6pEkpewNxt6tef415HmBHjnKiskf6P0J+evmZtvjiZs3fYhN7flajaZR6B\nUGZAKJgXmqVcbuYE5iG9A2/q/uHGT8E47MVkXOMGd7Y6t5W160rDvBtMQZH7ZPxp\ngYi/x7tUZktbaLh/wcknORsEJlm10SSd5SZAQ6vGXAuEHFkGbINVC4NTYnrWEsqc\n4xVxwi96KXG5YvfjTKNviavnEDhk30tMd6qzZ0pjYQKBgQDnInihxe0tpH/YFcne\noiL0+wSj3cb14SuB25V/j+Yj2s+tXjpvBKHMOH/WfrcCfE9dtjXbu8dOaO5l0hro\nlu1H0eYZUd0FkzZ+29shluXmiT/ACF7cit2NJFLQtbvvZ5+QKjZbcDngqR28EAQL\neafk7m228c0sQYoXdm905l5vRQKBgQDW0FtNytdH460Ews1ze2qzT9YKFTCwv0op\nepZeXbcMF/uZNEe1Hk5fb56TYb5h9vocEaprAigAYfrPNrcbKs5NdXjkYAlE1LFO\njjhB6u67+xWB+CXMCOdCw/z7+crrjYKO1IB8rMgTj4Y4LxMpNdqzpk8vTWpPhq9C\nJHYaHGBlCwKBgQClFrAHDHId+bL+yoFHrZM+W9SynoOvt8b1l7uuQz/kODPB5t3h\n0fMnBOv6bsOU2OlvS+goLHVtAfHVdD6YBsUwWTH6v8gYZU+1SJ+53CgVg86vAMuQ\nxvb8CwfD3yp/EwqbVCtDIGOWnfSJEP9ymtBa6hofY5Jim+VgYM23N5wX6QKBgCpp\nKo2aTZSg68jz2PJC3JcYXQ7SjjFnIvI7hLKO2BPoLEFcJAgrOpf3BpzcgGUBCPI/\nvqCv5UvmDEma6N3RPrfmSH72Qv426+axh4PkKUwtz1pArt2wqE/zN+Bbued1oeAn\nLlLvHfVWsc4n5SWOv2YWoK2bIDEhSzrIzhRro9BvAoGALPAwnap1Mm5WEjOXixHt\nftEqhZ/c7dN3ocLZ/ulvpTNCfAsbsdLClolC4GdE+a+apl9jGYrDHIVeXyFPgxSz\n8pq8wglVwv9e0qo4g95dGqUGSQCA/znNTV8d74KxxC+FdJ00LQm/3USpkv6n9Yn+\nZL/83F6Kh9hsy4B/+I9cXwY=\n-----END PRIVATE KEY-----\n
+FIREBASE_STORAGE_BUCKET=ajrasakha-loadtest.appspot.com
+# Skip the emailVerified gate in /api/auth/login — the load test creates users
+# in the Auth Emulator with emailVerified=false by default, and NODE_ENV=staging
+# triggers the SMTP path which we don't have. The SKIP flag is opt-in and only
+# used by this testbed (see AuthController.ts process.env.SKIP_EMAIL_VERIFICATION).
+SKIP_EMAIL_VERIFICATION=true
+
+
+# â”€â”€â”€ Kill every external side-effect channel â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+ENABLE_AI_SERVER=false
+ENABLE_DB_BACKUP=false
+WA_WEBHOOK_API_URL=
+WA_WEBHOOK_API_KEY=
+WA_SEND_MESSAGE_WEBHOOK_API_URL=
+WEB_WEBHOOK_API_URL=
+WEB_WEBHOOK_API_KEY=
+SMTP_USER=
+SMTP_PASS=
+PLIVO_STREAM_URL=ws://localhost/dummy
+PLIVO_AUTH_ID=dummy
+PLIVO_AUTH_TOKEN=dummy
+PLIVO_NUMBER=+10000000000
+LANGGRAPH_SERVER_IP=
+LANGRAPH_SERVER_IP=
+LANGRAPH_SERVER_PORT=
+AI_SERVER_IP=
+AI_SERVER_PORT=
+AGENT_SERVER_IP=
+AGENT_SERVER_PORT=
+OPENAI_SERVER_IP=
+OPENAI_SERVER_PORT=
+GDB_SERVER_IP=
+GDB_SERVER_PORT=
+WHATSAPP_SERVER_URL=
+WHATSAPP_SERVER_PORT=
+SARVAM_API_KEY=
+GEMMA_API=
+GEMMA_API_KEY=
+MINIMAX_API=
+MINIMAX_API_KEY=
+VICHARANASHALA_API_TOKEN=loadtest-dummy
+INTERNAL_API_KEY=loadtest-internal-key
+REVIEW_SYSTEM_AUTH_KEY=loadtest-review-key
+LGD_API_KEY=
+LGD_VILLAGES_API_URL=
+LGD_STATES_API_URL=
+LGD_DISTRICTS_API_URL=
+LGD_SUBDISTRICTS_API_URL=
+DATA_RELEASE_URL=
+# VAPID keys are real-but-dummy: web-push's `setVapidDetails()` is called at
+# module import time, so empty keys crash the boot. These will never actually
+# deliver a push (no real subscription in the seed data).
+VAPID_EMAIL=mailto:loadtest@example.invalid
+VAPID_PUBLIC_KEY=BMY1tZVRsmnN_vLe-7z-O8dPux7VMhnmON0v7Rl1-ghgwxKt1GjK2mihddOPNLV-uCbxZl4ah3xFakIjzQ1Q7p0
+VAPID_PRIVATE_KEY=9NXw8yRvAo62Tl447Yx4HOTcvD5wlzAL84GF2utxmR0
+FAST2SMS_API_KEY=
+GOOGLE_APPLICATION_CREDENTIALS=
+GCP_BACKUP_BUCKET=
+SENTRY_DSN=
+TAILSCALE_AUTHKEY=
+ADMIN_PASSWORD=loadtest-admin
+AI_INITIAL_ANSWER_GENERATE_URL=http://localhost:65535/generate-answer
+AI_PROXY_ADDRESS=

--- a/testing/docker/docker-compose.yml
+++ b/testing/docker/docker-compose.yml
@@ -1,0 +1,129 @@
+# =============================================================================
+# Project 7 — Reviewer System Load & SLA Testing Testbed
+# -----------------------------------------------------------------------------
+# Spins up an isolated environment that mirrors production but never touches
+# the real DB / Firebase project.
+#
+#  Services
+#  ────────
+#    mongo            : dedicated MongoDB instance, single-node replica set
+#                       (rs0). Multi-document transactions in the reviewer
+#                       backend require either a replica set or mongos; we
+#                       pick a single-node RS so the testbed is self-contained.
+#    mongo-repl-init  : one-shot sidecar that runs `rs.initiate()` (idempotent)
+#                       and applies ./mongo-init/*.js (the user indexes the
+#                       app expects) AFTER the primary is writable.
+#    firebase-emulator: Firebase Auth Emulator (issues idTokens for /api/login)
+#    reviewer-backend : the Ajrasakha reviewer backend pointed at the above
+#
+#  Volumes
+#  ───────
+#    mongo-data       : persistent Mongo data (drop with `make down-volumes`)
+#    backend-loadtest-env.env : env-file overlay for the backend container
+# =============================================================================
+
+services:
+  mongo:
+    image: mongo:8
+    container_name: p7-mongo
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    ports:
+      - "27019:27017"          # host port chosen to avoid clashing with local mongod
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 }).ok"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  mongo-repl-init:
+    # One-shot. Idempotent. The `--replSet rs0` flag on the `mongo` container
+    # is meaningless until something calls `rs.initiate()`; we do that here
+    # once the primary is healthy, then re-apply the loadtest indexes
+    # (which the docker-entrypoint-initdb.d hook would normally run on a
+    # first-start, but we override `command:` on `mongo` to pass replSet,
+    # so that hook is bypassed).
+    #
+    # Logic in ./mongo-init/02-repl-init.sh — easier to read than a multi-line
+    # YAML block, and easier to keep CRLF-free (Dockerfile-app's `find ... sed`
+    # CRLF strip covers anything we drop in here too).
+    image: mongo:8
+    container_name: p7-mongo-repl-init
+    depends_on:
+      mongo:
+        condition: service_healthy
+    working_dir: /mongo-init
+    volumes:
+      - ./mongo-init:/mongo-init:ro
+    entrypoint: ["bash", "/mongo-init/02-repl-init.sh"]
+    restart: "no"
+
+  firebase-emulator:
+    # firebase-tools image — runs only the Auth Emulator for issuing
+    # idTokens that mirror what identitytoolkit.googleapis.com would issue.
+    # The official `ghcr.io/firebase/firebase-tools:14` tag is not on a public
+    # registry mirror accessible from this host; `andreysenov/firebase-tools`
+    # is the same `firebase` CLI repackaged and works for our purposes
+    # (`emulators:start --only auth`).
+    image: andreysenov/firebase-tools:latest
+    container_name: p7-firebase-auth
+    command:
+      - "firebase"
+      - "emulators:start"
+      - "--only"
+      - "auth"
+      - "--project"
+      - "ajrasakha-loadtest"
+    working_dir: /firebase
+    volumes:
+      # firebase.json pins host=0.0.0.0; without this the auth emulator
+      # binds to loopback only and other containers in the compose network
+      # cannot reach it on the bridge interface.
+      - ./firebase.json:/firebase/firebase.json:ro
+    environment:
+      # The emulator requires an explicit project; do NOT use a real one.
+      GCLOUD_PROJECT: ajrasakha-loadtest
+      FIREBASE_AUTH_EMULATOR_HOST: 0.0.0.0:9099
+      # Auth Emulator listens on 9099 internally; expose the same port.
+    ports:
+      - "9099:9099"            # Auth REST endpoint  (used by /api/login)
+      # NOTE: 4000 (Emulator UI) is intentionally not mapped. Debug UI is not
+      # needed for the load-test harness and frequently collides with another
+      # Firebase emulator already bound to that port on the host.
+
+  reviewer-backend:
+    build:
+      context: ../../ajrasakha/backend
+      dockerfile: Dockerfile.app
+    container_name: p7-reviewer-backend
+    depends_on:
+      mongo:
+        condition: service_healthy
+      mongo-repl-init:
+        condition: service_completed_successfully
+      firebase-emulator:
+        condition: service_started
+    env_file:
+      - backend-loadtest.env
+    environment:
+      # These two MUST match the host:port mappings above so the backend
+      # container reaches its peers on the docker network.
+      # NOTE: no replicaSet query param here — the driver discovers the RS
+      # from the server's hello response and uses normal primary targeting.
+      DB_URL: mongodb://mongo:27017/?ssl=false&tls=false
+      FIREBASE_AUTH_EMULATOR_HOST: firebase-emulator:9099
+      # NODE_ENV must be exactly "production"|"staging" — see
+      # ajrasakha/.github/workflows/backend-staging-deployment.yml:124-127:
+      #   loadAppModules() reads ./build/modules only when NODE_ENV is one of
+      #   those two; otherwise it tries `./src/modules`, which the production
+      #   Dockerfile doesn't ship, and the boot crashes with ENOENT.
+      NODE_ENV: staging
+      APP_PORT: "3141"
+      APP_ROUTE_PREFIX: /api
+    ports:
+      - "3141:3141"
+    # HEALTHCHECK is already declared in Dockerfile.app; nothing more to do.
+
+volumes:
+  mongo-data:

--- a/testing/docker/firebase-sa.json
+++ b/testing/docker/firebase-sa.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "ajrasakha-loadtest",
+  "private_key_id": "loadtest-key-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDx4iMPdGld2ibl\nc92e0X3TQi8GVofkOBUKFqjrLkK5CrOUJrxr6M2yJnWYR8ewW6LJUHk0Iwd0pRFI\nZT5dObT7jdSM7Pa7j5AH3oPK4278F5efTNd//X5IeccHJZkvnClxUsttg5dvxkCt\nNp9/+265uEyxEpjjfRpeyqzUoc9mZPxykxjeMDIlbN6YUSBnTBkQNo8sBzhWhpta\n3IphgkKh500Tw3TML0Om5GwxZITGeOF7iz5dYYoD2bXGlyPnpRHoEDMT/deeWBNF\nuMsad2u9QzjQPH1GtPtVQF+nrGUwqoYxKLJNJwLJKYIrgEpYiyyjiLDqOc1aorL1\n9nbaDrdzAgMBAAECggEABZ2uxe5dRem7PK6xY2f74Q/afKboOZTfiYOX8vrOJo8k\n4a3dq71Gm49yeoMlBbWaEQW6BHXtvsZmkwwB1dbVNvIxV3D1Pq5bA62JSwiUAbQL\nMOPSrNeSexWFn/V3PYo+YE4jpHAeqNJQ1DhFZIqVpNKSAUTsNpfutxW1BMjSiYf5\nQ/Dy4iA8LwiQ6Zmioo1mJ5vwxCrzNz1IEoL+9cuAUDsB9ok3eD4ct49QvFbRbvbP\nZC3mj7svpe9gxWWywcaADeNbCRswsaCk4VyXALYVcZKMMdjZqYpbhUvRzdn+HKJ3\neVxT9ayZKI4vh8UwWTHds8/QfdQ2jsh7IQYTXlKoEQKBgQD5g6PlPPrwLgSdfi/5\nwj/1xt/nbfBh0B0fmmFAkJd81JTyqlBUb9Kyvq+exSoj0pGYHspPNKQwIzjIaQS3\nOo+UrVCTJ8qqXBPeZaOBsHGyt6TZFzriaZwLG0YKtKLm5zBNe3P3HkhwlJNnhicP\np9veDwohywboPSHfLJx19K8wAwKBgQD4K7fVJhv1t3YFnBH8/eR9vl0DaqayHYgn\nabaDt6i85JaGO1b0Qo9YQU3UialV7p5xbxSTZd939C2BjOZqyHuhv2K9UMMAexqJ\ngB1zXjsV8L+o43rg2jJSynW2Lv5lPB3w19YjjwKox7jegawYzKukQEk7LpiR7d/q\n/ArV3JLX0QKBgQCflW5x47qrewNAp8CPgYne7D+wiURBixXVbKve25vIHz7UpdGS\n76JW6FbyuS/mkXrFTIwgdI6+qwhaRbDab/39HYx3Ue/xXcrnZyJYhD10DLjGkHD8\n9obzI5J8rmOyQxNFuzvERf4W4zAT+l1pSfb546ybSHs2dkL/tkyrtL+HeQKBgQDk\nCWf2V/pBIr80EGEHE1UtpgpZ5VofOLuvW5f2GIDYcUNPPJ99+ts0wWz+6y/KYmT8\n3pENkAJzes+Fxy7C2E2iJvZX9yn3+yY7SpnFNMUeOAYk7kIu8tBi+t6G9U+VPlRU\nxj9ilTpgVIUvEABPGWJunxOrafmPvgCPL+HU+cWEwQKBgQDFK+For30TJVt0ZvTc\nNwqbqzb+HhR91J6xa2z9V4716x2oyaHB9ldhlWzpLupTAoS2PNHOjq7QP2GeStTi\ndsKgSTx5RLQqhUTlIKFdZfOIaiUcRt+YAQGKDmPWeBoSNyoWeARoyJPRHXKsIx6c\n8VUcPKXhexTg4PCOC6fz8uel6A==\n-----END PRIVATE KEY-----\n",
+  "client_email": "emulator@ajrasakha-loadtest.iam.gserviceaccount.com",
+  "client_id": "000000000000000000000",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/loadtest"
+}

--- a/testing/docker/firebase.json
+++ b/testing/docker/firebase.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Binding config for the Firebase Auth Emulator. Without this file the CLI uses defaults (loopback), so other containers cannot reach it on the docker bridge. host=0.0.0.0 is required for `docker compose` cross-service traffic.",
+  "emulators": {
+    "auth": {
+      "host": "0.0.0.0",
+      "port": 9099
+    },
+    "hub": {
+      "host": "0.0.0.0",
+      "port": 4400
+    }
+  }
+}

--- a/testing/docker/mongo-init/01-loadtest-indexes.js
+++ b/testing/docker/mongo-init/01-loadtest-indexes.js
@@ -1,0 +1,36 @@
+// =============================================================================
+// MongoDB init script — runs once on first container start via the
+// docker-entrypoint-initdb.d mechanism.
+//
+// We pre-create the indexes that the reviewer backend reads at runtime so the
+// load test does not pay createIndex cost during measurement. These mirror the
+// indexes the production code path depends on (see backend/src/modules/...).
+// =============================================================================
+
+const targetDb = 'agriai_loadtest';
+print('init: switching to', targetDb);
+db = db.getSiblingDB(targetDb);
+
+print('init: creating users indexes');
+db.users.createIndex({ email: 1 }, { unique: true });
+db.users.createIndex({ firebaseUID: 1 }, { unique: true });
+db.users.createIndex({ role: 1, reputation_score: 1 });
+db.users.createIndex({ 'preference.state': 1, 'preference.crop': 1 });
+
+print('init: creating questions indexes');
+db.questions.createIndex({ status: 1, autoAllocateModerator: 1 });
+db.questions.createIndex({ 'details.state': 1, 'details.normalised_crop': 1 });
+db.questions.createIndex({ createdAt: 1 });
+db.questions.createIndex({ moderatorId: 1, status: 1 });
+db.questions.createIndex({ userId: 1, status: 1 });
+
+print('init: creating question_submissions indexes');
+db.question_submissions.createIndex({ questionId: 1 });
+db.question_submissions.createIndex({ 'queue': 1 });
+db.question_submissions.createIndex({ 'history.updatedBy': 1, 'history.status': 1 });
+
+print('init: creating reroutes indexes');
+db.reroutes.createIndex({ questionId: 1 });
+db.reroutes.createIndex({ 'reroutes.reroutedTo': 1, 'reroutes.status': 1 });
+
+print('init: all indexes created');

--- a/testing/docker/mongo-init/02-repl-init.sh
+++ b/testing/docker/mongo-init/02-repl-init.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# =============================================================================
+# Replica-set bootstrap for the load-test Mongo container.
+# ------------------------------------------------------------------
+# Idempotent. Runs once per `mongo-repl-init` container start.
+#   * if RS is already initiated (volume persists), this is a no-op
+#   * else: rs.initiate({_id:"rs0", members:[{_id:0, host:"mongo:27017"}]})
+#   * then waits for primary to come up
+#   * then re-applies every *.js in /mongo-init (the user indexes the app
+#     relies on)
+#
+# IMPORTANT: keep CRLF out of this file. Editing on Windows + saving as
+# UTF-8-with-BOM or CRLF will break `bash` with "set: illegal option" the
+# same way it broke start.sh.
+# =============================================================================
+set -u
+
+echo "[mongo-repl-init] checking rs.status()..."
+if mongosh --host mongo:27017 --quiet --eval 'try { var s = rs.status(); if (s && s.ok) { print("already initiated"); quit(0); } } catch (e) { /* fall through */ }'; then
+  echo "[mongo-repl-init] rs already initiated"
+else
+  echo "[mongo-repl-init] initiating replica set..."
+  mongosh --host mongo:27017 --quiet --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "mongo:27017"}]})'
+fi
+
+echo "[mongo-repl-init] waiting for primary..."
+for i in $(seq 1 30); do
+  WRITABLE=$(mongosh --host mongo:27017 --quiet --eval 'db.runCommand({ hello: 1 }).isWritablePrimary' 2>/dev/null | tr -d '\r')
+  if [ "$WRITABLE" = "true" ]; then
+    echo "[mongo-repl-init] primary ready after ${i}s"
+    break
+  fi
+  sleep 2
+done
+
+echo "[mongo-repl-init] applying *.js indexes..."
+for f in /mongo-init/*.js; do
+  [ -f "$f" ] || continue
+  echo "[mongo-repl-init] applying $f"
+  mongosh --host mongo:27017 --quiet "$f"
+done
+
+echo "[mongo-repl-init] done"

--- a/testing/firebase/.firebaserc
+++ b/testing/firebase/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "ajrasakha-loadtest"
+  }
+}

--- a/testing/firebase/firebase.json
+++ b/testing/firebase/firebase.json
@@ -1,0 +1,6 @@
+{
+  "emulators": {
+    "auth": { "port": 9099 },
+    "ui": { "enabled": false }
+  }
+}

--- a/testing/fixtures/summary.js
+++ b/testing/fixtures/summary.js
@@ -1,0 +1,8 @@
+print(db.users.countDocuments({firebaseUID:/^lt-/}) + ' users');
+print(db.questions.countDocuments({}) + ' questions');
+print(db.question_submissions.countDocuments({}) + ' question_submissions');
+print(db.questions.countDocuments({status:'queue_duplicate'}) + ' curated duplicates');
+print(db.questions.countDocuments({status:'open'}) + ' open');
+print(db.questions.countDocuments({status:'in-review'}) + ' in-review');
+print(db.questions.countDocuments({status:'closed'}) + ' closed');
+print(db.questions.countDocuments({status:'delayed'}) + ' delayed');

--- a/testing/fixtures/verify_indexes.js
+++ b/testing/fixtures/verify_indexes.js
@@ -1,0 +1,8 @@
+print('users indexes:');
+db.users.getIndexes().forEach(function(i){ print('  ' + i.name + ' ' + JSON.stringify(i.key) + (i.unique ? ' UNIQUE' : '')); });
+print('questions indexes:');
+db.questions.getIndexes().forEach(function(i){ print('  ' + i.name + ' ' + JSON.stringify(i.key) + (i.unique ? ' UNIQUE' : '')); });
+print('question_submissions indexes:');
+db.question_submissions.getIndexes().forEach(function(i){ print('  ' + i.name + ' ' + JSON.stringify(i.key)); });
+print('reroutes indexes:');
+db.reroutes.getIndexes().forEach(function(i){ print('  ' + i.name + ' ' + JSON.stringify(i.key)); });

--- a/testing/fixtures/verify_seed.js
+++ b/testing/fixtures/verify_seed.js
@@ -1,0 +1,9 @@
+print('users      = ' + db.users.countDocuments({firebaseUID:/^lt-/}));
+print('questions  = ' + db.questions.countDocuments({}));
+print('submissions= ' + db.question_submissions.countDocuments({}));
+print('duplicates = ' + db.questions.countDocuments({status:'queue_duplicate'}));
+print('--- sample duplicate pair ---');
+const dup = db.questions.findOne({status:'queue_duplicate', originalQuestion:{$exists:true}});
+printjson(dup);
+print('--- index listing on questions ---');
+db.questions.getIndexes().forEach(function(i){ print(i.name + ' ' + JSON.stringify(i.key)); });

--- a/testing/locust/.env.example
+++ b/testing/locust/.env.example
@@ -1,0 +1,37 @@
+# Ajrasakha reviewer-system Locust — environment template.
+# Copy to `.env` (or set in your shell) and edit per your environment.
+#
+#   cp testing/locust/.env.example testing/locust/.env
+#
+# All of these have sane defaults; override only if you deviate from the
+# dev stack documented in `testing/scripts/run.ps1`.
+
+# --- Backend ---------------------------------------------------------------
+LOCUST_HOST=http://localhost:3141
+
+# --- Mongo (used by helpers/credentials.py + reconcile_reputation.py) -----
+DB_URL=mongodb://localhost:27017
+DB_NAME=agriai_loadtest      # must be the load-test DB; the harness
+                             # asserts this and refuses to touch anything
+                             # else (mirrors helpers/credentials.py).
+
+# --- Firebase Auth emulator (only used by run.ps1; Locust reads the
+#     access tokens emitted by `register_firebase_users.mjs`) --------------
+FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
+
+# --- Load profile ---------------------------------------------------------
+# One of: moderate | heavy_allocate | squash_p95 | moderator_heap
+LOAD_PROFILE=moderate
+
+# --- Per-scenario runtime hint (consumed by run-locust-*.ps1) -------------
+LOCUST_RUN_TIME=60m
+
+# --- Optional: change where Locust writes CSVs ---------------------------
+# Each scenario runner sets RESULTS_DIR automatically. Override only if
+# you want to redirect (e.g. a CI artifact directory).
+# RESULTS_DIR=results/1x_locust
+
+# --- Optional: number of Locust worker processes -------------------------
+# 1 = single-process (default for the in-lab harness). Use 3 with
+# `--master` on a real load box; see hardening_recommendations.md R-3.
+# LOCUST_PROCESSES=1

--- a/testing/locust/README.md
+++ b/testing/locust/README.md
@@ -1,0 +1,96 @@
+# Reviewer-System Locust Suite
+
+This directory contains the load-testing harness that drives the
+Ajrasakha reviewer backend through three scenarios — 1× baseline,
+5× burst, and 10× overload — and asserts against the SLAs defined in
+`results/sla_targets.md`.
+
+## Layout
+
+```
+testing/locust/
+├── __init__.py
+├── locustfile_reviewer.py      # Entry point loaded by `locust -f`.
+├── locust.conf                  # Locust config (process count, runtime).
+├── requirements.txt             # Pinned deps.
+├── helpers/
+│   ├── assertions.py            # Locust event-listener + CSV writers.
+│   ├── credentials.py           # CredentialPool drawn from `agriai_loadtest`.
+│   └── payloads.py              # Request-body builders for every endpoint.
+├── tasks/
+│   ├── login.py                 # Force re-auth probe.
+│   ├── allocated.py             # POST /api/questions/allocated variants.
+│   ├── queue_details.py         # GET /api/questions/queue-details.
+│   ├── submit_review.py         # POST /api/answers.
+│   ├── approve_initial_answer.py
+│   ├── allocate_experts.py      # POST /allocate-experts, /bulk-pae-allocate.
+│   ├── moderator_approve.py     # POST /api/answers/moderator/approve.
+│   ├── feedback_review.py       # POST /:qid/feedback-reviewer, /:qid/:fid/feedback-action.
+│   ├── rebalance.py             # /reAllocateLessWorkload, /reallocate-timebound, /reallocate-manual.
+│   ├── reroute.py               # POST /:qid/allocate-reroute-experts.
+│   └── cosine_check.py          # POST /api/questions/check-duplicate.
+├── users/
+│   ├── reviewer.py              # Base HttpUser + auth + samplers.
+│   └── roles.py                 # Per-role user classes.
+└── scenarios/
+    ├── 1x.py
+    ├── 5x.py
+    └── 10x.py
+```
+
+## Running
+
+Pre-flight (see `testing/scripts/preflight.ps1`):
+
+1. Mongo is **promoted to a single-node replica set** (the
+   `/allocated` and `_withTransaction` paths require it).
+2. The seed scripts (`testing/seed/seed_all.mjs`) have been run.
+3. `pip install -r testing/locust/requirements.txt` completes.
+
+Then:
+
+```powershell
+pwsh -File testing/scripts/run-locust-1x.ps1
+pwsh -File testing/scripts/run-locust-5x.ps1   # heavy_allocate profile
+pwsh -File testing/scripts/run-locust-10x.ps1  # squash_p95 profile
+```
+
+Each script writes its results to `results/<scenario>_locust/`.
+
+## Output artefacts per scenario
+
+| File                              | Producer                     | Consumer                           |
+|-----------------------------------|------------------------------|------------------------------------|
+| `requests.csv`                    | `helpers/assertions.py`      | `aggregate_results.py`             |
+| `assertions.csv`                  | `helpers/assertions.py`      | `aggregate_results.py`             |
+| `queue_lengths.csv`               | `helpers/assertions.py`      | bug-1195 regression                |
+| `reputation_snapshots.csv`        | `helpers/assertions.py`      | `reconcile_reputation.py`          |
+| `aggregated.csv`                  | `aggregate_results.py`       | `performance_report.md`            |
+| `sla_summary.csv`                 | `aggregate_results.py`       | `performance_report.md`            |
+| `reputation_drift.csv`            | `reconcile_reputation.py`    | `performance_report.md`            |
+
+## Load profiles
+
+The orchestrator supports four profiles via `LOAD_PROFILE`:
+
+| Profile         | Boosts                                                                       |
+|-----------------|------------------------------------------------------------------------------|
+| `moderate`      | (default) even mix                                                            |
+| `heavy_allocate`| PAE workload ×5  — drives the S2 allocator-budget breach                      |
+| `squash_p95`    | Expert & Moderator weight ×5 — drives S2/S5 p95+error breach                  |
+| `moderator_heap`| Moderator weight ×10 — drives S6 reputation-drift breach                      |
+
+Pass `LOAD_PROFILE=...` to any of the three `run-locust-*.ps1` scripts
+or `env LOAD_PROFILE=... python scenarios/<scenario>.py`.
+
+## Environment variables
+
+| Variable                          | Default                   | Notes                                       |
+|-----------------------------------|---------------------------|---------------------------------------------|
+| `LOCUST_HOST`                     | `http://localhost:3141`   | Backend origin                              |
+| `DB_URL`                          | `mongodb://localhost:27017` | Mongo for the credential pool             |
+| `DB_NAME`                         | `agriai_loadtest` (asserted) | Must be `agriai_loadtest`                |
+| `FIREBASE_AUTH_EMULATOR_HOST`     | (set by `run.ps1`)        | When using the Firebase auth emulator      |
+| `LOAD_PROFILE`                    | `moderate`                | See above                                   |
+| `RESULTS_DIR`                     | `results/<scenario>_locust` | Auto-set by `run-locust-*.ps1`           |
+| `LOCUST_RUN_TIME`                 | per-scenario (60m, 30m, 15m) | Locust headless budget                   |

--- a/testing/locust/helpers/assertions.py
+++ b/testing/locust/helpers/assertions.py
@@ -1,0 +1,365 @@
+"""
+assertions.py — Locust event-listener for the reviewer-system load test.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import threading
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from locust import events
+
+_lock = threading.Lock()
+_results_dir: Optional[Path] = None
+_request_csv = None
+_request_csv_writer = None
+_assertions_csv_writer = None
+_assertions_file = None
+_reputation_snapshots: Dict[str, Dict[str, Any]] = {}
+# Per-event history of every reputation snapshot we observe, keyed by
+# user_id. Used by `reconcile_reputation.py` to detect in-memory races
+# (any monotonicity violation = a missed update).
+_reputation_snapshot_history: List[Tuple[float, str, float, str]] = []
+_assertion_counts: Dict[str, int] = defaultdict(int)
+_failed_request_count: Dict[str, int] = defaultdict(int)
+_total_request_count: Dict[str, int] = defaultdict(int)
+_queue_lengths: List[Tuple[float, str, int]] = []
+_cosine_p95_samples: List[float] = []
+
+
+def init(results_dir: str) -> None:
+    """Open per-run output files. Call once from an init hook."""
+    global _results_dir, _request_csv, _request_csv_writer
+    global _assertions_csv_writer, _assertions_file
+
+    _results_dir = Path(results_dir)
+    _results_dir.mkdir(parents=True, exist_ok=True)
+
+    requests_path = _results_dir / "requests.csv"
+    _request_csv = open(requests_path, "w", newline="", encoding="utf-8")
+    _request_csv_writer = csv.writer(_request_csv)
+    _request_csv_writer.writerow([
+        "timestamp", "endpoint", "method", "name", "status_code",
+        "response_time_ms", "response_length", "failure", "assertion", "context",
+    ])
+    _request_csv.flush()
+
+    _assertions_file = open(
+        _results_dir / "assertions.csv", "w", newline="", encoding="utf-8"
+    )
+    _assertions_csv_writer = csv.writer(_assertions_file)
+    _assertions_csv_writer.writerow(["assertion_key", "count"])
+    _assertions_file.flush()
+
+
+def flush_all() -> None:
+    """Flush buffered CSV rows under the global lock.
+
+    Holding `_lock` here prevents the `_on_quitting` flush from racing
+    with an in-flight request handler still writing through
+    `record_request`.
+    """
+    with _lock:
+        if _request_csv is not None:
+            _request_csv.flush()
+        if _assertions_file is not None:
+            _assertions_file.flush()
+
+
+def close() -> None:
+    """Close output CSV handles under the global lock.
+
+    If a Locust user thread is mid-`record_request` when the runner
+    fires the `quitting` event, this lock keeps the writer from being
+    closed while the writerow() call is still buffered/flushed.
+    """
+    global _request_csv, _assertions_csv_writer, _assertions_file
+    with _lock:
+        if _request_csv is not None:
+            _request_csv.flush()
+            _request_csv.close()
+        if _assertions_file is not None:
+            _assertions_file.flush()
+            _assertions_file.close()
+        _request_csv = None
+        _assertions_csv_writer = None
+        _assertions_file = None
+
+
+def write_assertion(key: str, count: int = 1) -> None:
+    with _lock:
+        _assertion_counts[key] += count
+        if _assertions_csv_writer is not None:
+            _assertions_csv_writer.writerow([key, count])
+            _assertions_file.flush()
+
+def record_reputation_snapshot(user_id: str, snapshot: Dict[str, Any]) -> None:
+    with _lock:
+        _reputation_snapshots[user_id] = snapshot
+        # Also append to history so `reconcile_reputation.py` can later
+        # detect monotonicity violations (= an in-memory race where a
+        # concurrent update was lost).
+        try:
+            score = float(snapshot.get("reputation_score") or 0)
+        except (TypeError, ValueError):
+            return
+        _reputation_snapshot_history.append((
+            float(snapshot.get("at") or 0.0),
+            user_id,
+            score,
+            str(snapshot.get("context") or ""),
+        ))
+
+
+def get_reputation_snapshots() -> Dict[str, Dict[str, Any]]:
+    with _lock:
+        return dict(_reputation_snapshots)
+
+
+def get_reputation_snapshot_history() -> List[Tuple[float, str, float, str]]:
+    with _lock:
+        return list(_reputation_snapshot_history)
+
+
+def write_reputation_snapshot_csv() -> Path:
+    if _results_dir is None:
+        return Path("reputation_snapshots.csv")
+    out = _results_dir / "reputation_snapshots.csv"
+    with open(out, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["user_id", "captured_at", "snapshot_json"])
+        for uid, snap in _reputation_snapshots.items():
+            w.writerow([uid, time.time(), json.dumps(snap, default=str)])
+    return out
+
+
+def write_reputation_snapshot_history_csv() -> Optional[Path]:
+    """Write every observed reputation snapshot to `reputation_snapshot_history.csv`.
+
+    Used by `reconcile_reputation.py` to detect in-memory races: any user
+    whose reputation went DOWN between two consecutive history entries
+    has lost an increment (no decrement endpoint exists in the mock).
+    """
+    if _results_dir is None:
+        return None
+    out = _results_dir / "reputation_snapshot_history.csv"
+    with open(out, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["at", "user_id", "reputation_score", "context"])
+        # Stable order: by (user_id, at) so monotonicity checks are local.
+        rows = sorted(_reputation_snapshot_history, key=lambda r: (r[1], r[0]))
+        for r in rows:
+            w.writerow([f"{r[0]:.6f}", r[1], f"{r[2]:.6f}", r[3]])
+    return out
+
+
+def record_queue_length(endpoint: str, length: int) -> None:
+    with _lock:
+        _queue_lengths.append((time.time(), endpoint, length))
+
+
+def get_queue_lengths() -> List[Tuple[float, str, int]]:
+    with _lock:
+        return list(_queue_lengths)
+
+
+def write_queue_length_csv() -> Optional[Path]:
+    if _results_dir is None:
+        return None
+    out = _results_dir / "queue_lengths.csv"
+    with open(out, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["timestamp", "endpoint", "queue_length"])
+        for ts, ep, ln in _queue_lengths:
+            w.writerow([ts, ep, ln])
+    return out
+
+
+def record_cosine_sample(response_time_ms: float) -> None:
+    with _lock:
+        _cosine_p95_samples.append(response_time_ms)
+
+
+def get_cosine_samples() -> List[float]:
+    with _lock:
+        return list(_cosine_p95_samples)
+
+def record_request(
+    *,
+    endpoint: str,
+    method: str,
+    name: str,
+    status_code: int,
+    response_time_ms: float,
+    response_length: int,
+    failure: Optional[str],
+    assertion: str,
+    context: Dict[str, Any],
+) -> None:
+    """Append a single request to `requests.csv` and update counters."""
+    with _lock:
+        _total_request_count[name] += 1
+        if failure:
+            _failed_request_count[name] += 1
+            if 500 <= status_code <= 599:
+                _assertion_counts["HTTP_5XX"] += 1
+                if _assertions_csv_writer is not None:
+                    _assertions_csv_writer.writerow(["HTTP_5XX", 1])
+                    _assertions_file.flush()
+        if _request_csv_writer is not None:
+            try:
+                _request_csv_writer.writerow([
+                    time.time(),
+                    endpoint,
+                    method,
+                    name,
+                    status_code,
+                    f"{response_time_ms:.1f}",
+                    response_length,
+                    failure or "",
+                    assertion,
+                    json.dumps(context, default=str)[:512],
+                ])
+                _request_csv.flush()
+            except ValueError:
+                # Under gevent, a record_request coroutine that already
+                # entered the `with _lock:` block can be yielded out at
+                # the I/O call; meanwhile close() (in _on_quitting) can
+                # close the underlying file. When the writer resumes it
+                # would otherwise raise "I/O operation on closed file."
+                # Swallow that case — the data is already flushed/closed
+                # by the quit path and the run is ending.
+                pass
+
+
+def get_failure_ratio() -> Dict[str, float]:
+    """Return `{name: failed/total}` for every seen request name."""
+    out: Dict[str, float] = {}
+    with _lock:
+        for name, total in _total_request_count.items():
+            failed = _failed_request_count.get(name, 0)
+            out[name] = (failed / total) if total else 0.0
+    return out
+
+
+def get_assertion_counts() -> Dict[str, int]:
+    with _lock:
+        return dict(_assertion_counts)
+
+@events.request.add_listener
+def _on_request(
+    request_type: str,
+    name: str,
+    response_time: float,
+    response_length: int,
+    response: Optional[Any],
+    context: Dict[str, Any],
+    exception: Optional[BaseException],
+    start_time: float,
+    url: str,
+    **kwargs: Any,
+) -> None:
+    """Locust 2.x request hook. Buckets 5xx, decodes JSON for captures."""
+    status_code = 0
+    body_text: str = ""
+    body_json: Optional[Dict[str, Any]] = None
+    if response is not None:
+        status_code = getattr(response, "status_code", 0)
+        try:
+            body_text = response.text or ""
+        except Exception:
+            body_text = ""
+        if body_text and body_text.lstrip().startswith(("{", "[")):
+            try:
+                parsed = json.loads(body_text)
+                if isinstance(parsed, dict):
+                    body_json = parsed
+            except Exception:
+                body_json = None
+
+    failure_msg: Optional[str] = None
+    if exception is not None:
+        failure_msg = repr(exception)
+    elif status_code >= 500:
+        failure_msg = f"HTTP {status_code}"
+
+    assertion = "PASS"
+    if status_code == 401:
+        assertion = "IGNORE_AUTH"
+    elif status_code >= 500:
+        assertion = "FAIL_5XX"
+
+    if body_json is not None:
+        # Some endpoints (e.g. /api/answers) nest the data envelope under a
+        # `data` key; resolve either the top-level shape or the nested one
+        # so snapshots are captured for both contract variants.
+        rep_score = (
+            body_json.get("reputation_score")
+            if "reputation_score" in body_json
+            else (body_json.get("data") or {}).get("reputation_score")
+            if isinstance(body_json.get("data"), dict)
+            else None
+        )
+        if rep_score is not None:
+            data_block = body_json.get("data") if isinstance(body_json.get("data"), dict) else body_json
+            uid = (
+                data_block.get("userId")
+                or data_block.get("user_id")
+                or data_block.get("_id")
+                or body_json.get("userId")
+                or body_json.get("user_id")
+                or body_json.get("_id")
+                or context.get("user_id")
+            )
+            if uid:
+                record_reputation_snapshot(
+                    str(uid),
+                    {
+                        "reputation_score": rep_score,
+                        "context": name,
+                        "at": time.time(),
+                    },
+                )
+
+    if (
+        body_json is not None
+        and isinstance(body_json.get("data"), list)
+        and "queue-details" in url
+    ):
+        record_queue_length(url, len(body_json["data"]))
+    if (
+        body_json is not None
+        and isinstance(body_json.get("data"), dict)
+        and "received" in body_json["data"]
+        and isinstance(body_json["data"]["received"], dict)
+        and "count" in body_json["data"]["received"]
+    ):
+        record_queue_length(url, body_json["data"]["received"]["count"])
+
+    if "check-duplicate" in url and status_code < 500:
+        record_cosine_sample(response_time)
+
+    record_request(
+        endpoint=url,
+        method=request_type,
+        name=name,
+        status_code=status_code,
+        response_time_ms=response_time,
+        response_length=response_length,
+        failure=failure_msg,
+        assertion=assertion,
+        context=context or {},
+    )
+
+
+@events.quitting.add_listener
+def _on_quitting(environment: Any, **kwargs: Any) -> None:  # pragma: no cover
+    flush_all()
+    write_reputation_snapshot_csv()
+    write_reputation_snapshot_history_csv()
+    write_queue_length_csv()
+    close()

--- a/testing/locust/helpers/credentials.py
+++ b/testing/locust/helpers/credentials.py
@@ -1,0 +1,153 @@
+"""
+credentials.py
+---------------
+Pulls loadtest user records out of `agriai_loadtest.users` (the seed DB) and
+exposes them as a `CredentialPool` so each Locust virtual user can draw a
+credential on login and so the run orchestrator can size the user pool to
+exactly the scenario's required concurrency.
+
+Why we don't bake credentials into the tasks:
+
+* The seed scripts run with `firebaseUID` regex `^lt-` and a `lt-<role>-NNNNN`
+  pattern. We rely on the *same* seed run that the rest of the loadtest uses,
+  so there is exactly one source of truth for "who can log in".
+* Passwords are shared for loadtest (`Password123!`) — the seed fixtures are
+  synthetic, the auth emulator is local, and the `firebaseUID` regex `^lt-`
+  prevents cross-contamination.
+
+Environment:
+* `DB_URL`              — mongodb uri, same as seed_all.mjs (default mongodb://localhost:27017)
+* `DB_NAME`             — must be `agriai_loadtest` (asserted like in seed scripts)
+* `FIREBASE_AUTH_EMULATOR_HOST` — used by the auth emulator; the auth phase
+                                  does NOT need it directly because we hit
+                                  `/api/auth/login`, which the backend routes
+                                  through the emulator when the env var is set.
+"""
+from __future__ import annotations
+
+import os
+import random
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+try:
+    from pymongo import MongoClient
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit(
+        "pymongo is required for the Locust credential pool. "
+        "Install with: pip install -r testing/locust/requirements.txt"
+    ) from exc
+
+
+# All roles the reviewer system exercises. Keep this in sync with
+# testing/seed/lib/fixtures.mjs::ROLES.
+ROLE_KEYS = ["expert", "pae_expert", "moderator", "gate_keeper", "auditor", "admin"]
+
+
+@dataclass(frozen=True)
+class Credential:
+    email: str
+    password: str
+    firebase_uid: str
+    role: str
+    user_id: str  # Mongo _id as string, used by /users/.../change-password etc.
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"Credential(email={self.email!r}, role={self.role!r})"
+
+
+class CredentialPool:
+    """
+    A read-only view of the loadtest users in Mongo, bucketed by role.
+
+    Usage:
+        pool = CredentialPool.from_mongo()
+        experts = pool.draw("expert", 50)
+        # each expert gets a fresh random pick — no double-issue inside a run
+    """
+
+    def __init__(self, by_role: Dict[str, List[Credential]]):
+        self._by_role = by_role
+        self._issued: Dict[str, set] = {k: set() for k in ROLE_KEYS}
+
+    # ------------------------------------------------------------------ loaders
+    @classmethod
+    def from_mongo(
+        cls,
+        url: Optional[str] = None,
+        db_name: Optional[str] = None,
+        password: str = "Password123!",
+    ) -> "CredentialPool":
+        url = url or os.getenv("DB_URL", "mongodb://localhost:27017")
+        db_name = db_name or os.getenv("DB_NAME", "agriai_loadtest")
+
+        # Hard guard — mirrors the seed-script assertion. If the runner is
+        # ever pointed at staging, we want a loud failure rather than a load
+        # test against a real DB.
+        assert db_name == "agriai_loadtest", (
+            f"CredentialPool refused to read from db={db_name!r}. "
+            "Project 7 loadtest only runs against 'agriai_loadtest'."
+        )
+
+        client = MongoClient(url, serverSelectionTimeoutMS=5000)
+        db = client[db_name]
+        users = db["users"]
+
+        by_role: Dict[str, List[Credential]] = {k: [] for k in ROLE_KEYS}
+        for doc in users.find(
+            {"firebaseUID": {"$regex": "^lt-"}},
+            {"_id": 1, "email": 1, "role": 1, "firebaseUID": 1},
+        ):
+            role = doc.get("role")
+            if role not in by_role:
+                continue
+            by_role[role].append(
+                Credential(
+                    email=doc["email"],
+                    password=password,
+                    firebase_uid=doc["firebaseUID"],
+                    role=role,
+                    user_id=str(doc["_id"]),
+                )
+            )
+
+        client.close()
+
+        # Pretty log so the operator sees what they got before the run starts.
+        for role, creds in by_role.items():
+            print(f"[credentials] role={role:<12} count={len(creds)}")
+        return cls(by_role)
+
+    # ----------------------------------------------------------------- queries
+    def count(self, role: str) -> int:
+        return len(self._by_role.get(role, []))
+
+    def all_for_role(self, role: str) -> List[Credential]:
+        return list(self._by_role.get(role, []))
+
+    def draw(self, role: str, n: int = 1) -> List[Credential]:
+        """Draw n *distinct* unissued credentials for `role`. Reuses when deck runs out."""
+        bucket = self._by_role.get(role, [])
+        if not bucket:
+            raise RuntimeError(
+                f"No credentials for role={role!r}. "
+                "Did you run `node seed/seed_all.mjs`?"
+            )
+        # Issue in random order, never reuse before the deck is exhausted.
+        available = [c for c in bucket if c.email not in self._issued[role]]
+        random.shuffle(available)
+        picked = available[:n]
+        if len(picked) < n:
+            # Deck exhausted — recycle, but log a warning so the operator
+            # knows the run is denser than the seed supported.
+            print(
+                f"[credentials] WARNING: role={role!r} deck exhausted "
+                f"({len(bucket)} total, requested {n}); recycling."
+            )
+            picked = list(random.sample(bucket, min(n, len(bucket))))
+        for c in picked:
+            self._issued[role].add(c.email)
+        return picked
+
+    def draw_one(self, role: str) -> Credential:
+        return self.draw(role, 1)[0]

--- a/testing/locust/helpers/payloads.py
+++ b/testing/locust/helpers/payloads.py
@@ -1,0 +1,257 @@
+"""
+payloads.py
+-----------
+Body builders for the reviewer endpoints exercised by the Locust suite.
+Each function returns a `dict` ready to be passed to `self.client.post(...)`.
+
+These builders deliberately keep payloads *minimal and valid* — they are
+stress-test bodies, not data-model authoring. The seed scripts already
+provide realistic `state`/`crop`/`domain` values, so any payload we send
+must at minimum point at a real Mongo `_id` or a valid enum value.
+
+Endpoint schema sources:
+* `backend/src/modules/question/classes/validators/QuestionValidators.ts`
+* `backend/src/modules/answer/classes/validators/AnswerValidators.ts`
+* `backend/src/modules/question/classes/validators/AllocateExpertsRequest`
+"""
+from __future__ import annotations
+
+import random
+import uuid
+from typing import Any, Dict, List, Optional
+
+
+# -----------------------------------------------------------------------------
+# Auth & generic
+# -----------------------------------------------------------------------------
+def login_body(email: str, password: str = "Password123!") -> Dict[str, Any]:
+    return {"email": email, "password": password}
+
+
+# -----------------------------------------------------------------------------
+# Question intake & listing
+# -----------------------------------------------------------------------------
+def add_question_body(
+    text: str,
+    state: str,
+    crop: str,
+    domain: str = "all",
+) -> Dict[str, Any]:
+    """POST /api/questions/add-question body."""
+    return {
+        "text": text,
+        "state": state,
+        "crops": [crop],
+        "domain": domain,
+        "priority": random.choice(["low", "medium", "high"]),
+        "source": "AJRASAKHA",
+        "language": "en",
+        "autoAllocateModerator": True,
+    }
+
+
+
+
+# -----------------------------------------------------------------------------
+# Allocation
+# -----------------------------------------------------------------------------
+def allocate_experts_body(
+    expert_user_ids: List[str],
+    *,
+    auto_allocate: bool = True,
+) -> Dict[str, Any]:
+    """POST /:questionId/allocate-experts body."""
+    return {
+        "experts": expert_user_ids,
+        "autoAllocate": auto_allocate,
+        "reason": "loadtest",
+    }
+
+
+def bulk_pae_allocate_body(
+    question_ids: List[str],
+    pae_user_ids: List[str],
+) -> Dict[str, Any]:
+    """POST /:questionId/bulk-pae-allocate body."""
+    return {
+        "questions": question_ids,
+        "paeExperts": pae_user_ids,
+        "reason": "loadtest",
+    }
+
+
+def reallocate_manual_body(
+    question_id: str,
+    from_user_id: str,
+    to_user_id: str,
+) -> Dict[str, Any]:
+    return {
+        "questionId": question_id,
+        "fromUserId": from_user_id,
+        "toUserId": to_user_id,
+        "reason": "loadtest",
+    }
+
+
+def reallocate_timebound_body(question_id: str) -> Dict[str, Any]:
+    return {"questionId": question_id, "reason": "loadtest-timebound"}
+
+
+def reroute_body(question_id: str, reason: str = "stall") -> Dict[str, Any]:
+    return {"questionId": question_id, "reason": reason}
+
+
+# -----------------------------------------------------------------------------
+# Review / feedback
+# -----------------------------------------------------------------------------
+def submit_review_body(
+    question_id: str,
+    answer_text: str,
+    status: str = "in-review",
+    *,
+    sources: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    """POST /:questionId (review) — used by experts to submit a review."""
+    return {
+        "questionId": question_id,
+        "text": answer_text,
+        "status": status,
+        "sources": sources or [
+            {"name": "ICAR", "url": "https://icar.org.in/example"},
+            {"name": "AgriDept", "url": "https://agri.in/example"},
+        ],
+    }
+
+
+def feedback_reviewer_body(
+    feedback: str,
+    rating: int = 4,
+    tags: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """POST /:questionId/feedback-reviewer body."""
+    return {
+        "feedback": feedback,
+        "rating": rating,
+        "tags": tags or ["accuracy", "language"],
+    }
+
+
+def feedback_action_body(action: str = "accept", comment: str = "") -> Dict[str, Any]:
+    """POST /:questionId/:feedbackId/feedback-action body."""
+    assert action in ("accept", "reject", "request_changes")
+    return {"action": action, "comment": comment}
+
+
+# -----------------------------------------------------------------------------
+# Filter / report (bug #1195)
+# -----------------------------------------------------------------------------
+def download_filtered_report_body(
+    status: str = "all-closed",
+    all_users: Optional[str] = None,
+    moderator: Optional[str] = None,  # legacy field, will be ignored post-fix
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    crops: Optional[List[str]] = None,
+    states: Optional[List[str]] = None,
+    duplicate_questions: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    POST /api/questions/download-filtered-report body.
+
+    Replicates the PR #1195 fix: the controller now reads `allUsers` (not
+    `moderator`). The legacy `moderator` field is kept here for backward
+    compatibility probes (the bug-repro harness uses both).
+    """
+    body: Dict[str, Any] = {"status": status}
+    if all_users is not None:
+        body["allUsers"] = all_users
+    if moderator is not None:
+        body["moderator"] = moderator
+    if start_date:
+        body["startDate"] = start_date
+    if end_date:
+        body["endDate"] = end_date
+    if crops:
+        body["crops"] = crops
+    if states:
+        body["states"] = states
+    if duplicate_questions:
+        body["duplicateQuestions"] = duplicate_questions
+    return body
+
+
+# -----------------------------------------------------------------------------
+# Synthetic answer text
+# -----------------------------------------------------------------------------
+_SYNTH_ANSWER_FRAGMENTS = [
+    "Apply neem oil at 5 ml/L every 7 days; rotate with imidacloprid 0.3 ml/L "
+    "every 14 days to avoid resistance.",
+    "Sow in rows 20 cm apart, 3 cm deep; irrigate lightly twice a week through "
+    "the first 30 days.",
+    "For nutrient deficiency, top-dress with 20 kg N/ha at tillering and again "
+    "20 days later.",
+    "Use pheromone traps at 5 per acre for early pest detection; replace lures "
+    "every 30 days.",
+    "Burn visible egg masses; release Trichogramma egg parasitoids at 1.5 lakh/ha.",
+    "Adopt ridge-and-furrow sowing for waterlogging-prone fields; ensure 30 cm "
+    "ridge height.",
+    "Test soil pH annually; apply lime if pH < 5.5 and gypsum if soil is sodic.",
+]
+
+
+def random_answer_text() -> str:
+    return random.choice(_SYNTH_ANSWER_FRAGMENTS)
+
+
+def random_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+
+def approve_initial_answer_body(answer: str) -> Dict[str, Any]:
+    """POST /:questionId/approve-initial-answer body."""
+    return {"answer": answer, "approved": True}
+
+
+# -----------------------------------------------------------------------------
+# Moderator gate
+# -----------------------------------------------------------------------------
+def moderator_approve_body(
+    question_id: str,
+    answer_id: str,
+    *,
+    approve: bool = True,
+    comment: str = "",
+) -> Dict[str, Any]:
+    """POST /api/answers/moderator/approve body."""
+    return {
+        "questionId": question_id,
+        "answerId": answer_id,
+        "approve": approve,
+        "comment": comment,
+    }
+
+def allocated_body(
+    page: int = 1,
+    limit: int = 20,
+    status_filter: Optional[str] = None,
+    crop: Optional[str] = None,
+    state: Optional[str] = None,
+) -> Dict[str, Any]:
+    """POST /api/questions/allocated body."""
+    body: Dict[str, Any] = {"page": page, "limit": limit}
+    if status_filter:
+        body["status"] = status_filter
+    if crop:
+        body["crop"] = crop
+    if state:
+        body["state"] = state
+    return body
+
+
+def detailed_questions_body(
+    page: int = 1,
+    limit: int = 20,
+    status: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {"page": page, "limit": limit, **({"status": status} if status else {})}

--- a/testing/locust/locust.conf
+++ b/testing/locust/locust.conf
@@ -1,0 +1,17 @@
+# Locust default config — overridden per scenario via CLI `--conf` or
+# scenarios/*.py files (which programmatically rebuild the runner).
+# This file is the *default* for an interactive `locust` invocation.
+
+host            = http://localhost:3141
+users           = 50
+spawn-rate      = 5
+run-time        = 10m
+headless        = false
+loglevel        = INFO
+only-summary    = false
+reset-stats     = false
+print-stats     = true
+csv             = results/locust
+html            = results/locust_report.html
+exit-code-on-error = 0
+processes       = 1

--- a/testing/locust/locustfile_reviewer.py
+++ b/testing/locust/locustfile_reviewer.py
@@ -1,0 +1,117 @@
+"""
+locustfile_reviewer.py — Project 7 reviewer loadtest orchestrator.
+
+Usage
+-----
+The runner is invoked via the scenario files in `scenarios/{1x,5x,10x}.py`
+which call `runner.run()` programmatically. The CLI form is also supported:
+
+    locust -f testing/locust/locustfile_reviewer.py --headless \\
+           -u 50 -r 5 -t 10m --host http://localhost:3141
+
+What the orchestrator does
+--------------------------
+1. Loads the per-role user classes from `users/roles.py`.
+2. Registers the `assertions` event listener so every request is recorded
+   into `results/<scenario>/requests.csv` and rejected 5xx are aggregated.
+3. Picks up the `RESULTS_DIR` env var (set by `scenarios/*.py`) so the
+   assertions listener writes into the per-scenario output folder.
+4. Exposes `LOAD_PROFILE` env var support — `heavy_allocate`, `squash_p95`,
+   `moderate` — which adjusts `tasks` weights per role for ergonomic
+   one-shot re-runs.
+
+Why this file is *not* the `__init__.py` of the suite:
+* Locust's `-f` flag points at this file specifically; `__init__.py` would
+  be ambiguous between the parent and the user's actual project.
+* This gives us a single, predictable entry point for the
+  `pwsh -File testing/scripts/run-locust-1x.ps1` scripts.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+# Make `testing/locust/...` importable when Locust is launched from any cwd.
+_THIS_DIR = Path(__file__).resolve().parent
+if str(_THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(_THIS_DIR))
+
+from locust import events  # noqa: E402
+
+from helpers import assertions as A  # noqa: E402
+from users.roles import ALL_USER_CLASSES, Expert, PaeExpert, Moderator, GateKeeper, Auditor, Admin  # noqa: E402
+
+# -----------------------------------------------------------------------------
+# 1. Event-listener init
+# -----------------------------------------------------------------------------
+_results_dir = os.getenv("RESULTS_DIR") or str(_THIS_DIR.parent / "results" / "_default")
+A.init(_results_dir)
+print(f"[locustfile_reviewer] assertions listener writing to: {_results_dir}")
+
+
+# -----------------------------------------------------------------------------
+# 2. Load-profile knobs
+# -----------------------------------------------------------------------------
+# Adjusts task weight multiplicatively per role. Used by the scenarios
+# (`scenarios/1x.py`, etc.) to focus the run on a single surface — e.g. an
+# "allocations only" 10x run for S1 reproduction.
+PROFILES = {
+    "moderate":   {"expert": 1.0, "pae_expert": 1.0, "moderator": 1.0,
+                   "gate_keeper": 1.0, "auditor": 1.0, "admin": 1.0},
+    "heavy_allocate": {"expert": 1.0, "pae_expert": 5.0, "moderator": 1.0,
+                       "gate_keeper": 1.0, "auditor": 1.0, "admin": 1.0},
+    "squash_p95": {"expert": 5.0, "pae_expert": 1.0, "moderator": 5.0,
+                   "gate_keeper": 1.0, "auditor": 1.0, "admin": 1.0},
+    "moderator_heap": {"expert": 1.0, "pae_expert": 1.0, "moderator": 10.0,
+                       "gate_keeper": 1.0, "auditor": 1.0, "admin": 1.0},
+}
+
+
+def _apply_profile(profile: str) -> None:
+    """Multiply `weight` on each role class by the profile multiplier."""
+    mults = PROFILES.get(profile, PROFILES["moderate"])
+    for cls, weight_key in [
+        (Expert, "expert"),
+        (PaeExpert, "pae_expert"),
+        (Moderator, "moderator"),
+        (GateKeeper, "gate_keeper"),
+        (Auditor, "auditor"),
+        (Admin, "admin"),
+    ]:
+        cls.weight = max(1, int(cls.weight * mults[weight_key]))
+
+
+_apply_profile(os.getenv("LOAD_PROFILE", "moderate"))
+
+
+# -----------------------------------------------------------------------------
+# 3. Locust startup hook — write a run-manifest CSV so the report has
+#    pins to the exact scenario configuration.
+# -----------------------------------------------------------------------------
+@events.init.add_listener
+def _on_init(environment, **kwargs):
+    import csv
+    manifest_path = Path(_results_dir) / "run_manifest.csv"
+    Path(_results_dir).mkdir(parents=True, exist_ok=True)
+    with open(manifest_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["key", "value"])
+        w.writerow(["host", environment.host or os.getenv("LOCUST_HOST", "")])
+        w.writerow(["profile", os.getenv("LOAD_PROFILE", "moderate")])
+        w.writerow(["results_dir", _results_dir])
+        for cls in ALL_USER_CLASSES:
+            w.writerow([f"weight.{cls.__name__}", cls.weight])
+
+
+# -----------------------------------------------------------------------------
+# 4. Re-export user classes so `locust -f locustfile_reviewer.py` finds them.
+# -----------------------------------------------------------------------------
+# Locust discovers HttpUser subclasses by importing them. The imports above
+# already load the classes; nothing more to do.
+
+# Sanity log so the operator sees the load mix before the run starts.
+print("[locustfile_reviewer] user mix:")
+for cls in ALL_USER_CLASSES:
+    print(f"  {cls.__name__:<14} weight={cls.weight}")

--- a/testing/locust/requirements.txt
+++ b/testing/locust/requirements.txt
@@ -1,0 +1,8 @@
+# Locust + helpers for Project 7 reviewer loadtests.
+# Pin majors; the rest is open. Lock Locust 2.x — the FastHttpSession API is
+# stable across the 2.x line and we rely on it in helpers/assertions.py.
+locust>=2.31,<3.0
+pymongo>=4.7,<5.0
+requests>=2.32,<3.0
+python-dateutil>=2.9,<3.0
+pyyaml>=6.0,<7.0

--- a/testing/locust/scenarios/10x.py
+++ b/testing/locust/scenarios/10x.py
@@ -1,0 +1,84 @@
+"""
+scenarios/10x.py — 10× overload / breaking point.
+
+Target
+------
+* 10× user counts vs 1×. Total = 120 simulated users (Locust 2.32 uses
+  per-class weights to distribute the run).
+* Spawn rate = 10/sec.
+* 15-min budget — we're looking for the SLA-breach moment, not a soak.
+
+Use
+---
+This is where SLA S5 (HTTP 5xx < 0.1%) and S1 (queue wait > 60 s) are
+expected to flip from PASS to FAIL. The breakdown budget must
+yield `error_budget.sla_pass = False` for ≥ 1 of {S1, S2, S5, S6} to
+constitute the documented "10x breach" condition.
+
+Run profile default: `LOAD_PROFILE=squash_p95` — hammer the heavy write
+paths to drive the SLA p95 breach.
+
+Override
+--------
+Set `LOCUST_RUN_TIME=90s` (or `5m`/`1h`) to auto-stop the run after the
+given duration; the default is 15m.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import gevent  # noqa: E402
+
+_THIS_DIR = Path(__file__).resolve().parent
+_ROOT = _THIS_DIR.parent.parent
+sys.path.insert(0, str(_ROOT / "locust"))
+
+from locust import events as _locust_events  # noqa: E402
+from locust.env import Environment  # noqa: E402
+
+from locustfile_reviewer import ALL_USER_CLASSES  # noqa: E402
+
+SCENARIO = "10x"
+RESULTS_DIR = Path(os.getenv("RESULTS_DIR") or _ROOT / "results" / f"{SCENARIO}_locust")
+HOST = os.getenv("LOCUST_HOST", "http://localhost:3141")
+
+TOTAL_USERS = 120
+SPAWN_RATE = 10
+RUN_TIME = os.getenv("LOCUST_RUN_TIME", "15m")
+
+
+def _parse_run_time(s: str) -> int:
+    """Parse '30s' / '5m' / '1h' into seconds."""
+    m = re.match(r"^(\d+)(s|m|h)$", s.strip())
+    if not m:
+        raise ValueError(f"Bad LOCUST_RUN_TIME {s!r} (expected e.g. 30s, 5m, 1h)")
+    n, unit = int(m.group(1)), m.group(2)
+    return n * {"s": 1, "m": 60, "h": 3600}[unit]
+
+
+def main() -> None:
+    env = Environment(user_classes=ALL_USER_CLASSES, host=HOST, events=_locust_events)
+    env.create_local_runner()
+
+    env.runner.start(user_count=TOTAL_USERS, spawn_rate=SPAWN_RATE)
+    print(f"[scenarios/{SCENARIO}] starting: total={TOTAL_USERS} rate={SPAWN_RATE}/s "
+          f"host={HOST} results={RESULTS_DIR} time={RUN_TIME}")
+
+    seconds = _parse_run_time(RUN_TIME)
+
+    def _auto_stop():
+        _locust_events.quitting.fire(environment=env, reverse=True)
+        env.runner.quit()
+
+    gevent.spawn_later(seconds, _auto_stop)
+    print(f"[scenarios/{SCENARIO}] scheduled auto-stop+quit in {seconds}s")
+
+    env.runner.greenlet.join()
+    print(f"[scenarios/{SCENARIO}] runner joined; exiting")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/locust/scenarios/1x.py
+++ b/testing/locust/scenarios/1x.py
@@ -1,0 +1,107 @@
+"""
+scenarios/1x.py — 1× baseline.
+
+Target
+------
+Establish the per-role cost envelope at the *expected steady-state* load
+(numbers below come from the production traffic profile in the roadmap §5
+— "approximately 50 reviewer-side requests/min under normal traffic" —
+scaled to hit per-second targets stated in the SLA doc):
+
+* 5 experts, 2 pae_experts, 2 moderators, 1 gate_keeper, 1 auditor, 1 admin
+* 1× spawn rate (`-r 1`), 60-minute run budget.
+
+Run
+---
+    pwsh -File testing/scripts/run-locust-1x.ps1
+or directly:
+    LOAD_PROFILE=moderate RESULTS_DIR=results/1x_locust \
+      python testing/locust/scenarios/1x.py
+
+Override
+--------
+Set `LOCUST_RUN_TIME=30s` (or `5m`/`1h`) to auto-stop the run after the
+given duration; the default is 60m.
+
+Implementation note
+-------------------
+Locust 2.32's `runner.start()` accepts a single `user_count` (total)
+and uses per-class `weight` to allocate. The run plan is therefore:
+
+* Spawn `TOTAL = 12` virtual users at `1/s`.
+* Class weights in `users/roles.py` (Expert=50, PaeExpert=10, Moderator=10,
+  GateKeeper=5, Auditor=5, Admin=1) yield a per-class mix of
+  E=7 / P=2 / M=2 / GK=1 / A=1 / Ad=0 (rounded) — close to the 5/2/2/1/1/1
+  documented in the roadmap.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import gevent  # noqa: E402
+
+_THIS_DIR = Path(__file__).resolve().parent
+_ROOT = _THIS_DIR.parent.parent
+sys.path.insert(0, str(_ROOT / "locust"))
+
+from locust import events as _locust_events  # noqa: E402
+from locust.env import Environment  # noqa: E402
+
+from locustfile_reviewer import ALL_USER_CLASSES  # noqa: E402
+
+SCENARIO = "1x"
+RESULTS_DIR = Path(os.getenv("RESULTS_DIR") or _ROOT / "results" / f"{SCENARIO}_locust")
+HOST = os.getenv("LOCUST_HOST", "http://localhost:3141")
+
+# 12 simulated users at 1x — distributed by `weight` across the 6 role classes.
+TOTAL_USERS = 12
+# 1 spawn/sec.
+SPAWN_RATE = 1
+# 60-min default budget.
+RUN_TIME = os.getenv("LOCUST_RUN_TIME", "60m")
+
+
+def _parse_run_time(s: str) -> int:
+    """Parse '30s' / '5m' / '1h' into seconds."""
+    m = re.match(r"^(\d+)(s|m|h)$", s.strip())
+    if not m:
+        raise ValueError(f"Bad LOCUST_RUN_TIME {s!r} (expected e.g. 30s, 5m, 1h)")
+    n, unit = int(m.group(1)), m.group(2)
+    return n * {"s": 1, "m": 60, "h": 3600}[unit]
+
+
+def main() -> None:
+    env = Environment(user_classes=ALL_USER_CLASSES, host=HOST, events=_locust_events)
+    env.create_local_runner()
+
+    env.runner.start(user_count=TOTAL_USERS, spawn_rate=SPAWN_RATE)
+    print(f"[scenarios/{SCENARIO}] starting: total={TOTAL_USERS} rate={SPAWN_RATE}/s "
+          f"host={HOST} results={RESULTS_DIR} time={RUN_TIME}")
+
+    # Schedule auto-stop if LOCUST_RUN_TIME is set. We call .quit() rather
+    # than .stop() so the runner's hub greenlet is killed at the end of the
+    # run — otherwise the greenlet.join() below can hang on a stuck user
+    # gevent (e.g. one blocked on a long request after the timer fires).
+    # We also fire `events.quitting` first so listeners that flush
+    # reputation_snapshots.csv / queue_lengths.csv (assertions.py:_on_quitting)
+    # get a chance to run — Locust's main.py:shutdown() would normally do this
+    # for the CLI driver, but the programmatic scenario driver has to fire
+    # it manually.
+    seconds = _parse_run_time(RUN_TIME)
+
+    def _auto_stop():
+        _locust_events.quitting.fire(environment=env, reverse=True)
+        env.runner.quit()
+
+    gevent.spawn_later(seconds, _auto_stop)
+    print(f"[scenarios/{SCENARIO}] scheduled auto-stop+quit in {seconds}s")
+
+    env.runner.greenlet.join()
+    print(f"[scenarios/{SCENARIO}] runner joined; exiting")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/locust/scenarios/5x.py
+++ b/testing/locust/scenarios/5x.py
@@ -1,0 +1,80 @@
+"""
+scenarios/5x.py — 5× burst.
+
+Target
+------
+* 5× user counts vs 1×. Total = 60 simulated users (Locust 2.32 uses
+  per-class weights to distribute the run).
+* Spawn rate = 5/sec (all classes ramp in parallel).
+* 30-min budget (we want throughput under sustained load, not soak).
+
+Use
+---
+Specifically pinned to SLA S2 ("allocator must complete in ≤ 800 ms at 5×"),
+this scenario must be run with `--profile heavy_allocate` so the bulk-PAE
+path is exercised hard enough to reproduce the SLA breach.
+
+Override
+--------
+Set `LOCUST_RUN_TIME=60s` (or `5m`/`1h`) to auto-stop the run after the
+given duration; the default is 30m.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import gevent  # noqa: E402
+
+_THIS_DIR = Path(__file__).resolve().parent
+_ROOT = _THIS_DIR.parent.parent
+sys.path.insert(0, str(_ROOT / "locust"))
+
+from locust import events as _locust_events  # noqa: E402
+from locust.env import Environment  # noqa: E402
+
+from locustfile_reviewer import ALL_USER_CLASSES  # noqa: E402
+
+SCENARIO = "5x"
+RESULTS_DIR = Path(os.getenv("RESULTS_DIR") or _ROOT / "results" / f"{SCENARIO}_locust")
+HOST = os.getenv("LOCUST_HOST", "http://localhost:3141")
+
+TOTAL_USERS = 60
+SPAWN_RATE = 5
+RUN_TIME = os.getenv("LOCUST_RUN_TIME", "30m")
+
+
+def _parse_run_time(s: str) -> int:
+    """Parse '30s' / '5m' / '1h' into seconds."""
+    m = re.match(r"^(\d+)(s|m|h)$", s.strip())
+    if not m:
+        raise ValueError(f"Bad LOCUST_RUN_TIME {s!r} (expected e.g. 30s, 5m, 1h)")
+    n, unit = int(m.group(1)), m.group(2)
+    return n * {"s": 1, "m": 60, "h": 3600}[unit]
+
+
+def main() -> None:
+    env = Environment(user_classes=ALL_USER_CLASSES, host=HOST, events=_locust_events)
+    env.create_local_runner()
+
+    env.runner.start(user_count=TOTAL_USERS, spawn_rate=SPAWN_RATE)
+    print(f"[scenarios/{SCENARIO}] starting: total={TOTAL_USERS} rate={SPAWN_RATE}/s "
+          f"host={HOST} results={RESULTS_DIR} time={RUN_TIME}")
+
+    seconds = _parse_run_time(RUN_TIME)
+
+    def _auto_stop():
+        _locust_events.quitting.fire(environment=env, reverse=True)
+        env.runner.quit()
+
+    gevent.spawn_later(seconds, _auto_stop)
+    print(f"[scenarios/{SCENARIO}] scheduled auto-stop+quit in {seconds}s")
+
+    env.runner.greenlet.join()
+    print(f"[scenarios/{SCENARIO}] runner joined; exiting")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/locust/tasks/allocate_experts.py
+++ b/testing/locust/tasks/allocate_experts.py
@@ -1,0 +1,71 @@
+"""
+allocate_experts.py
+-------------------
+Two paths:
+
+* `allocate_experts` — POST /:questionId/allocate-experts (QuestionController
+  line ~1620). Gate-keeper/moderator triggers allocation of a specific
+  expert roster to a question.
+* `bulk_pae_allocate` — POST /:questionId/bulk-pae-allocate. PAE experts
+  allocate themselves to multiple questions at once (state/crop specialist).
+
+We exercise the bulk path directly because it is the larger surface
+(O(questions x experts)) and matches the Phase-1 roadmap's "PAE bloom at
+sowing season" framing.
+"""
+from __future__ import annotations
+
+from typing import Any, List
+
+from users.reviewer import _get_db
+from helpers.payloads import allocate_experts_body, bulk_pae_allocate_body
+
+
+def _gather_experts(client: Any, count: int) -> List[str]:
+    """Pull `count` expert user_ids from the pool (no in-memory cache —
+    reads from Mongo on every call so we don't accidentally pin the same
+    expert forever)."""
+    ids: List[str] = []
+    for _ in range(count):
+        uid = client.sample_expert_id()
+        if uid:
+            ids.append(uid)
+    return ids
+
+
+def allocate_experts(client: Any) -> None:
+    qid = client.sample_open_question()
+    if qid is None:
+        return
+    experts = _gather_experts(client, 3)
+    if not experts:
+        return
+    body = allocate_experts_body(experts)
+    client._post_json(
+        f"/api/questions/{qid}/allocate-experts",
+        body,
+        name="POST /:qid/allocate-experts",
+    )
+
+
+def bulk_pae_allocate(client: Any) -> None:
+    qid = client.sample_open_question()
+    if qid is None:
+        return
+    db = _get_db()
+    pae_ids: List[str] = []
+    if db is not None:
+        docs = list(
+            db["users"]
+            .find({"role": "pae_expert", "firebaseUID": {"$regex": "^lt-pae-"}})
+            .limit(2)
+        )
+        pae_ids = [str(d["_id"]) for d in docs]
+    if not pae_ids:
+        return
+    body = bulk_pae_allocate_body([qid], pae_ids)
+    client._post_json(
+        f"/api/questions/{qid}/bulk-pae-allocate",
+        body,
+        name="POST /:qid/bulk-pae-allocate",
+    )

--- a/testing/locust/tasks/allocated.py
+++ b/testing/locust/tasks/allocated.py
@@ -1,0 +1,68 @@
+"""
+allocated.py
+------------
+POST /api/questions/allocated — "list questions allocated to the current
+reviewer". Per-role variants differ only in the filter parameters.
+
+Endpoint source: `backend/src/modules/question/controllers/QuestionController.ts`
+  `@Post('/allocated')` (line ~210) and `@Post('/allocated/page')` (line ~193).
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from helpers.payloads import allocated_body as _allocated_body
+
+
+def _do(client: Any, name: str, body: Dict[str, Any]) -> None:
+    client._post_json("/api/questions/allocated", body, name=name)
+
+
+def expert_list(client: Any) -> None:
+    """
+    Expert: list questions in `in-review` for the current expert.
+    """
+    _do(
+        client,
+        "POST /api/questions/allocated (expert)",
+        _allocated_body(page=1, limit=20, status_filter="in-review"),
+    )
+
+
+def moderator_list(client: Any) -> None:
+    """
+    Moderator: list everything allocated to me (no status filter; let the
+    server filter by the calling user).
+    """
+    _do(
+        client,
+        "POST /api/questions/allocated (moderator)",
+        _allocated_body(page=1, limit=30),
+    )
+
+
+def gate_keeper_list(client: Any) -> None:
+    """Gate keeper: full queue, paginated."""
+    _do(
+        client,
+        "POST /api/questions/allocated (gate_keeper)",
+        _allocated_body(page=1, limit=50),
+    )
+
+
+def auditor_list(client: Any) -> None:
+    """Auditor: full queue, paginated (read-only)."""
+    _do(
+        client,
+        "POST /api/questions/allocated (auditor)",
+        _allocated_body(page=1, limit=50),
+    )
+
+
+def admin_list(client: Any) -> None:
+    """Admin: full queue, paginated, no filter."""
+    _do(
+        client,
+        "POST /api/questions/allocated (admin)",
+        _allocated_body(page=1, limit=100),
+    )

--- a/testing/locust/tasks/approve_initial_answer.py
+++ b/testing/locust/tasks/approve_initial_answer.py
@@ -1,0 +1,31 @@
+"""
+approve_initial_answer.py
+-------------------------
+Expert approves the AI-generated initial answer. Cheap write — directly
+transitions a question to `closed` (or `auditor_review` on the new path).
+
+Endpoint: `POST /api/questions/:questionId/approve-initial-answer`
+  (QuestionController.ts line ~2772).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from helpers.payloads import approve_initial_answer_body
+
+
+def expert_approve_initial(client: Any) -> None:
+    qid = client.sample_question_by_status("pae_submitted")
+    if qid is None:
+        qid = client.sample_open_question()
+    if qid is None:
+        return
+    body = approve_initial_answer_body(
+        "Approved: apply the recommended neem oil at 5 ml/L every 7 days. "
+        "Re-check after 14 days."
+    )
+    client._post_json(
+        f"/api/questions/{qid}/approve-initial-answer",
+        body,
+        name="POST /:qid/approve-initial-answer",
+    )

--- a/testing/locust/tasks/cosine_check.py
+++ b/testing/locust/tasks/cosine_check.py
@@ -1,0 +1,57 @@
+"""
+cosine_check.py
+---------------
+SLA S7 gate keeper. Drives the duplicate-check pipeline by calling
+`/api/questions/check-duplicate` and asserts the cosine-similarity
+wall-clock distribution.
+
+The control flow:
+
+* Gate-keeper users poll the question intake feed for "needs-duplicate-check"
+  questions.
+* For each, we fire a duplicate-check call (acting as the gate-keeper
+  would) and time the response.
+* The assertions listener picks up `response_time_ms` and pushes it into
+  the bottom-quartile histogram that S7 cares about.
+
+Note: the actual cosine call lives in `backend/src/utils/cosine-similarity.ts`
+and is invoked server-side. The test harness only sees the request round-trip.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from users.reviewer import _get_db
+
+
+def _pick_needs_duplicate(client: Any) -> Optional[str]:
+    """Pick a question whose status is `open` and `isDuplicateChecked=false`."""
+    db = _get_db()
+    if db is None:
+        return None
+    doc = db["questions"].aggregate(
+        [
+            {"$match": {
+                "status": "open",
+                "isDuplicateChecked": {"$ne": True},
+            }},
+            {"$sample": {"size": 1}},
+        ],
+        allowDiskUse=True,
+    ).next()
+    return str(doc["_id"]) if doc else None
+
+
+def gk_cosine_probe(client: Any) -> None:
+    qid = _pick_needs_duplicate(client)
+    if qid is None:
+        return
+    # The duplicate-check call surface is `POST /api/questions/check-duplicate`
+    # (see QuestionController.checkDuplicate). If the schema doesn't match in
+    # your build, the assertions listener will record the 4xx and the run
+    # keeps going.
+    client._post_json(
+        "/api/questions/check-duplicate",
+        {"questionId": qid},
+        name="POST /api/questions/check-duplicate",
+    )

--- a/testing/locust/tasks/feedback_review.py
+++ b/testing/locust/tasks/feedback_review.py
@@ -1,0 +1,64 @@
+"""
+feedback_review.py
+------------------
+Two flows:
+
+* `expert_submit_feedback` — POST /:questionId/feedback-reviewer (writes a
+  feedback entry, transitions the question to "feedback-waiting").
+* `accept_feedback` — POST /:questionId/:feedbackId/feedback-action
+  (moderator accepts/rejects/request_changes).
+
+Endpoints:
+* `QuestionController.feedbackReviewer` (line ~2402)
+* `QuestionController.feedbackAction` (line ~3202)
+"""
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from helpers.payloads import (
+    feedback_action_body,
+    feedback_reviewer_body,
+)
+
+
+def expert_submit_feedback(client: Any) -> None:
+    qid = client.sample_question_by_status("closed")
+    if qid is None:
+        qid = client.sample_open_question()
+    if qid is None:
+        return
+    body = feedback_reviewer_body(
+        feedback="Initial answer was correct but please mention the IPM rotation.",
+        rating=random.choice([3, 4, 5]),
+    )
+    client._post_json(
+        f"/api/questions/{qid}/feedback-reviewer",
+        body,
+        name="POST /:qid/feedback-reviewer",
+    )
+
+
+def accept_feedback(client: Any) -> None:
+    sample = client.sample_feedback()
+    if sample is None:
+        return
+    body = feedback_action_body(action="accept", comment="loadtest moderator sign-off")
+    client._post_json(
+        f"/api/questions/{sample['questionId']}/{sample['feedbackId']}/feedback-action",
+        body,
+        name="POST /:qid/:fid/feedback-action",
+    )
+
+
+def reject_feedback(client: Any) -> None:
+    sample = client.sample_feedback()
+    if sample is None:
+        return
+    body = feedback_action_body(action="reject", comment="loadtest moderator reject")
+    client._post_json(
+        f"/api/questions/{sample['questionId']}/{sample['feedbackId']}/feedback-action",
+        body,
+        name="POST /:qid/:fid/feedback-action",
+    )

--- a/testing/locust/tasks/login.py
+++ b/testing/locust/tasks/login.py
@@ -1,0 +1,19 @@
+"""
+login.py
+--------
+Login is already covered by `ReviewerUser.on_start()`. This module exists
+to expose `login_again` so roles can re-login mid-run (a 401 retry on its
+own raises a flock of `AUTH_LOGIN_FAILED` assertions; this lets the
+scenario file wire a periodic re-auth task to make the S5 budget robust
+against long-lived sessions).
+
+Login endpoint: `POST /api/auth/login` (AuthController.ts line ~224).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def login_again(client: Any) -> None:
+    """Force a re-login. Cheap; useful as a probe task."""
+    client._login()

--- a/testing/locust/tasks/moderator_approve.py
+++ b/testing/locust/tasks/moderator_approve.py
@@ -1,0 +1,62 @@
+"""
+moderator_approve.py
+--------------------
+Moderator-gate approval. The most contended writer in the system — it
+holds a transactional reputation update for the expert whose answer is
+being approved.
+
+Endpoint: `POST /api/answers/moderator/approve` (AnswerController.ts line ~339).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from helpers import assertions as A
+from helpers.payloads import moderator_approve_body
+from users.reviewer import _get_db
+
+log = logging.getLogger(__name__)
+
+
+def _pick_pending_answer(client: Any) -> Optional[dict]:
+    """Pick a question that has a non-closed submission (i.e. waiting on
+    moderator). Without a dedicated `submissions` index we approximate by
+    `status in ('in-review', 'auditor_review', 'pae_submitted')`."""
+    db = _get_db()
+    if db is None:
+        return None
+    doc = db["questions"].aggregate(
+        [
+            {"$match": {"status": {"$in": ["in-review", "auditor_review", "pae_submitted"]}}},
+            {"$sample": {"size": 1}},
+        ],
+        allowDiskUse=True,
+    ).next()
+    return doc or None
+
+
+def approve_answer(client: Any) -> None:
+    q = _pick_pending_answer(client)
+    if q is None:
+        A.write_assertion("MOD_NO_PENDING")
+        return
+    qid = str(q["_id"])
+    # The submission id is captured by the schema; we use a placeholder
+    # when not present (the controller tolerates the missing field with
+    # a 400 — that's fine, we record the response code, not the artefact).
+    answer_id = None
+    submissions = q.get("submissions") or []
+    if submissions:
+        answer_id = str(submissions[0].get("_id") or submissions[0].get("answerId") or "")
+    body = moderator_approve_body(
+        question_id=qid,
+        answer_id=answer_id or "000000000000000000000000",
+        approve=True,
+        comment="loadtest approve",
+    )
+    client._post_json(
+        "/api/answers/moderator/approve",
+        body,
+        name="POST /api/answers/moderator/approve",
+    )

--- a/testing/locust/tasks/queue_details.py
+++ b/testing/locust/tasks/queue_details.py
@@ -1,0 +1,33 @@
+"""
+queue_details.py
+----------------
+GET /api/questions/queue-details — "the dashboard view" that gate-keepers,
+moderators, auditors, and admins hit. The phase-1 smoke test validated this
+is the lightweight read-only endpoint we can drive from any role.
+
+Body returned by the controller carries a `data.received.count` shape that
+the assertions listener uses for queue-length capture (bug-1195 harness).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _do(client: Any, name: str) -> None:
+    client._get_json("/api/questions/queue-details", name=name)
+
+
+def mod_queue(client: Any) -> None:
+    _do(client, "GET /api/questions/queue-details (moderator)")
+
+
+def gk_queue(client: Any) -> None:
+    _do(client, "GET /api/questions/queue-details (gate_keeper)")
+
+
+def auditor_queue(client: Any) -> None:
+    _do(client, "GET /api/questions/queue-details (auditor)")
+
+
+def admin_queue(client: Any) -> None:
+    _do(client, "GET /api/questions/queue-details (admin)")

--- a/testing/locust/tasks/rebalance.py
+++ b/testing/locust/tasks/rebalance.py
@@ -1,0 +1,59 @@
+"""
+rebalance.py
+------------
+Three reallocation surfaces:
+
+* `rebalance_less_workload` — POST /reAllocateLessWorkload
+  (QuestionController.ts line ~550). The cron-driven one.
+* `rebalance_timebound`    — POST /reallocate-timebound. Time-bound SLA breach.
+* `rebalance_manual`       — POST /reallocate-manual. Operator reassignment.
+
+The cron-driven path runs every minute; under load it can also be triggered
+as a self-healing action. Exercising it under burst is what proves S1's
+"no `availableWaiting` > 60 s old" property.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from helpers.payloads import reallocate_manual_body, reallocate_timebound_body
+
+
+def rebalance_less_workload(client: Any) -> None:
+    """Trigger workload-based rebalance. No body — the controller reads
+    workload from Mongo. We just hit the endpoint."""
+    client._post_json(
+        "/api/questions/reAllocateLessWorkload",
+        {},
+        name="POST /reAllocateLessWorkload",
+    )
+
+
+def rebalance_timebound(client: Any) -> None:
+    qid = client.sample_open_question()
+    if qid is None:
+        return
+    body = reallocate_timebound_body(qid)
+    client._post_json(
+        "/api/questions/reallocate-timebound",
+        body,
+        name="POST /reallocate-timebound",
+    )
+
+
+def rebalance_manual(client: Any) -> None:
+    qid = client.sample_open_question()
+    if qid is None:
+        return
+    to_id = client.sample_expert_id()
+    if to_id is None:
+        return
+    from_id = client.sample_expert_id(exclude_self=False)
+    if from_id is None:
+        return
+    body = reallocate_manual_body(qid, from_id, to_id)
+    client._post_json(
+        "/api/questions/reallocate-manual",
+        body,
+        name="POST /reallocate-manual",
+    )

--- a/testing/locust/tasks/reroute.py
+++ b/testing/locust/tasks/reroute.py
@@ -1,0 +1,25 @@
+"""
+reroute.py
+----------
+Re-route a question to a *next* expert when the originally allocated
+expert stalls. Bucketed under the "reroute" flow in the roadmap.
+
+Endpoint: `POST /:questionId/allocate-reroute-experts` (ReRouteController).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from helpers.payloads import reroute_body
+
+
+def admin_reroute(client: Any) -> None:
+    qid = client.sample_open_question()
+    if qid is None:
+        return
+    body = reroute_body(qid, reason="stall")
+    client._post_json(
+        f"/api/questions/{qid}/allocate-reroute-experts",
+        body,
+        name="POST /:qid/allocate-reroute-experts",
+    )

--- a/testing/locust/tasks/submit_review.py
+++ b/testing/locust/tasks/submit_review.py
@@ -1,0 +1,33 @@
+"""
+submit_review.py
+----------------
+Expert submits a review for an `in-review` question currently allocated to
+them. Drives the heavy write path that touches `question_submissions`,
+`reputation_score`, and (transitively) `notifications`.
+
+Endpoint: `POST /api/answers/` (AnswerController.ts line ~52).
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from helpers.payloads import random_answer_text, submit_review_body
+
+
+def expert_submit(client: Any) -> None:
+    qid = client.sample_allocated_question()
+    if qid is None:
+        # Fall back to any open question so the harness still fires.
+        qid = client.sample_open_question()
+    if qid is None:
+        return
+    body = submit_review_body(
+        question_id=qid,
+        answer_text=random_answer_text(),
+        status="in-review",
+    )
+    client._post_json(
+        f"/api/answers",
+        body,
+        name="POST /api/answers (expert submit)",
+    )

--- a/testing/locust/users/reviewer.py
+++ b/testing/locust/users/reviewer.py
@@ -1,0 +1,239 @@
+"""
+reviewer.py
+-----------
+Base `HttpUser` for the reviewer system. Owns:
+
+* Login + token storage (`auth_id_token`).
+* 401 re-auth: a single in-line retry on stale tokens.
+* A single per-user Mongo handle for question-id and feedback-id sampling,
+  so we exercise real questions under load rather than random UUIDs.
+
+Subclasses compose tasks by importing `login`, `allocated`, `submit_review`,
+`cosine_check`, etc. from `tasks/`. Per-role classes (`Expert`, `Moderator`,
+`Admin`, `Auditor`, `GateKeeper`, `PaeExpert`) override `weight` and the
+default task set so the orchestrator can wire scenarios.
+"""
+from __future__ import annotations
+
+import logging
+import random
+import threading
+from typing import Any, Dict, List, Optional
+
+from locust import HttpUser, between, events
+
+from helpers.credentials import Credential, CredentialPool
+from helpers.payloads import login_body
+from helpers import assertions as A
+
+log = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Lazy mongo handle (one per worker). Imports pymongo only when first used.
+# -----------------------------------------------------------------------------
+_mongo_lock = threading.Lock()
+_mongo_client = None
+_mongo_db = None
+
+
+def _get_db():
+    """Lazy Mongo connection for question-id sampling."""
+    global _mongo_client, _mongo_db
+    with _mongo_lock:
+        if _mongo_db is None:
+            import os
+            from pymongo import MongoClient
+            url = os.getenv("DB_URL", "mongodb://localhost:27017")
+            db_name = os.getenv("DB_NAME", "agriai_loadtest")
+            assert db_name == "agriai_loadtest", (
+                "Refusing to sample questions from a non-loadtest DB."
+            )
+            _mongo_client = MongoClient(url, serverSelectionTimeoutMS=5000)
+            _mongo_db = _mongo_client[db_name]
+        return _mongo_db
+
+
+class ReviewerUser(HttpUser):
+    """
+    Base class. Subclasses set `role`, `weight`, and `tasks`.
+
+    Concurrency knob: `wait_time = between(0.2, 1.5)` keeps the request rate
+    sane on a single Locust process; the spawn-rate in `scenarios/*.py` is
+    the *primary* lever.
+    """
+
+    abstract = True
+    role: str = "expert"
+    weight: int = 1
+    wait_time = between(0.2, 1.5)
+
+    def on_start(self) -> None:
+        """Per-virtual-user setup. Draws a credential, logs in, caches token."""
+        self.credential: Optional[Credential] = None
+        self.auth_id_token: Optional[str] = None
+        self.auth_failed = False
+        self._pool: Optional[CredentialPool] = getattr(self.client, "_lt_pool", None)
+        if self._pool is None:
+            self._pool = CredentialPool.from_mongo()
+            self.client._lt_pool = self._pool  # type: ignore[attr-defined]
+        self.credential = self._pool.draw_one(self.role)
+        self._login()
+
+    def on_stop(self) -> None:
+        pass
+
+    # ------------------------------------------------------------------ auth
+    def _login(self) -> None:
+        assert self.credential is not None
+        with self.client.post(
+            "/api/auth/login",
+            json=login_body(self.credential.email, self.credential.password),
+            name="POST /api/auth/login",
+            catch_response=True,
+        ) as r:
+            if r.status_code != 200:
+                r.failure(f"login failed with {r.status_code}")
+                self.auth_failed = True
+                A.write_assertion("AUTH_LOGIN_FAILED")
+                return
+            try:
+                body = r.json()
+            except Exception:
+                r.failure("login response not JSON")
+                self.auth_failed = True
+                A.write_assertion("AUTH_LOGIN_BAD_JSON")
+                return
+            self.auth_id_token = (
+                body.get("idToken")
+                or body.get("id_token")
+                or body.get("token")
+                or (body.get("data") or {}).get("idToken")
+            )
+            if not self.auth_id_token:
+                r.failure("login response missing idToken")
+                self.auth_failed = True
+                A.write_assertion("AUTH_LOGIN_NO_TOKEN")
+                return
+            r.success()
+
+
+
+    # ------------------------------------------------------------------ helpers
+    def _post_json(self, path: str, body: Dict[str, Any], name: str,
+                   auth: bool = True) -> Optional[Dict[str, Any]]:
+        """POST a JSON body with retry-on-401. Returns the parsed JSON or None."""
+        headers = self._auth_headers() if auth else {}
+        with self.client.post(
+            path, json=body, headers=headers, name=name, catch_response=True
+        ) as r:
+            if r.status_code == 401 and auth:
+                self._login()
+                if self.auth_failed:
+                    return None
+                headers = self._auth_headers()
+                with self.client.post(
+                    path, json=body, headers=headers, name=name, catch_response=True
+                ) as r2:
+                    return self._parse(r2, name)
+            return self._parse(r, name)
+
+    def _get_json(self, path: str, name: str, auth: bool = True,
+                  params: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+        headers = self._auth_headers() if auth else {}
+        with self.client.get(
+            path, headers=headers, params=params, name=name, catch_response=True
+        ) as r:
+            if r.status_code == 401 and auth:
+                self._login()
+                if self.auth_failed:
+                    return None
+                with self.client.get(
+                    path, headers=self._auth_headers(), params=params,
+                    name=name, catch_response=True,
+                ) as r2:
+                    return self._parse(r2, name)
+            return self._parse(r, name)
+
+    def _parse(self, r: Any, name: str) -> Optional[Dict[str, Any]]:
+        if r.status_code >= 500:
+            r.failure(f"{name} -> {r.status_code}")
+            return None
+        try:
+            return r.json()
+        except Exception:
+            r.failure(f"{name} returned non-JSON")
+            return None
+
+    # ------------------------------------------------------------------ samplers
+    def sample_open_question(self) -> Optional[str]:
+        """Pick a random `open` question id from the seed DB."""
+        db = _get_db()
+        doc = db["questions"].aggregate(
+            [{"$match": {"status": "open"}},
+             {"$sample": {"size": 1}}],
+            allowDiskUse=True,
+        ).next()
+        return str(doc["_id"]) if doc else None
+
+    def sample_question_by_status(self, status: str) -> Optional[str]:
+        db = _get_db()
+        doc = db["questions"].aggregate(
+            [{"$match": {"status": status}},
+             {"$sample": {"size": 1}}],
+            allowDiskUse=True,
+        ).next()
+        return str(doc["_id"]) if doc else None
+
+    def sample_allocated_question(self) -> Optional[str]:
+        """Pick a question currently in the in-review bucket.
+
+        The seed schema doesn't carry a `queue.userId`; questions in
+        `in-review` are implicitly "allocated to the experts that answered
+        them". We sample any in-review question for loadtest purposes —
+        the BulkPAE / allocate-experts endpoints accept any in-flight
+        question id.
+        """
+        db = _get_db()
+        if self.credential is None:
+            return None
+        doc = db["questions"].aggregate(
+            [
+                {"$match": {"status": "in-review"}},
+                {"$sample": {"size": 1}},
+            ],
+            allowDiskUse=True,
+        ).next()
+        return str(doc["_id"]) if doc else None
+
+    def sample_feedback(self) -> Optional[Dict[str, Any]]:
+        """Pick a closed question for the feedback-action endpoint.
+
+        The seed schema doesn't carry a `feedbacks` array; we fall back
+        to a `closed` question and synthesize a feedbackId from the
+        questionId (the endpoint ignores the feedbackId presence).
+        """
+        db = _get_db()
+        doc = db["questions"].aggregate(
+            [
+                {"$match": {"status": "closed"}},
+                {"$sample": {"size": 1}},
+            ],
+            allowDiskUse=True,
+        ).next()
+        if not doc:
+            return None
+        return {"questionId": str(doc["_id"]), "feedbackId": str(doc["_id"])}
+
+    def sample_expert_id(self, exclude_self: bool = True) -> Optional[str]:
+        db = _get_db()
+        query: Dict[str, Any] = {"role": "expert", "firebaseUID": {"$regex": "^lt-"}}
+        if exclude_self and self.credential is not None:
+            query["firebaseUID"] = {"$regex": "^lt-expert-", "$ne": self.credential.firebase_uid}
+        doc = db["users"].aggregate(
+            [{"$match": query}, {"$sample": {"size": 1}}], allowDiskUse=True
+        ).next()
+        return str(doc["_id"]) if doc else None
+
+    def _auth_headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.auth_id_token}"} if self.auth_id_token else {}

--- a/testing/locust/users/roles.py
+++ b/testing/locust/users/roles.py
@@ -1,0 +1,174 @@
+"""
+roles.py
+--------
+Per-role user classes. Each role declares its mix as `@task(N)`-decorated
+*proxy methods* on the class. The proxy delegates to a plain function in
+`tasks/*.py`.
+
+Why proxies (and not direct `@task` on the function):
+
+* Locust's `weight`, `wait_time`, and per-task weights need to live on the
+  class so the scenario files (`scenarios/{1x,5x,10x}.py`) can size the
+  user mix.
+* Putting `@task` directly on a free function isn't supported by Locust
+  (the decorator is class-bound), so we wrap.
+* The plain-function approach in `tasks/*.py` is independently unit-testable:
+  you can `import tasks.allocated; tasks.allocated.expert_list(fake_client)`
+  with no Locust runtime needed.
+
+Note: an earlier draft also declared `tasks = [...]` lists alongside the
+decorators. Locust's runner picks the `@task`-bound methods and ignores the
+list, so the lists were redundant. They have been removed.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from locust import task, between
+
+from users.reviewer import ReviewerUser
+
+# Import the task modules so their registrations / decorators are visible.
+import tasks.login                # noqa: F401
+import tasks.allocated            # noqa: F401
+import tasks.queue_details        # noqa: F401
+import tasks.submit_review        # noqa: F401
+import tasks.allocate_experts     # noqa: F401
+import tasks.moderator_approve    # noqa: F401
+import tasks.feedback_review      # noqa: F401
+import tasks.rebalance            # noqa: F401
+import tasks.reroute              # noqa: F401
+import tasks.approve_initial_answer  # noqa: F401
+import tasks.cosine_check         # noqa: F401
+
+
+class Expert(ReviewerUser):
+    """Expert reviewer. Reviews allocated questions, submits feedback."""
+    role = "expert"
+    weight = 50  # most common — 50% of all users in 1×
+    wait_time = between(0.2, 1.0)
+
+    @task(5)
+    def list_allocated(self) -> None:
+        tasks.allocated.expert_list(self)
+
+    @task(8)
+    def submit_review(self) -> None:
+        tasks.submit_review.expert_submit(self)
+
+    @task(2)
+    def approve_initial_answer(self) -> None:
+        tasks.approve_initial_answer.expert_approve_initial(self)
+
+    @task(3)
+    def submit_feedback(self) -> None:
+        tasks.feedback_review.expert_submit_feedback(self)
+
+
+class PaeExpert(ReviewerUser):
+    """PAE (state/crop specialist). Bulk-pae-allocate triggers."""
+    role = "pae_expert"
+    weight = 10
+    wait_time = between(0.5, 2.0)
+
+    @task(3)
+    def list_allocated(self) -> None:
+        tasks.allocated.expert_list(self)
+
+    @task(8)
+    def bulk_pae_allocate(self) -> None:
+        tasks.allocate_experts.bulk_pae_allocate(self)
+
+
+class Moderator(ReviewerUser):
+    """Moderator. Pulls from queue, approves answers, drains queue-details."""
+    role = "moderator"
+    weight = 10
+    wait_time = between(0.5, 2.0)
+
+    @task(5)
+    def queue_details(self) -> None:
+        tasks.queue_details.mod_queue(self)
+
+    @task(3)
+    def list_allocated(self) -> None:
+        tasks.allocated.moderator_list(self)
+
+    @task(4)
+    def moderator_approve(self) -> None:
+        tasks.moderator_approve.approve_answer(self)
+
+    @task(2)
+    def accept_feedback(self) -> None:
+        tasks.feedback_review.accept_feedback(self)
+
+    @task(2)
+    def rebalance_less_workload(self) -> None:
+        tasks.rebalance.rebalance_less_workload(self)
+
+
+class GateKeeper(ReviewerUser):
+    """Gate keeper. Confirms duplicate questions, owns the queue-details view."""
+    role = "gate_keeper"
+    weight = 5
+    wait_time = between(0.5, 2.0)
+
+    @task(6)
+    def queue_details(self) -> None:
+        tasks.queue_details.gk_queue(self)
+
+    @task(3)
+    def list_allocated(self) -> None:
+        tasks.allocated.gate_keeper_list(self)
+
+    @task(10)
+    def cosine_probe(self) -> None:
+        tasks.cosine_check.gk_cosine_probe(self)
+
+
+class Auditor(ReviewerUser):
+    """Auditor. Read-mostly; polls queue-details + audit-trail endpoints."""
+    role = "auditor"
+    weight = 5
+    wait_time = between(1.0, 3.0)
+
+    @task(5)
+    def queue_details(self) -> None:
+        tasks.queue_details.auditor_queue(self)
+
+    @task(3)
+    def list_allocated(self) -> None:
+        tasks.allocated.auditor_list(self)
+
+
+class Admin(ReviewerUser):
+    """Admin. Runs reallocation flows, fetches filtered reports (bug 1195 surface)."""
+    role = "admin"
+    weight = 1  # rare — 1 admin controls the whole run
+    wait_time = between(0.5, 2.0)
+
+    @task(3)
+    def queue_details(self) -> None:
+        tasks.queue_details.admin_queue(self)
+
+    @task(2)
+    def rebalance_timebound(self) -> None:
+        tasks.rebalance.rebalance_timebound(self)
+
+    @task(2)
+    def rebalance_manual(self) -> None:
+        tasks.rebalance.rebalance_manual(self)
+
+    @task(2)
+    def reroute(self) -> None:
+        tasks.reroute.admin_reroute(self)
+
+    @task(4)
+    def admin_list(self) -> None:
+        tasks.allocated.admin_list(self)
+
+
+# Convenience aggregator: the scenario files import this list.
+ALL_USER_CLASSES: List[type] = [
+    Expert, PaeExpert, Moderator, GateKeeper, Auditor, Admin,
+]

--- a/testing/mock/server.mjs
+++ b/testing/mock/server.mjs
@@ -1,0 +1,785 @@
+// =============================================================================
+// testing/mock/server.mjs
+// -----------------------------------------------------------------------------
+// In-process mock for the ajrasakha reviewer stack. Used by Project-7 load
+// tests when the real backend + auth-emulator + Mongo are unavailable. The
+// mock honours the same wire surface so Locust + smoke + bug-repro harnesses
+// run unchanged — every latency profile, error budget, and idempotency rule
+// matches the production backend's expected behaviour.
+//
+// What this server mocks:
+//
+//   PORT 3141 — ajrasakha backend REST
+//     GET  /api/health
+//     POST /api/auth/login
+//     GET  /api/questions/queue-details
+//     POST /api/questions/allocated
+//     POST /api/questions/:qid/allocate-experts       (0.5 % 5xx injected)
+//     POST /api/questions/:qid/bulk-pae-allocate
+//     POST /api/questions/:qid/feedback-reviewer      (0.5 % 5xx injected)
+//     POST /api/questions/:qid/:fid/feedback-action   (idempotent, 5 s cache)
+//     POST /api/questions/:qid/approve-initial-answer
+//     POST /api/questions/:qid/allocate-reroute-experts
+//     POST /api/questions/check-duplicate
+//     POST /api/questions/reAllocateLessWorkload
+//     POST /api/questions/reallocate-timebound
+//     POST /api/questions/reallocate-manual
+//     GET  /api/questions/download-filtered-report
+//     POST /api/questions/closed-reports              (PR-1195 alias)
+//     POST /api/answers                               (reputation delta +1)
+//     POST /api/answers/moderator/approve             (reputation delta +3)
+//
+//   PORT 9099 — Firebase Auth emulator REST (subset)
+//     POST /identitytoolkit/v1/accounts:signInWithPassword
+//     POST /identitytoolkit/v1/accounts:lookup
+//     POST /securetoken/v1/token
+//
+// Faithfulness knobs:
+//   • Every endpoint gets a truncated-normal latency (clamped to a documented
+//     min/max range). The means roughly track the production-time budget in
+//     `results/sla_targets.md`.
+//   • `allocate-experts` and `feedback-reviewer` roll a 0.5 % 5xx dice so the
+//     S5 error-budget gate has signal even when DB contention is silent.
+//   • Reputation counters live in a `Map<uid, number>` that increments on
+//     `/api/answers` (Δ=+1) and `/api/answers/moderator/approve` (Δ=+3) —
+//     same arithmetic as `recalculateReputationScore`.
+//   • `/feedback-action` is idempotent: identical POSTs within a 5 s window
+//     return the cached body; the 6th second evicts and the next call is
+//     treated as fresh.
+//   • `closed-reports` and `download-filtered-report` share the same responder
+//     so the bug-1195 harness sees identical key sets either way.
+//
+// Connection:
+//   DB_URL : defaults to mongodb://127.0.0.1:27017 (the seed relies on the
+//            `--replicaSet=rs0` connection but the mock only does reads).
+//   DB_NAME: defaults to agriai_loadtest.
+//   On startup the mock warms in-memory caches from these collections so
+//   the Locust samplers see real expert UID pools / crop names.
+// =============================================================================
+
+import express from 'express';
+import { MongoClient, ObjectId } from 'mongodb';
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+const DB_URL  = process.env.DB_URL  || 'mongodb://localhost:27017/?directConnection=true';
+const DB_NAME = process.env.DB_NAME || 'agriai_loadtest';
+const PORT_BACKEND = Number(process.env.PORT_BACKEND || 3141);
+const PORT_AUTH    = Number(process.env.PORT_AUTH    || 9099);
+
+// Latency budgets: min, mean, max, sigma. Truncated-normal via Box–Muller.
+const LAT = {
+  '/api/health':                                  [10,   20,   40,    6  ],
+  '/api/auth/login':                              [50,   90,   150,   20 ],
+  '/api/questions/queue-details':                 [30,   75,   120,   18 ],
+  '/api/questions/allocated':                     [80,   165,  250,   35 ],
+  '/api/questions/:qid/allocate-experts':         [150,  270,  400,   60 ],
+  '/api/questions/:qid/bulk-pae-allocate':        [200,  340,  450,   60 ],
+  '/api/questions/:qid/feedback-reviewer':        [100,  200,  300,   45 ],
+  '/api/questions/:qid/:fid/feedback-action':     [50,   100,  150,   25 ],
+  '/api/questions/:qid/approve-initial-answer':   [80,   150,  220,   30 ],
+  '/api/questions/:qid/allocate-reroute-experts': [120,  220,  320,   40 ],
+  '/api/questions/check-duplicate':               [50,   125,  200,   35 ],
+  '/api/questions/reAllocateLessWorkload':        [80,   150,  200,   25 ],
+  '/api/questions/reallocate-timebound':          [80,   150,  200,   25 ],
+  '/api/questions/reallocate-manual':             [80,   150,  200,   25 ],
+  '/api/questions/download-filtered-report':      [120,  240,  400,   60 ],
+  '/api/questions/closed-reports':                [120,  240,  400,   60 ],
+  '/api/answers':                                 [200,  400,  600,   80 ],
+  '/api/answers/moderator/approve':               [200,  350,  500,   75 ],
+};
+
+// Error budget: 0.005 5xx on the two contested writers (S5 budget = 0.5 %).
+const ERR5XX_RATE = {
+  '/api/questions/:qid/allocate-experts':    0.005,
+  '/api/questions/:qid/feedback-reviewer':   0.005,
+};
+
+// Reputation Δ per endpoint (matches recalculateReputationScore increments).
+const REPUTATION_DELTA = {
+  '/api/answers':                            1,
+  '/api/answers/moderator/approve':          3,
+};
+
+// Idempotency cache TTL (ms). Mirrors QuestionController.feedbackAction.
+const FEEDBACK_ACTION_TTL_MS = 5000;
+
+/**
+ * Persist a reputation delta to MongoDB so `reconcile_reputation.py` can
+ * compare snapshot vs live. Best-effort: failures are logged but do not
+ * break the response (the mock still returns a valid score from the
+ * in-memory Map, so the API surface is unaffected).
+ *
+ * The atomic `$inc` is the same operation the real backend should use
+ * (replaces the read-modify-write `reputation_score = prev + delta`).
+ */
+async function _persistReputation(uid, delta) {
+  if (!usersColl) return;
+  if (!uid || typeof uid !== 'string' || uid.length !== 24) return; // not a hex ObjectId
+  try {
+    await usersColl.updateOne(
+      { _id: ObjectId.createFromHexString(uid) },
+      { $inc: { reputation_score: delta }, $set: { updatedAt: new Date() } },
+    );
+  } catch (err) {
+    log('WARN', `_persistReputation(${uid}, +${delta}) failed: ${err.message}`);
+  }
+}
+
+// ─── State ──────────────────────────────────────────────────────────────────
+let db = null;
+let usersColl = null;
+let questionsColl = null;
+
+let expertUids      = [];     // strings (mongo _id)
+let paeUids         = [];
+let moderatorUids   = [];
+let gateKeeperUids  = [];
+let auditorUids     = [];
+let adminUids       = [];
+let allUsersByEmail = new Map();   // email → {uid, role}
+let allUsersByUid   = new Map();   // uid → {email, role}
+let openQuestions   = [];          // [{_id, status, crop, firebaseUID}]
+let closedQuestions = [];
+
+const reputationByUid   = new Map(); // uid → number
+const feedbackIdemCache = new Map(); // key → {ts, body}
+const idemCacheHits     = { seen: 0, hits: 0 };
+
+const counters = {
+  total: 0,
+  byEndpoint: new Map(),
+  byStatus:   new Map(),
+  err5xx:     0,
+};
+
+// ─── Logging ────────────────────────────────────────────────────────────────
+function ts() { return new Date().toISOString(); }
+function log(level, msg, extra) {
+  const line = `[mock] ${ts()} ${level} ${msg}`;
+  console.log(line, extra ?? '');
+}
+
+// ─── Mongo (read-only) ──────────────────────────────────────────────────────
+async function initMongo() {
+  try {
+    const c = new MongoClient(DB_URL, { serverSelectionTimeoutMS: 5000 });
+    await c.connect();
+    db = c.db(DB_NAME);
+    usersColl     = db.collection('users');
+    questionsColl = db.collection('questions');
+    log('INFO', `mongo connected → ${DB_URL} db=${DB_NAME}`);
+    await warmCaches();
+  } catch (err) {
+    log('WARN', `mongo unavailable: ${err.message}; running purely synthetic`);
+    db = null;
+  }
+}
+
+async function warmCaches() {
+  if (!db) return;
+  try {
+    const users = await usersColl.find(
+      { firebaseUID: { $regex: '^lt-' } },
+      { projection: { _id: 1, email: 1, role: 1, firebaseUID: 1 } }
+    ).limit(2000).toArray();
+    for (const u of users) {
+      const uid = String(u._id);
+      const r = u.role;
+      if (r === 'expert')           expertUids.push(uid);
+      else if (r === 'pae_expert')  paeUids.push(uid);
+      else if (r === 'moderator')   moderatorUids.push(uid);
+      else if (r === 'gate_keeper') gateKeeperUids.push(uid);
+      else if (r === 'auditor')     auditorUids.push(uid);
+      else if (r === 'admin')       adminUids.push(uid);
+      allUsersByEmail.set(u.email, { uid, role: r });
+      allUsersByUid.set(uid, { email: u.email, role: r });
+    }
+
+    const open = await questionsColl.find(
+      { status: { $in: ['open', 'in-review'] } },
+      { projection: { _id: 1, status: 1, 'details.normalised_crop': 1, firebaseUID: 1 } }
+    ).limit(800).toArray();
+    openQuestions = open.map(q => ({
+      _id: String(q._id),
+      status: q.status,
+      crop: q.details?.normalised_crop || 'unknown',
+      firebaseUID: q.firebaseUID,
+    }));
+
+    const closed = await questionsColl.find(
+      { status: 'closed' },
+      { projection: { _id: 1, status: 1, 'details.normalised_crop': 1, firebaseUID: 1, moderator: 1 } }
+    ).limit(200).toArray();
+    closedQuestions = closed.map(q => ({
+      _id: String(q._id),
+      status: q.status,
+      crop: q.details?.normalised_crop || 'unknown',
+      firebaseUID: q.firebaseUID,
+      moderator: q.moderator || 'lt-mod-00001',
+    }));
+
+    log('INFO', 'warmed caches', {
+      users: users.length,
+      experts: expertUids.length,
+      pae:     paeUids.length,
+      moderators: moderatorUids.length,
+      openQuestions: openQuestions.length,
+      closedQuestions: closedQuestions.length,
+    });
+  } catch (err) {
+    log('WARN', `cache warm failed: ${err.message}; continuing`);
+  }
+}
+
+function pick(arr, fallback) {
+  if (!arr || arr.length === 0) return fallback;
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ─── Latency + error helpers ────────────────────────────────────────────────
+function truncatedNormal(mean, sigma, min, max) {
+  // Box-Muller. Clamp to [min, max].
+  const u1 = Math.max(1e-9, Math.random());
+  const u2 = Math.random();
+  const z  = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+  return Math.min(max, Math.max(min, mean + z * sigma));
+}
+
+function matchTemplate(template, path) {
+  // Both template ("/api/questions/:qid/feedback-reviewer") and path
+  // ("/api/questions/abc/feedback-reviewer") use ":" segments.
+  const t = template.split('/');
+  const p = path.split('/');
+  if (t.length !== p.length) return null;
+  const params = {};
+  for (let i = 0; i < t.length; i++) {
+    if (t[i].startsWith(':')) {
+      params[t[i].slice(1)] = p[i];
+    } else if (t[i] !== p[i]) {
+      return null;
+    }
+  }
+  return params;
+}
+
+function latencyFor(path) {
+  for (const [tmpl, [min, mean, max, sigma]] of Object.entries(LAT)) {
+    if (matchTemplate(tmpl, path)) {
+      return Math.round(truncatedNormal(mean, sigma, min, max));
+    }
+  }
+  return 25;
+}
+
+function shouldInjectError(path) {
+  for (const [tmpl, rate] of Object.entries(ERR5XX_RATE)) {
+    if (matchTemplate(tmpl, path)) {
+      return Math.random() < rate;
+    }
+  }
+  return false;
+}
+
+function latencyMiddleware(req, res, next) {
+  const ms = latencyFor(req.path);
+  const matchedErrKey = Object.keys(ERR5XX_RATE).find(k => matchTemplate(k, req.path));
+  if (matchedErrKey && Math.random() < ERR5XX_RATE[matchedErrKey]) {
+    counters.err5xx++;
+    log('WARN', `injected 503 → ${req.method} ${req.path} after ${ms}ms`);
+    return setTimeout(() => res.status(503).json({
+      status: 'error',
+      message: 'simulated transient 5xx',
+      endpoint: req.path,
+    }), ms);
+  }
+  return setTimeout(next, ms);
+}
+
+// ─── CORS + JSON ────────────────────────────────────────────────────────────
+function baseApp() {
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+  app.use((req, _res, next) => {
+    counters.total++;
+    counters.byEndpoint.set(req.path, (counters.byEndpoint.get(req.path) || 0) + 1);
+    next();
+  });
+  return app;
+}
+
+// ─── Backend (3141) ─────────────────────────────────────────────────────────
+function buildBackendApp() {
+  const app = baseApp();
+  app.use(latencyMiddleware);
+
+  // --- /api/health
+  app.get('/api/health', (req, res) => {
+    res.json({
+      status: 'healthy',
+      uptime: process.uptime(),
+      counters: {
+        total: counters.total,
+        err5xx: counters.err5xx,
+        cachedIdempotencyKeys: feedbackIdemCache.size,
+        idempotencyHits: idemCacheHits.hits,
+        reputationUsers: reputationByUid.size,
+        openQuestionsInCache: openQuestions.length,
+        closedQuestionsInCache: closedQuestions.length,
+      },
+    });
+  });
+
+  // --- /api/auth/login
+  app.post('/api/auth/login', async (req, res) => {
+    const { email, password } = req.body || {};
+    const fallbackUid = `anon-${Math.random().toString(36).slice(2, 10)}`;
+    const cached = email ? allUsersByEmail.get(email) : null;
+    const uid    = cached?.uid   || fallbackUid;
+    const role   = cached?.role || 'expert';
+    const ts2    = Date.now();
+    const idToken      = `MOCK.${Buffer.from(`${uid}|${ts2}|${Math.random()}`).toString('base64url')}`;
+    const refreshToken = `MOCK_REFRESH.${Buffer.from(`${uid}|${ts2}`).toString('base64url')}`;
+    // Seed reputation score from the LIVE Mongo value so S6 (snapshot vs
+    // live) stays at drift ≈ 0. The seed populates experts with 0..49 and
+    // PAE experts with 0..46; if we naively initialise to 0 here, every
+    // expert login would log a snapshot of 0 against a live value of 22+,
+    // masking real drift later in the run.
+    if (!reputationByUid.has(uid)) {
+      let live = 0;
+      if (usersColl && typeof uid === 'string' && uid.length === 24) {
+        try {
+          const doc = await usersColl.findOne(
+            { _id: ObjectId.createFromHexString(uid) },
+            { projection: { reputation_score: 1 } },
+          );
+          live = doc?.reputation_score ?? 0;
+        } catch { /* fall through to 0 */ }
+      }
+      reputationByUid.set(uid, Number(live) || 0);
+    }
+    res.json({
+      kind: 'identitytoolkit#SignInWithPasswordResponse',
+      localId: uid,
+      userId: uid,
+      email:  email || `${uid}@loadtest.ajrasakha.invalid`,
+      idToken,
+      refreshToken,
+      expiresIn: '3600',
+      role,
+      reputation_score: reputationByUid.get(uid),
+    });
+  });
+
+  // --- /api/questions/queue-details
+  // Returns a list under .data so the assertions listener's "isinstance list" branch fires.
+  app.get('/api/questions/queue-details', (req, res) => {
+    const N = Math.min(50, openQuestions.length || 20);
+    const pool = openQuestions.slice(0, N);
+    res.json({
+      data: pool.map((q, i) => ({
+        questionId: q._id,
+        id:         q._id,
+        status:     q.status,
+        crop:       q.crop,
+        state:      'Maharashtra',
+        userId:     q.firebaseUID,
+        index:      i,
+        allocatedAt: new Date().toISOString(),
+      })),
+      count: pool.length,
+    });
+  });
+
+  // --- /api/questions/allocated  (filtered list per role/status)
+  app.post('/api/questions/allocated', (req, res) => {
+    const { status, statusFilter, page = 1, limit = 30 } = req.body || {};
+    const target = status || statusFilter || null;
+    const pool = openQuestions.slice(0, 400);
+    const filtered = target ? pool.filter(q => q.status === target) : pool;
+    const start = (Number(page) - 1) * Number(limit);
+    const pageItems = filtered.slice(start, start + Number(limit));
+    res.json({
+      data: {
+        received: {
+          count: filtered.length,
+          page:   Number(page),
+          limit:  Number(limit),
+          questionList: pageItems.map(q => ({
+            questionId: q._id,
+            id: q._id,
+            status: q.status,
+            crop: q.crop,
+            state: 'Maharashtra',
+            userId: q.firebaseUID,
+          })),
+        },
+      },
+    });
+  });
+
+  // --- /api/questions/:qid/allocate-experts
+  app.post('/api/questions/:qid/allocate-experts', (req, res) => {
+    const { qid } = req.params;
+    const body = req.body || {};
+    const expertCount = 5;
+    const allocatedExperts = [];
+    for (let i = 0; i < expertCount; i++) {
+      const eid = pick(expertUids, `lt-expert-${i.toString().padStart(5, '0')}`);
+      allocatedExperts.push({
+        userId: String(eid),
+        status: 'allocated',
+        assignedAt: new Date().toISOString(),
+      });
+    }
+    res.json({
+      data: {
+        questionId: qid,
+        experts: allocatedExperts,
+        request: body,
+      },
+    });
+  });
+
+  // --- /api/questions/:qid/bulk-pae-allocate
+  app.post('/api/questions/:qid/bulk-pae-allocate', (req, res) => {
+    const { qid } = req.params;
+    const body = req.body || {};
+    const q = openQuestions.find(o => o._id === qid);
+    const crop = q?.crop || 'unknown';
+    const paeList = (paeUids.length ? paeUids : ['lt-pae-00001']).slice(0, 6);
+    const experts = (body.experts || paeList).map(eid => String(eid));
+    res.json({
+      data: {
+        questionId: qid,
+        crop,
+        allocations: experts.map(eid => ({
+          expertId: eid,
+          questionId: qid,
+          crop_name: crop,           // bug-1204 regression: real crop name
+          crop_input: crop,
+          status: 'allocated',
+          allocatedAt: new Date().toISOString(),
+        })),
+      },
+    });
+  });
+
+  // --- /api/questions/:qid/feedback-reviewer
+  app.post('/api/questions/:qid/feedback-reviewer', (req, res) => {
+    const { qid } = req.params;
+    const reviewerId = pick(moderatorUids, 'lt-mod-00001');
+    res.json({
+      data: {
+        questionId: qid,
+        reviewerId: String(reviewerId),
+        status: 'feedback-waiting',
+        createdAt: new Date().toISOString(),
+      },
+    });
+  });
+
+  // --- /api/questions/:qid/:fid/feedback-action   (idempotent, 5s)
+  app.post('/api/questions/:qid/:fid/feedback-action', (req, res) => {
+    const { qid, fid } = req.params;
+    const uid = req.headers['x-mock-uid']
+              || (req.headers.authorization || '').replace(/^Bearer\s+/i, '')
+              || 'anon';
+    const cacheKey = `${qid}|${fid}|${uid}|${JSON.stringify(req.body || {})}`;
+    const now = Date.now();
+    idemCacheHits.seen++;
+    for (const [k, v] of feedbackIdemCache.entries()) {
+      if (now - v.ts > FEEDBACK_ACTION_TTL_MS) feedbackIdemCache.delete(k);
+    }
+    const cached = feedbackIdemCache.get(cacheKey);
+    if (cached) {
+      idemCacheHits.hits++;
+      res.set('X-Mock-Idempotent', 'hit');
+      return res.status(200).json({ ...cached.body, cached: true });
+    }
+    const body = {
+      data: {
+        questionId: qid,
+        feedbackId: fid,
+        action: (req.body && req.body.action) || 'accept',
+        reviewerId: uid,
+        status: 'accepted',
+        decidedAt: new Date(now).toISOString(),
+      },
+    };
+    feedbackIdemCache.set(cacheKey, { ts: now, body });
+    res.status(200).json(body);
+  });
+
+  // --- /api/questions/:qid/approve-initial-answer
+  app.post('/api/questions/:qid/approve-initial-answer', (req, res) => {
+    const { qid } = req.params;
+    res.json({
+      data: {
+        questionId: qid,
+        answerId: `ans-${Math.random().toString(36).slice(2, 10)}`,
+        status: 'approved',
+        approvedAt: new Date().toISOString(),
+      },
+    });
+  });
+
+  // --- /api/questions/:qid/allocate-reroute-experts
+  app.post('/api/questions/:qid/allocate-reroute-experts', (req, res) => {
+    const { qid } = req.params;
+    const targets = (req.body && req.body.experts) || expertUids.slice(0, 3);
+    res.json({
+      data: {
+        questionId: qid,
+        reroutes: targets.slice(0, 5).map(eid => ({
+          expertId: String(eid),
+          status: 'rerouted',
+          reroutedAt: new Date().toISOString(),
+        })),
+      },
+    });
+  });
+
+  // --- /api/questions/check-duplicate
+  app.post('/api/questions/check-duplicate', (req, res) => {
+    const similar = [];
+    const N = Math.min(5, openQuestions.length);
+    for (let i = 0; i < N; i++) {
+      similar.push({
+        questionId: openQuestions[i]._id,
+        similarity: 0.45 + Math.random() * 0.4,
+        status: openQuestions[i].status,
+      });
+    }
+    res.json({
+      data: {
+        duplicates: similar,
+        cosine_computed: true,
+        at: new Date().toISOString(),
+      },
+    });
+  });
+
+  // --- rebalance trio
+  app.post('/api/questions/reAllocateLessWorkload', (req, res) => {
+    const n = Math.floor(Math.random() * 15);
+    res.json({ data: { reAllocated: n, triggered: 'cron-mock', at: new Date().toISOString() } });
+  });
+  app.post('/api/questions/reallocate-timebound', (req, res) => {
+    const { qid } = req.body || {};
+    res.json({ data: { questionId: qid, reAllocated: 1, reason: 'timebound', at: new Date().toISOString() } });
+  });
+  app.post('/api/questions/reallocate-manual', (req, res) => {
+    const { questionId } = req.body || {};
+    res.json({
+      data: {
+        questionId,
+        from: 'lt-expert-00001',
+        to:   pick(expertUids, 'lt-expert-00002'),
+        at: new Date().toISOString(),
+      },
+    });
+  });
+
+  // --- /api/questions/download-filtered-report   (PR-1195 alias / closed-reports)
+  function reportBody(payload) {
+    const allUsers   = !!(payload && (payload.allUsers || payload.allusers));
+    const moderator  = payload && payload.moderator;
+    const source     = allUsers ? 'all' : (moderator || 'all');
+    const cropKey    = allUsers ? 'allUsers' : (moderator || 'allUsers');
+    const items = (closedQuestions.length ? closedQuestions : openQuestions.slice(0, 20)).slice(0, 10);
+    const rows = items.map(q => ({
+      questionId: q._id,
+      id: q._id,
+      status: q.status,
+      crop: q.crop,
+      state: 'Maharashtra',
+      moderator: q.moderator || moderator || 'lt-mod-00001',
+      userId: q.firebaseUID,
+      allUsers: allUsers || null,                     // PR-1195: also present (always)
+      moderatorFilter: moderator || null,             // legacy alias (always)
+      filterKey: cropKey,
+      source,
+      closedAt: new Date().toISOString(),
+    }));
+    return {
+      data: rows,                              // top-level list — bug-1195 contract
+      received: {
+        count: rows.length,
+        questionList: rows,                    // legacy alias
+      },
+      meta: {
+        calledWith: { allUsers, moderator, cropKey },
+        bug1195_regression: 'identical-key-set',
+      },
+    };
+  }
+
+  app.get('/api/questions/download-filtered-report', (req, res) => {
+    res.json(reportBody(req.query));
+  });
+  app.post('/api/questions/closed-reports', (req, res) => {
+    res.json(reportBody(req.body || {}));
+  });
+
+  // --- /api/answers (reputation delta +1)
+  // NOTE: handler is `async` so the Mongo $inc is awaited BEFORE the
+  // response is sent. Without awaiting, the fire-and-forget persist lets
+  // `reconcile_reputation.py` query the live value while it's still being
+  // updated, misreporting every snapshot as drifted. The single $inc is
+  // a sub-millisecond op, so the response-time impact is negligible.
+  app.post('/api/answers', async (req, res) => {
+    try {
+      const body = req.body || {};
+      const uid  = body.userId || pick(expertUids, 'lt-expert-00001');
+      const prev = reputationByUid.get(uid) || 0;
+      const next = prev + (REPUTATION_DELTA['/api/answers'] || 0);
+      reputationByUid.set(uid, next);
+      await _persistReputation(uid, REPUTATION_DELTA['/api/answers'] || 0);
+      res.json({
+        data: {
+          questionId: body.questionId,
+          answerId: `ans-${Math.random().toString(36).slice(2, 10)}`,
+          status: 'in-review',
+          userId: uid,
+          reputation_score: next,
+          reputation_delta: next - prev,
+        },
+      });
+    } catch (err) {
+      log('ERR', `/api/answers threw: ${err.stack || err.message}`);
+      res.status(500).json({ error: 'internal_error' });
+    }
+  });
+
+  // --- /api/answers/moderator/approve (reputation delta +3)
+  app.post('/api/answers/moderator/approve', async (req, res) => {
+    try {
+      const body = req.body || {};
+      const uid  = body.userId || pick(expertUids, 'lt-expert-00001');
+      const prev = reputationByUid.get(uid) || 0;
+      const next = prev + (REPUTATION_DELTA['/api/answers/moderator/approve'] || 0);
+      reputationByUid.set(uid, next);
+      await _persistReputation(uid, REPUTATION_DELTA['/api/answers/moderator/approve'] || 0);
+      res.json({
+        data: {
+          questionId: body.questionId,
+          answerId: body.answerId,
+          moderatorApproved: true,
+          userId: uid,
+          reputation_score: next,
+          reputation_delta: next - prev,
+          at: new Date().toISOString(),
+        },
+      });
+    } catch (err) {
+      log('ERR', `/api/answers/moderator/approve threw: ${err.stack || err.message}`);
+      res.status(500).json({ error: 'internal_error' });
+    }
+  });
+
+  // Catch-all (404 inside the mock surface).
+  app.use((req, res) => {
+    log('INFO', `404 (unmocked) ${req.method} ${req.path}`);
+    res.status(404).json({ status: 'error', message: `unmocked: ${req.method} ${req.path}` });
+  });
+
+  return app;
+}
+
+// ─── Auth emulator (9099) ───────────────────────────────────────────────────
+function buildAuthApp() {
+  const app = baseApp();
+  app.use(latencyMiddleware);
+
+  app.post([
+    '/identitytoolkit/v1/accounts:signInWithPassword',
+    '/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword',
+  ], (req, res) => {
+    const { email = `anon-${Math.random().toString(36).slice(2)}@loadtest.invalid` } = req.body || {};
+    const cached = allUsersByEmail.get(email);
+    const localId = cached?.uid || email.split('@')[0];
+    const ts2 = Date.now();
+    const idToken      = `MOCK.${Buffer.from(`${localId}|${ts2}`).toString('base64url')}`;
+    const refreshToken = `MOCK_REFRESH.${Buffer.from(`${localId}|${ts2}`).toString('base64url')}`;
+    res.json({
+      kind: 'identitytoolkit#SignInWithPasswordResponse',
+      localId,
+      email,
+      displayName: '',
+      idToken,
+      refreshToken,
+      expiresIn: '3600',
+    });
+  });
+
+  app.post([
+    '/identitytoolkit/v1/accounts:lookup',
+    '/identitytoolkit.googleapis.com/v1/accounts:lookup',
+  ], (req, res) => {
+    const ids = (req.body && req.body.localId) || [];
+    const list = (Array.isArray(ids) ? ids : [ids]).map((id) => {
+      const found = Array.from(allUsersByUid.entries()).find(([uid]) => uid === id);
+      return {
+        localId: id,
+        email: found ? found[1].email : `${id}@loadtest.ajrasakha.invalid`,
+        emailVerified: true,
+        providerUserInfo: [{ providerId: 'password', rawId: id }],
+      };
+    });
+    res.json({ kind: 'identitytoolkit#GetAccountInfoResponse', users: list });
+  });
+
+  app.post('/securetoken/v1/token', (req, res) => {
+    const refresh = (req.body && req.body.refresh_token) || 'unknown';
+    const ts2 = Date.now();
+    const access_token  = `MOCK.${Buffer.from(`${refresh}|${ts2}`).toString('base64url')}`;
+    const refresh_token = `MOCK_REFRESH.${Buffer.from(`${ts2}`).toString('base64url')}`;
+    res.json({
+      access_token,
+      refresh_token,
+      expires_in: '3600',
+      token_type: 'Bearer',
+      user_id: 'mock-user',
+      project_id: 'mock-project',
+    });
+  });
+
+  app.get('/emulator', (req, res) => res.json({
+    emulator: 'mock',
+    endpoints: [
+      '/identitytoolkit/v1/accounts:signInWithPassword',
+      '/identitytoolkit/v1/accounts:lookup',
+      '/securetoken/v1/token',
+    ],
+  }));
+
+  app.use((req, res) => res.status(404).json({
+    status: 'error',
+    message: `unmocked auth path: ${req.method} ${req.path}`,
+  }));
+
+  return app;
+}
+
+// ─── Boot ───────────────────────────────────────────────────────────────────
+async function main() {
+  await initMongo();
+  const backend = buildBackendApp();
+  const auth    = buildAuthApp();
+
+  backend.listen(PORT_BACKEND, () => {
+    log('INFO', `backend listening on http://127.0.0.1:${PORT_BACKEND}`);
+  });
+  auth.listen(PORT_AUTH, () => {
+    log('INFO', `auth emulator listening on http://127.0.0.1:${PORT_AUTH}`);
+  });
+
+  process.on('SIGINT',  () => { log('INFO', 'SIGINT — exiting');    process.exit(0); });
+  process.on('SIGTERM', () => { log('INFO', 'SIGTERM — exiting');   process.exit(0); });
+  process.on('uncaughtException', (e) => log('ERROR', `uncaughtException ${e.message}\n${e.stack}`));
+}
+
+main().catch(err => {
+  console.error('[mock] FATAL', err);
+  process.exit(1);
+});

--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -1,0 +1,195 @@
+{
+  "name": "ajrasakha-loadtest-p7",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ajrasakha-loadtest-p7",
+      "version": "1.0.0",
+      "dependencies": {
+        "@faker-js/faker": "^9.7.0",
+        "dotenv": "^16.5.0",
+        "mongodb": "^6.17.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.13.tgz",
+      "integrity": "sha512-E3Sv4eCYAlKYUTx8S3ioQcDUscOif+8zZ5OnW1IzJ+Tt+EO+ke8mn+Y3FX6N1H79picwbdOavVOb1jPi2EOyrg==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/testing/package.json
+++ b/testing/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ajrasakha-loadtest-p7",
+  "version": "1.0.0",
+  "description": "Project 7 — Reviewer System Load & SLA Testing toolchain",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "seed":        "node seed/seed_all.mjs",
+    "seed:users":  "node seed/seed_users.mjs",
+    "seed:q":      "node seed/seed_questions.mjs",
+    "register:fb": "node seed/register_firebase_users.mjs",
+    "clear":       "node seed/clear.mjs",
+    "indexes":     "node seed/ensure_indexes.mjs",
+    "smoke":       "node scripts/smoke.mjs",
+    "reconcile":   "node scripts/reconcile_reputation.mjs"
+  },
+  "dependencies": {
+    "@faker-js/faker": "^9.7.0",
+    "dotenv": "^16.5.0",
+    "mongodb": "^6.17.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/testing/results/_default/assertions.csv
+++ b/testing/results/_default/assertions.csv
@@ -1,0 +1,1 @@
+assertion_key,count

--- a/testing/results/_default/requests.csv
+++ b/testing/results/_default/requests.csv
@@ -1,0 +1,1 @@
+timestamp,endpoint,method,name,status_code,response_time_ms,response_length,failure,assertion,context

--- a/testing/scripts/aggregate_results.py
+++ b/testing/scripts/aggregate_results.py
@@ -1,0 +1,292 @@
+﻿#!/usr/bin/env python3
+"""aggregate_results.py - Per-scenario SLA aggregator (Project 7)."""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+try:
+    import yaml
+    _HAS_YAML = True
+except ImportError:
+    _HAS_YAML = False
+
+
+SLA_P95_ALLOCATE_MS = 800.0
+SLA_HTTP_5XX_RATIO  = 0.001
+SLA_QUEUE_WAIT_S    = 60.0
+SLA_COSINE_P95_MS   = 1500.0
+SLA_REP_DRIFT_MAX   = 0
+_S4_DEFAULT_BUDGETS_MS = {
+    "POST /api/auth/login": 400.0,
+    "GET /api/questions/queue-details": 500.0,
+    "POST /api/questions/allocated": 600.0,
+    "POST /:qid/feedback-reviewer": 800.0,
+    "POST /api/answers/moderator/approve": 1200.0,
+}
+
+
+def _repo_root():
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_budgets():
+    yaml_path = _repo_root() / "testing" / "config" / "sla.yaml"
+    if yaml_path.exists() and _HAS_YAML:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    return {
+        "scenarios": {
+            "1x_locust":  {"s5_http_5xx_ratio_max": SLA_HTTP_5XX_RATIO,
+                           "s3_end_queue_length_max": 100},
+            "5x_locust":  {"s5_http_5xx_ratio_max": SLA_HTTP_5XX_RATIO,
+                           "s3_end_queue_length_max": 500},
+            "10x_locust": {"s5_http_5xx_ratio_max": SLA_HTTP_5XX_RATIO,
+                           "s3_end_queue_length_max": 1000},
+        },
+        "sla_gates": {
+            "S1": {"budget_ms": SLA_QUEUE_WAIT_S * 1000.0},
+            "S2": {"budget_ms": SLA_P95_ALLOCATE_MS},
+            "S3": {},
+            "S4": {"endpoint_budgets_ms": dict(_S4_DEFAULT_BUDGETS_MS)},
+            "S5": {},
+            "S6": {"budget_drift": SLA_REP_DRIFT_MAX},
+            "S7": {"budget_ms": SLA_COSINE_P95_MS},
+        },
+    }
+
+
+def _read_csv(path):
+    if not path.exists():
+        return []
+    with open(path, "r", newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def _percentile(values, p):
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = (len(s) - 1) * p
+    f, c = int(k), min(int(k) + 1, len(s) - 1)
+    if f == c:
+        return s[int(k)]
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+def _per_endpoint(rows):
+    by_name = {}
+    err_by_name = {}
+    tot_by_name = {}
+    for r in rows:
+        name = r.get("name") or ""
+        if not name:
+            continue
+        try:
+            rt = float(r.get("response_time_ms") or 0)
+        except ValueError:
+            rt = 0.0
+        by_name.setdefault(name, []).append(rt)
+        tot_by_name[name] = tot_by_name.get(name, 0) + 1
+        try:
+            code = int(r.get("status_code") or 0)
+        except ValueError:
+            code = 0
+        if 500 <= code <= 599:
+            err_by_name[name] = err_by_name.get(name, 0) + 1
+
+    out = {}
+    for name, lst in by_name.items():
+        out[name] = {
+            "count":     len(lst),
+            "p50_ms":    _percentile(lst, 0.50),
+            "p95_ms":    _percentile(lst, 0.95),
+            "p99_ms":    _percentile(lst, 0.99),
+            "max_ms":    max(lst),
+            "err_count": err_by_name.get(name, 0),
+            "err_ratio": (err_by_name.get(name, 0) / max(1, tot_by_name[name])),
+        }
+    return out
+
+
+def _cosine_p95(rows):
+    rt = []
+    for r in rows:
+        if "check-duplicate" in (r.get("endpoint") or ""):
+            try:
+                rt.append(float(r["response_time_ms"]))
+            except (KeyError, ValueError):
+                pass
+    return _percentile(rt, 0.95) if rt else 0.0
+
+
+def _end_queue_lengths(rows):
+    if not rows:
+        return {}
+    by_ep = {}
+    for r in rows:
+        ep = r.get("endpoint") or ""
+        try:
+            ts = float(r.get("timestamp") or 0)
+            ql = int(r.get("queue_length") or 0)
+        except ValueError:
+            continue
+        by_ep.setdefault(ep, []).append((ts, ql))
+    out = {}
+    for ep, samples in by_ep.items():
+        samples.sort(key=lambda x: x[0])
+        n = max(1, len(samples) // 20)
+        tail = [q for _, q in samples[-n:]]
+        out[ep] = int(round(sum(tail) / len(tail))) if tail else 0
+    return out
+
+
+def _s4_breaches(agg, budgets):
+    breaches = []
+    for name, v in agg.items():
+        for key, budget in budgets.items():
+            if key in name:
+                if v["p95_ms"] > budget:
+                    breaches.append((name, v["p95_ms"], budget))
+                break
+    return breaches
+
+
+def _sla_summary(scenario, agg, rep_drift_count, cosine_p95_ms, end_queue_lengths, budgets):
+    out = []
+    scen_cfg = (budgets.get("scenarios") or {}).get(scenario) or {}
+    gates    = budgets.get("sla_gates") or {}
+
+    max_latency_ms = max((v["max_ms"] for v in agg.values()), default=0.0)
+    s1_budget_ms = float((gates.get("S1") or {}).get("budget_ms")
+                         or (SLA_QUEUE_WAIT_S * 1000))
+    out.append(("S1", "queue_wait_proxy", max_latency_ms <= s1_budget_ms,
+                f"max_latency={max_latency_ms:.0f}ms budget={s1_budget_ms:.0f}ms"))
+
+    s2_budget_ms = float((gates.get("S2") or {}).get("budget_ms")
+                         or SLA_P95_ALLOCATE_MS)
+    alloc = [v["p95_ms"] for k, v in agg.items() if "allocat" in k]
+    worst = max(alloc) if alloc else 0.0
+    out.append(("S2", "allocator_p95", worst <= s2_budget_ms,
+                f"worst_allocate_p95={worst:.1f}ms budget={s2_budget_ms:.1f}ms"))
+
+    s3_threshold = int(scen_cfg.get("s3_end_queue_length_max") or 0)
+    if end_queue_lengths:
+        worst_end = max(end_queue_lengths.values())
+        worst_ep  = max(end_queue_lengths, key=lambda k: end_queue_lengths[k])
+        out.append(("S3", "queue_drained", worst_end <= s3_threshold,
+                    f"worst_end={worst_end} ({worst_ep}) budget={s3_threshold} per-scenario"))
+    else:
+        out.append(("S3", "queue_drained", True,
+                    f"no queue_lengths.csv - skipped (budget={s3_threshold})"))
+
+    s4_budgets = dict((gates.get("S4") or {}).get("endpoint_budgets_ms")
+                      or _S4_DEFAULT_BUDGETS_MS)
+    breaches = _s4_breaches(agg, s4_budgets)
+    if not agg:
+        s4_pass = True
+        s4_detail = "no requests observed"
+    else:
+        s4_pass = (len(breaches) == 0)
+        if breaches:
+            rows = ", ".join(f"{n}={obs:.0f}ms>bdg={bdg:.0f}ms" for n, obs, bdg in breaches[:3])
+            s4_detail = (f"{len(breaches)} breach(es); first: {rows} "
+                         f"(of {len(s4_budgets)} budgeted endpoints)")
+        else:
+            n_with_budget = sum(1 for name in agg if any(k in name for k in s4_budgets))
+            s4_detail = f"all {n_with_budget} budgeted endpoints within budget"
+    out.append(("S4", "per_endpoint_p95", s4_pass, s4_detail))
+
+    s5_budget = float(scen_cfg.get("s5_http_5xx_ratio_max") or SLA_HTTP_5XX_RATIO)
+    worst5 = max((v["err_ratio"] for v in agg.values()), default=0.0)
+    worst5_name = (max(agg, key=lambda k: agg[k]["err_ratio"]) if agg else "")
+    out.append(("S5", "http_5xx", worst5 <= s5_budget,
+                f"worst_5xx_ratio={worst5:.4%} ({worst5_name}) budget={s5_budget:.4%} per-scenario"))
+
+    s6_budget = int((gates.get("S6") or {}).get("budget_drift") or SLA_REP_DRIFT_MAX)
+    out.append(("S6", "reputation_mismatches", rep_drift_count <= s6_budget,
+                f"drift_count={rep_drift_count} budget={s6_budget}"))
+
+    s7_budget_ms = float((gates.get("S7") or {}).get("budget_ms") or SLA_COSINE_P95_MS)
+    out.append(("S7", "cosine_p95", cosine_p95_ms <= s7_budget_ms,
+                f"p95={cosine_p95_ms:.1f}ms budget={s7_budget_ms:.1f}ms"))
+
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", required=True)
+    args = ap.parse_args()
+
+    repo = _repo_root()
+    budgets = _load_budgets()
+
+    scen_dir = repo / "results" / args.scenario
+    scen_dir.mkdir(parents=True, exist_ok=True)
+
+    req_rows = _read_csv(scen_dir / "requests.csv")
+    ass_rows = _read_csv(scen_dir / "assertions.csv")
+    ql_rows  = _read_csv(scen_dir / "queue_lengths.csv")
+
+    agg = _per_endpoint(req_rows)
+    cosine_p95_ms = _cosine_p95(req_rows)
+    end_ql = _end_queue_lengths(ql_rows)
+
+    out_csv = scen_dir / "aggregated.csv"
+    with open(out_csv, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["scenario", "name", "count", "p50_ms", "p95_ms",
+                    "p99_ms", "max_ms", "err_count", "err_ratio"])
+        for name, v in sorted(agg.items()):
+            w.writerow([
+                args.scenario, name,
+                int(v["count"]),
+                f"{v['p50_ms']:.1f}", f"{v['p95_ms']:.1f}",
+                f"{v['p99_ms']:.1f}", f"{v['max_ms']:.1f}",
+                int(v["err_count"]), f"{v['err_ratio']:.4%}",
+            ])
+
+    rep_drift = int(sum(int(r["count"]) for r in ass_rows if r.get("assertion_key") == "REP_DRIFT"))
+    summary = _sla_summary(
+        scenario=args.scenario,
+        agg=agg,
+        rep_drift_count=rep_drift,
+        cosine_p95_ms=cosine_p95_ms,
+        end_queue_lengths=end_ql,
+        budgets=budgets,
+    )
+    sla_csv = scen_dir / "sla_summary.csv"
+    with open(sla_csv, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["scenario", "sla_id", "name", "passed", "detail"])
+        for sla_id, name, passed, detail in summary:
+            w.writerow([args.scenario, sla_id, name, int(bool(passed)), detail])
+
+    runs_csv = repo / "results" / "aggregated" / "_runs.csv"
+    runs_csv.parent.mkdir(parents=True, exist_ok=True)
+    new_file = not runs_csv.exists()
+    with open(runs_csv, "a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        if new_file:
+            w.writerow(["scenario", "sla_pass", "sla_gate_count", "p95_max_ms", "err_ratio_max"])
+        sla_pass = bool(all(p for _, _, p, _ in summary))
+        w.writerow([
+            args.scenario,
+            int(sla_pass),
+            len(summary),
+            f"{max((v['p95_ms'] for v in agg.values()), default=0):.1f}",
+            f"{max((v['err_ratio'] for v in agg.values()), default=0):.4%}",
+        ])
+
+    overall = "PASS" if all(p for _, _, p, _ in summary) else "FAIL"
+    n_pass = sum(1 for _, _, p, _ in summary if p)
+    print(f"[aggregate] {args.scenario}: {overall} ({n_pass}/{len(summary)} gates) -> {out_csv.name} {sla_csv.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/scripts/boot-backend-local.ps1
+++ b/testing/scripts/boot-backend-local.ps1
@@ -1,0 +1,97 @@
+# Boots the reviewer-backend locally against the already-running:
+#   - MongoDB on 127.0.0.1:27017
+#   - Firebase Auth Emulator on 127.0.0.1:9099
+# and waits for /api/health to return 200.
+#
+# Used for host-side validation of Phase 1; not part of normal Phase 2+ flow.
+#
+# Usage (from repo root):
+#   pwsh -File testing/scripts/boot-backend-local.ps1
+
+$ErrorActionPreference = 'Stop'
+$envFile    = Join-Path $PSScriptRoot '..\docker\backend-loadtest.env'
+$backendDir = Join-Path $PSScriptRoot '..\..\ajrasakha\backend'
+$logFile    = Join-Path $env:TEMP 'backend-boot.log'
+$healthUrl  = 'http://127.0.0.1:3141/api/health'
+
+Write-Host "[boot] Loading env overlay from $envFile" -ForegroundColor Cyan
+
+Get-Content $envFile | Where-Object { $_ -and ($_ -notmatch '^\s*#') } | ForEach-Object {
+  if ($_ -match '^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$') {
+    $k = $Matches[1]
+    $v = $Matches[2].Trim()
+    # Strip surrounding double quotes if present
+    if ($v.StartsWith('"') -and $v.EndsWith('"')) { $v = $v.Substring(1, $v.Length - 2) }
+    # In-container hostname 'mongo' becomes 127.0.0.1 on host-side boot.
+    # Anchor the pattern so we only replace the host segment, never the 'mongo' in 'mongodb://'.
+    # The lookahead matches both ':port' and '/path' so URIs with query strings work.
+    if ($k -in 'DB_URL','DB_URL_ANALYTICS','ANNAM_URL_ANALYTICS') {
+      $v = $v -replace '(?<=://)mongo(?=[:/])', '127.0.0.1'
+    }
+    Set-Item -Path "env:$k" -Value $v
+  }
+}
+
+# Inject a real Firebase Admin private key from docker/firebase-sa.json if one
+# isn't already present. The placeholder in backend-loadtest.env was a stub that
+# the firebase-admin SDK rejects with "Too few bytes to read ASN.1 value".
+$saPath = Join-Path $PSScriptRoot '..\docker\firebase-sa.json'
+if ((Test-Path $saPath) -and ([string]::IsNullOrEmpty($env:FIREBASE_PRIVATE_KEY) -or $env:FIREBASE_PRIVATE_KEY -match 'BEGIN PRIVATE KEY-----')) {
+  try {
+    $sa = Get-Content $saPath -Raw | ConvertFrom-Json
+    if ($sa.private_key) {
+      # Single-line env-friendly form: literal '\n' separators, not real newlines.
+      $env:FIREBASE_PRIVATE_KEY = $sa.private_key -replace "`r?`n", '\n'
+      $env:FIREBASE_CLIENT_EMAIL = $sa.client_email
+      Write-Host "[boot] Loaded FIREBASE_PRIVATE_KEY from $saPath ($($env:FIREBASE_PRIVATE_KEY.Length) chars)" -ForegroundColor DarkCyan
+    }
+  } catch {
+    Write-Warning "[boot] failed to read $saPath -- backend may fail to verify tokens"
+  }
+}
+
+# Auth emulator wiring
+$env:FIREBASE_AUTH_EMULATOR_HOST = '127.0.0.1:9099'
+$env:GCLOUD_PROJECT              = 'ajrasakha-loadtest'
+
+# Tailscale: explicitly disable (start.sh checks for empty key)
+$env:TAILSCALE_AUTHKEY = ''
+
+Write-Host "[boot] Starting backend (build already exists). Logs: $logFile" -ForegroundColor Cyan
+
+Push-Location $backendDir
+try {
+  $proc = Start-Process -FilePath "node" `
+                         -ArgumentList "build/index.js" `
+                         -RedirectStandardOutput $logFile `
+                         -RedirectStandardError  "$logFile.err" `
+                         -WindowStyle Hidden `
+                         -PassThru
+} finally {
+  Pop-Location
+}
+
+Write-Host "[boot] PID $($proc.Id); waiting up to 60s for $healthUrl ..." -ForegroundColor Cyan
+
+$deadline = (Get-Date).AddSeconds(60)
+$healthy  = $false
+while ((Get-Date) -lt $deadline) {
+  Start-Sleep -Seconds 2
+  try {
+    $r = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 3 -ErrorAction Stop
+    if ($r.StatusCode -eq 200) { $healthy = $true; break }
+  } catch { }
+}
+
+if ($healthy) {
+  Write-Host "[boot] HEALTHY: $healthUrl returned 200" -ForegroundColor Green
+  Write-Host "[boot] Backend PID $($proc.Id) is still running. Kill with: Stop-Process -Id $($proc.Id)"
+  exit 0
+} else {
+  Write-Host "[boot] FAILED: backend did not become healthy in 60s" -ForegroundColor Red
+  Write-Host "----- last 50 log lines -----" -ForegroundColor Yellow
+  if (Test-Path $logFile)     { Get-Content $logFile -Tail 25 }
+  if (Test-Path "$logFile.err") { Write-Host "----- stderr -----" -ForegroundColor Yellow; Get-Content "$logFile.err" -Tail 25 }
+  Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+  exit 1
+}

--- a/testing/scripts/dashboards.py
+++ b/testing/scripts/dashboards.py
@@ -1,0 +1,271 @@
+﻿#!/usr/bin/env python3
+"""
+dashboards.py - Generate a self-contained HTML dashboard from the latest CSVs.
+
+Reads:
+  results/aggregated/_runs.csv
+  results/<scenario>/aggregated.csv       (per-endpoint p50/p95/p99/max/err)
+  results/<scenario>/sla_summary.csv      (S1..S7 gate results)
+  results/<scenario>/reputation_drift.csv (S6 drift detail)
+
+Writes:
+  results/dashboards/index.html           (open in any browser)
+
+The output is fully static (no JS fetches at load time), so opening it
+via `file://` works in Chrome/Firefox/Edge without a server.
+
+Usage:
+  python testing/scripts/dashboards.py            # build for all 3 scenarios
+  python testing/scripts/dashboards.py --scenario 1x_locust
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+SCENARIOS = ["1x_locust", "5x_locust", "10x_locust"]
+
+
+def _read_csv(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    with open(path, "r", newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def _load_scenario(repo: Path, scenario: str) -> Dict[str, Any]:
+    scen_dir = repo / "results" / scenario
+    return {
+        "scenario": scenario,
+        "aggregated": _read_csv(scen_dir / "aggregated.csv"),
+        "sla":       _read_csv(scen_dir / "sla_summary.csv"),
+        "drift":     _read_csv(scen_dir / "reputation_drift.csv"),
+    }
+
+
+HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Ajrasakha Load Test Dashboard</title>
+<style>
+  :root {{
+    --bg: #0f172a;
+    --panel: #1e293b;
+    --panel-2: #273449;
+    --ink: #e2e8f0;
+    --ink-dim: #94a3b8;
+    --pass: #22c55e;
+    --fail: #ef4444;
+    --warn: #f59e0b;
+    --accent: #38bdf8;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{ font: 14px/1.45 -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+         margin: 0; background: var(--bg); color: var(--ink); }}
+  header {{ padding: 18px 28px; border-bottom: 1px solid #334155;
+           display: flex; justify-content: space-between; align-items: baseline; }}
+  header h1 {{ margin: 0; font-size: 18px; font-weight: 600; }}
+  header small {{ color: var(--ink-dim); }}
+  main {{ padding: 24px 28px; max-width: 1400px; margin: 0 auto; }}
+  section {{ background: var(--panel); border-radius: 8px; padding: 20px;
+            margin-bottom: 20px; }}
+  section h2 {{ margin: 0 0 16px; font-size: 15px; font-weight: 600;
+               color: var(--accent); letter-spacing: 0.04em;
+               text-transform: uppercase; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: 13px; }}
+  th, td {{ padding: 7px 10px; text-align: left; border-bottom: 1px solid #334155; }}
+  th {{ color: var(--ink-dim); font-weight: 500; font-size: 11px;
+       text-transform: uppercase; letter-spacing: 0.05em; }}
+  tr:last-child td {{ border-bottom: none; }}
+  .num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  .ok  {{ color: var(--pass); }}
+  .ng  {{ color: var(--fail); font-weight: 600; }}
+  .pill {{ display: inline-block; padding: 2px 8px; border-radius: 10px;
+          font-size: 11px; font-weight: 600; }}
+  .pill-ok  {{ background: rgba(34, 197, 94, 0.15);  color: var(--pass); }}
+  .pill-ng  {{ background: rgba(239, 68, 68, 0.15);  color: var(--fail); }}
+  .grid {{ display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }}
+  .card {{ background: var(--panel-2); border-radius: 6px; padding: 16px; }}
+  .card h3 {{ margin: 0 0 4px; font-size: 12px; font-weight: 500;
+             color: var(--ink-dim); text-transform: uppercase;
+             letter-spacing: 0.04em; }}
+  .card .big {{ font-size: 28px; font-weight: 600;
+               font-variant-numeric: tabular-nums; }}
+  .legend {{ font-size: 11px; color: var(--ink-dim); margin-top: 12px; }}
+  details summary {{ cursor: pointer; color: var(--accent); }}
+  .bar {{ display: inline-block; height: 6px; background: var(--accent);
+         border-radius: 3px; vertical-align: middle; margin-left: 8px; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>Ajrasakha Reviewer Load Test Dashboard</h1>
+  <small>generated {generated_at} - SLA budgets from testing/config/sla.yaml</small>
+</header>
+<main>
+  <section>
+    <h2>Scenario summary</h2>
+    <div class="grid">
+      {summary_cards}
+    </div>
+  </section>
+
+  <section>
+    <h2>SLA gates (S1-S7)</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Scenario</th>
+          <th>S1 queue_wait</th>
+          <th>S2 allocator_p95</th>
+          <th>S3 queue_drained</th>
+          <th>S4 per_endpoint_p95</th>
+          <th>S5 http_5xx</th>
+          <th>S6 reputation</th>
+          <th>S7 cosine_p95</th>
+          <th class="num">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sla_rows}
+      </tbody>
+    </table>
+  </section>
+
+  {per_scenario_sections}
+</main>
+</body>
+</html>
+"""
+
+
+def _summary_cards(data: List[Dict[str, Any]]) -> str:
+    cards = []
+    for s in data:
+        total = len(s["sla"])
+        passed = sum(1 for r in s["sla"] if r.get("passed") == "1")
+        cards.append(
+            f'<div class="card">'
+            f'<h3>{html.escape(s["scenario"])}</h3>'
+            f'<div class="big">{passed}/{total}</div>'
+            f'<div class="legend">SLA gates passing</div>'
+            f'</div>'
+        )
+    return "\n".join(cards)
+
+
+def _sla_row(s: Dict[str, Any]) -> str:
+    by_id = {r["sla_id"]: r for r in s["sla"]}
+    def cell(gate_id: str) -> str:
+        r = by_id.get(gate_id)
+        if not r:
+            return '<td class="num">-</td>'
+        passed = r["passed"] == "1"
+        cls = "pill-ok" if passed else "pill-ng"
+        sym = "&#10003;" if passed else "&#10007;"
+        # truncate long details
+        d = html.escape(r["detail"][:48] + ("..." if len(r["detail"]) > 48 else ""))
+        return (f'<td><span class="pill {cls}">{sym}</span>'
+                f' <span class="legend">{d}</span></td>')
+
+    total = len(s["sla"])
+    passed = sum(1 for r in s["sla"] if r["passed"] == "1")
+    return (
+        f"<tr><td><b>{html.escape(s['scenario'])}</b></td>"
+        + cell("S1") + cell("S2") + cell("S3") + cell("S4")
+        + cell("S5") + cell("S6") + cell("S7")
+        + f'<td class="num">{passed}/{total}</td></tr>'
+    )
+
+
+def _sla_rows(data: List[Dict[str, Any]]) -> str:
+    return "\n".join(_sla_row(s) for s in data)
+
+
+def _per_scenario_section(s: Dict[str, Any]) -> str:
+    rows = []
+    for r in s["aggregated"]:
+        err_ratio = r.get("err_ratio", "0.0000%")
+        cls = "ng" if err_ratio not in ("0.0000%", "") else ""
+        rows.append(
+            f"<tr><td>{html.escape(r['name'])}</td>"
+            f'<td class="num">{r["count"]}</td>'
+            f'<td class="num">{r["p50_ms"]}</td>'
+            f'<td class="num">{r["p95_ms"]}</td>'
+            f'<td class="num">{r["p99_ms"]}</td>'
+            f'<td class="num">{r["max_ms"]}</td>'
+            f'<td class="num {cls}">{err_ratio}</td>'
+            f"</tr>"
+        )
+    body = "\n".join(rows)
+    drift_rows = "".join(
+        f"<tr><td>{html.escape(r['user_id'])}</td>"
+        f'<td class="num">{r["snapshot"]}</td>'
+        f'<td class="num">{r["live"]}</td>'
+        f'<td class="num">{r["abs_delta"]}</td>'
+        f'<td class="num">{r["drift"]}</td></tr>'
+        for r in s["drift"][:20]
+    )
+    drift_count = sum(1 for r in s["drift"] if r.get("drift") == "1")
+    return f"""
+  <section>
+    <h2>{html.escape(s["scenario"])} - per-endpoint breakdown</h2>
+    <table>
+      <thead><tr>
+        <th>Endpoint</th><th class="num">count</th>
+        <th class="num">p50 ms</th><th class="num">p95 ms</th>
+        <th class="num">p99 ms</th><th class="num">max ms</th>
+        <th class="num">err %</th>
+      </tr></thead>
+      <tbody>{body}</tbody>
+    </table>
+
+    <details style="margin-top: 16px;">
+      <summary>S6 reputation drift ({drift_count} flagged users)</summary>
+      <table style="margin-top: 12px;">
+        <thead><tr>
+          <th>user_id</th>
+          <th class="num">snapshot</th><th class="num">live</th>
+          <th class="num">|delta|</th><th class="num">drift</th>
+        </tr></thead>
+        <tbody>{drift_rows or "<tr><td colspan=5>(none)</td></tr>"}</tbody>
+      </table>
+    </details>
+  </section>
+    """
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", choices=SCENARIOS + ["all"], default="all")
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parents[2]
+    scenarios = SCENARIOS if args.scenario == "all" else [args.scenario]
+    data = [_load_scenario(repo, s) for s in scenarios]
+
+    import datetime
+    generated_at = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    out = repo / "results" / "dashboards" / "index.html"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(HTML.format(
+        generated_at=generated_at,
+        summary_cards=_summary_cards(data),
+        sla_rows=_sla_rows(data),
+        per_scenario_sections="\n".join(_per_scenario_section(s) for s in data),
+    ), encoding="utf-8")
+
+    print(f"[dashboards] wrote {out} ({len(data)} scenario(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/scripts/diag-env.ps1
+++ b/testing/scripts/diag-env.ps1
@@ -1,0 +1,14 @@
+Get-Content 'c:\Users\iitmd\AJRASAKHA-LOADTESTING-P7\testing\docker\backend-loadtest.env' |
+  Where-Object { $_ -and ($_ -notmatch '^\s*#') } |
+  ForEach-Object {
+    if ($_ -match '^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$') {
+      $k = $Matches[1]
+      $v = $Matches[2].Trim()
+      if ($v.StartsWith('"') -and $v.EndsWith('"')) { $v = $v.Substring(1, $v.Length - 2) }
+      if ($k -eq 'DB_URL') { $v = $v -replace 'mongo', '127.0.0.1' }
+      Set-Item -Path "env:$k" -Value $v
+    }
+  }
+Write-Host "DB_URL=[$env:DB_URL]"
+Write-Host "DB_NAME=[$env:DB_NAME]"
+Write-Host "PORT=[$env:PORT]"

--- a/testing/scripts/diag-ports.ps1
+++ b/testing/scripts/diag-ports.ps1
@@ -1,0 +1,6 @@
+$ports = @(9099, 3141, 27017)
+foreach ($p in $ports) {
+  $r = Test-NetConnection 127.0.0.1 -Port $p -InformationLevel Quiet -WarningAction SilentlyContinue
+  Write-Host "127.0.0.1:$p = $r"
+}
+Get-Process -Name node -ErrorAction SilentlyContinue | Select-Object Id, StartTime | Format-Table -AutoSize | Out-String | Write-Host

--- a/testing/scripts/gen-firebase-sa.cjs
+++ b/testing/scripts/gen-firebase-sa.cjs
@@ -1,0 +1,31 @@
+// Generates a real RSA keypair and writes a Firebase-style service-account JSON.
+// Used once to give the load-test env a valid FIREBASE_PRIVATE_KEY that the
+// firebase-admin SDK can actually parse (the placeholder in
+// backend-loadtest.env was a stub that crashes at boot).
+const c = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { privateKey } = c.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding:  { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const sa = {
+  type: 'service_account',
+  project_id: 'ajrasakha-loadtest',
+  private_key_id: 'loadtest-key-id',
+  private_key: privateKey,
+  client_email: 'emulator@ajrasakha-loadtest.iam.gserviceaccount.com',
+  client_id: '000000000000000000000',
+  auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+  token_uri: 'https://oauth2.googleapis.com/token',
+  auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs',
+  client_x509_cert_url: 'https://www.googleapis.com/robot/v1/metadata/x509/loadtest',
+};
+
+const out = path.join(__dirname, '..', 'docker', 'firebase-sa.json');
+fs.writeFileSync(out, JSON.stringify(sa, null, 2));
+console.log(`Wrote ${out} (private key: ${privateKey.length} bytes)`);
+console.log('Now paste FIREBASE_PRIVATE_KEY from this file into backend-loadtest.env');

--- a/testing/scripts/preflight.ps1
+++ b/testing/scripts/preflight.ps1
@@ -1,0 +1,45 @@
+<#
+preflight.ps1 — Project 7 pre-flight gate.
+
+Run before any of `run-locust-{1x,5x,10x}.ps1`. Ensures:
+
+* Mongo is in single-node replica set mode (so `/allocated` and
+  `_withTransaction` paths work).
+* The seed corpus has the expected user counts (>= 12 users, >= 30
+  questions, all with `firebaseUID` matching `^lt-`).
+* Locust's Python deps are installed.
+
+Exits non-zero on first failure.
+
+(This is *not* the same gate as `testing/scripts/diag-env.ps1`,
+which is hardware-oriented. Use both for full coverage.)
+#>
+[CmdletBinding()]
+param(
+    [string]$MongoContainer = "mongo",
+    [string]$DbName         = "agriai_loadtest"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Exec-InMongo([string]$Script) {
+    docker exec $MongoContainer mongosh --quiet --eval "$Script" 2>$null
+}
+
+Write-Host "[preflight] checking Mongo replica-set state..."
+$rsOk = Exec-InMongo 'try { rs.status().ok } catch (e) { 0 }'
+if ("$rsOk" -ne "1") {
+    throw "Mongo '$MongoContainer' is not in replica set mode (got '$rsOk'). Run 'rs.initiate()' first."
+}
+Write-Host "[preflight] Mongo OK."
+
+Write-Host "[preflight] checking seed counts..."
+$usersQ = Exec-InMongo "db.getSiblingDB('$DbName').users.countDocuments({firebaseUID:/^lt-/})"
+$qsQ    = Exec-InMongo "db.getSiblingDB('$DbName').questions.countDocuments({firebaseUID:/^lt-/})"
+if ($usersQ -lt 12) { throw "Need >= 12 seed users; found $usersQ." }
+if ($qsQ -lt 30)    { throw "Need >= 30 seed questions; found $qsQ." }
+Write-Host "[preflight] seed OK: users=$usersQ questions=$qsQ"
+
+Write-Host "[preflight] checking Locust deps..."
+$missing = (pip check 2>&1 | Where-Object { $_ -match 'locust|pymongo' })
+Write-Host "[preflight] OK."

--- a/testing/scripts/reconcile_reputation.mjs
+++ b/testing/scripts/reconcile_reputation.mjs
@@ -1,0 +1,21 @@
+// =============================================================================
+// testing/scripts/reconcile_reputation.mjs
+// -----------------------------------------------------------------------------
+// Thin wrapper around ajrasakha/backend/scripts/recalculate-reputation-scores.mjs
+// so that Phase-3/Phase-5 SLAs can compare live reputation_score against the
+// independent re-derivation. Default = --dry-run (no writes).
+//
+// Run:
+//   node testing/scripts/reconcile_reputation.mjs                # dry-run
+//   node testing/scripts/reconcile_reputation.mjs --live        # apply changes
+// =============================================================================
+
+import { spawnSync } from 'child_process';
+import { resolve } from 'path';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const scriptPath = resolve(repoRoot, 'ajrasakha', 'backend', 'scripts', 'recalculate-reputation-scores.mjs');
+const extra = process.argv.includes('--live') ? [] : ['--dry-run'];
+
+const r = spawnSync('node', [scriptPath, ...extra], { stdio: 'inherit' });
+process.exit(r.status ?? 1);

--- a/testing/scripts/reconcile_reputation.py
+++ b/testing/scripts/reconcile_reputation.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+reconcile_reputation.py - Compare runtime reputation snapshots to ground truth.
+
+Reads:
+    results/<scenario>/reputation_snapshots.csv       (final per-user snapshot)
+    results/<scenario>/reputation_snapshot_history.csv (per-event timeline)
+    agriai_loadtest.users.reputation_score (live MongoDB)
+
+Writes:
+    results/<scenario>/reputation_drift.csv
+    results/<scenario>/reputation_races.csv
+    appends to `assertions.csv`:
+        REP_DRIFT             (snapshot-vs-live mismatch, S6)
+        REP_RACE_MONOTONICITY (in-memory race detected via history)
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+DRIFT_THRESHOLD = 1.0
+
+
+def _live_reputation():
+    from pymongo import MongoClient
+    url = os.getenv("DB_URL", "mongodb://127.0.0.1:27018/?replicaSet=rs0")
+    db_name = os.getenv("DB_NAME", "agriai_loadtest")
+    assert db_name == "agriai_loadtest", "Refusing to read non-loadtest DB."
+    db = MongoClient(url, serverSelectionTimeoutMS=5000)[db_name]
+    out = {}
+    for u in db["users"].find(
+        {"firebaseUID": {"$regex": "^lt-"}},
+        projection={"_id": 1, "reputation_score": 1, "reputationScore": 1},
+    ):
+        uid = str(u["_id"])
+        rep = u.get("reputation_score") or u.get("reputationScore") or 0.0
+        try:
+            out[uid] = float(rep)
+        except (TypeError, ValueError):
+            pass
+    return out
+
+
+def _detect_monotonicity_races(hist_path):
+    """Return list of (uid, prev_score, curr_score, prev_ctx, curr_ctx)
+    for every consecutive (per-user) history row where score decreased."""
+    if not hist_path.exists():
+        return []
+    races = []
+    by_uid = {}
+    with open(hist_path, "r", newline="", encoding="utf-8") as f:
+        for r in csv.DictReader(f):
+            try:
+                at = float(r["at"])
+                score = float(r["reputation_score"])
+            except (KeyError, ValueError, TypeError):
+                continue
+            by_uid.setdefault(r["user_id"], []).append(
+                (at, score, r.get("context", ""))
+            )
+    for uid, rows in by_uid.items():
+        rows.sort(key=lambda x: x[0])
+        for (a1, s1, c1), (a2, s2, c2) in zip(rows, rows[1:]):
+            if s2 < s1:
+                races.append((uid, s1, s2, c1, c2))
+    return races
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", required=True)
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parents[2]
+    scen_dir = repo / "results" / args.scenario
+    snap_path = scen_dir / "reputation_snapshots.csv"
+    hist_path = scen_dir / "reputation_snapshot_history.csv"
+    out_csv   = scen_dir / "reputation_drift.csv"
+    races_csv = scen_dir / "reputation_races.csv"
+
+    drift_count = 0
+    race_count  = 0
+    rows = []
+
+    # Snapshot vs. live (S6 drift)
+    if snap_path.exists():
+        try:
+            live = _live_reputation()
+        except Exception as e:
+            print(f"[reconcile] live Mongo unreachable ({e}); snapshot-vs-live skipped")
+            live = {}
+
+        with open(snap_path, "r", newline="", encoding="utf-8") as f:
+            for r in csv.DictReader(f):
+                uid = r["user_id"]
+                try:
+                    snap = json.loads(r["snapshot_json"])
+                    snap_value = float(snap.get("reputation_score") or 0)
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    snap_value = 0.0
+                live_value = live.get(uid, 0.0)
+                delta = abs(snap_value - live_value)
+                if delta > DRIFT_THRESHOLD:
+                    drift_count += 1
+                rows.append({
+                    "user_id": uid, "snapshot": snap_value,
+                    "live": live_value, "abs_delta": delta,
+                    "drift": int(delta > DRIFT_THRESHOLD),
+                })
+
+        with open(out_csv, "w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=["user_id", "snapshot", "live",
+                                              "abs_delta", "drift"])
+            w.writeheader()
+            w.writerows(rows)
+    else:
+        print(f"[reconcile] {snap_path} missing - snapshot-vs-live skipped")
+
+    # History monotonicity (in-memory race detector)
+    races = _detect_monotonicity_races(hist_path)
+    race_count = len(races)
+    with open(races_csv, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["user_id", "prev_score", "curr_score",
+                    "prev_context", "curr_context"])
+        for uid, p, c, pc, cc in races:
+            w.writerow([uid, f"{p:.4f}", f"{c:.4f}", pc, cc])
+
+    # Append both signals to assertions.csv
+    ass_path = scen_dir / "assertions.csv"
+    with open(ass_path, "a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["REP_DRIFT", drift_count])
+        w.writerow(["REP_RACE_MONOTONICITY", race_count])
+
+    print(f"[reconcile] {args.scenario}: "
+          f"drift={drift_count}/{len(rows)} races={race_count} "
+          f"-> {out_csv.name}, {races_csv.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testing/scripts/run-locust-10x.ps1
+++ b/testing/scripts/run-locust-10x.ps1
@@ -1,0 +1,52 @@
+<#
+run-locust-10x.ps1 — 10× overload.
+
+Pre-flight
+----------
+10× is expected to breach at least one of {S1, S2, S5, S6} — that is the
+intended outcome. The `error_budget.sla_pass` column in the aggregated
+CSV will record `False`, which is what the report wires to "10× breach".
+#>
+[CmdletBinding()]
+param(
+    # Renamed from `$Host` → `$HostUrl` for Windows PowerShell 5.1 compat.
+    [string]$HostUrl     = $(if ($env:LOCUST_HOST) { $env:LOCUST_HOST } else { "http://localhost:3141" }),
+    [string]$LoadProfile = "squash_p95",
+    [string]$RunFor      = "15m",
+    [string]$ResultsDir  = "results/10x_locust"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot     = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$LocustDir    = Resolve-Path (Join-Path $RepoRoot "testing\locust")
+$ResultAbsDir = Resolve-Path (Join-Path $RepoRoot $ResultsDir) -ErrorAction SilentlyContinue
+if (-not $ResultAbsDir) {
+    New-Item -ItemType Directory -Force -Path (Join-Path $RepoRoot $ResultsDir) | Out-Null
+    $ResultAbsDir = Resolve-Path (Join-Path $RepoRoot $ResultsDir)
+}
+
+$Env:PYTHONPATH = "$LocustDir;$Env:PYTHONPATH"
+$Env:LOCUST_HOST = $HostUrl
+$Env:LOAD_PROFILE = $LoadProfile
+$Env:RESULTS_DIR = $ResultAbsDir
+# Point reconcile_reputation.py at the same single-node replica set the
+# backend uses. Without these, the S6 drift check silently queries a
+# non-existent DB on port 27017 and reports every snapshot as drifted.
+if (-not $env:DB_URL)  { $env:DB_URL  = 'mongodb://127.0.0.1:27018/?replicaSet=rs0' }
+if (-not $env:DB_NAME) { $env:DB_NAME = 'agriai_loadtest' }
+
+Write-Host "[run-locust-10x] host=$HostUrl profile=$LoadProfile time=$RunFor out=$ResultAbsDir"
+
+Push-Location $RepoRoot
+try {
+    python "$LocustDir\scenarios\10x.py"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Locust 10x scenario exited with $LASTEXITCODE"
+    }
+    & python (Join-Path $PSScriptRoot "reconcile_reputation.py") --scenario 10x_locust
+    & (Join-Path $PSScriptRoot "aggregate_results.py") --scenario 10x_locust
+}
+finally {
+    Pop-Location
+}

--- a/testing/scripts/run-locust-1x.ps1
+++ b/testing/scripts/run-locust-1x.ps1
@@ -1,0 +1,71 @@
+<#
+run-locust-1x.ps1 — 1× baseline Locust run.
+
+Usage
+-----
+    pwsh -File testing/scripts/run-locust-1x.ps1
+or, with explicit host and env:
+    pwsh -File testing/scripts/run-locust-1x.ps1 -Host http://localhost:3141 `
+         -LoadProfile moderate -RunFor 60m
+
+Side-effects
+------------
+* Writes `results/1x_locust/requests.csv`, `assertions.csv`, `queue_lengths.csv`,
+  `reputation_snapshots.csv`, `run_manifest.csv`.
+* Appends a summary row to `results/aggregated/_runs.csv`.
+
+Pre-flight
+----------
+* The backend (`run.ps1`) and the seed must be live.
+* MongoDB must be a single-node replica set (sockets/transactions).
+* `pip install -r testing/locust/requirements.txt` must already be done.
+#>
+[CmdletBinding()]
+param(
+    # NOTE: Renamed from `$Host` → `$HostUrl`. PowerShell 5.1 (the default
+    # `powershell.exe`) has `$Host` as a read-only automatic variable, so
+    # binding that name fails outright. pwsh 7.x tolerates it, but the
+    # rename keeps the script portable across both runtimes.
+    [string]$HostUrl        = $(if ($env:LOCUST_HOST) { $env:LOCUST_HOST } else { "http://localhost:3141" }),
+    [string]$LoadProfile    = "moderate",
+    [string]$RunFor         = "60m",
+    [string]$ResultsDir     = "results/1x_locust"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot     = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$LocustDir    = Resolve-Path (Join-Path $RepoRoot "testing\locust")
+$ResultAbsDir = Resolve-Path (Join-Path $RepoRoot $ResultsDir) -ErrorAction SilentlyContinue
+if (-not $ResultAbsDir) {
+    New-Item -ItemType Directory -Force -Path (Join-Path $RepoRoot $ResultsDir) | Out-Null
+    $ResultAbsDir = Resolve-Path (Join-Path $RepoRoot $ResultsDir)
+}
+
+$Env:PYTHONPATH = "$LocustDir;$Env:PYTHONPATH"
+$Env:LOCUST_HOST = $HostUrl
+$Env:LOAD_PROFILE = $LoadProfile
+$Env:RESULTS_DIR = $ResultAbsDir
+# Point reconcile_reputation.py at the same single-node replica set the
+# backend uses. Without these, the S6 drift check silently queries a
+# non-existent DB on port 27017 and reports every snapshot as drifted.
+if (-not $env:DB_URL)  { $env:DB_URL  = 'mongodb://127.0.0.1:27018/?replicaSet=rs0' }
+if (-not $env:DB_NAME) { $env:DB_NAME = 'agriai_loadtest' }
+
+Write-Host "[run-locust-1x] host=$HostUrl profile=$LoadProfile time=$RunFor out=$ResultAbsDir"
+
+Push-Location $RepoRoot
+try {
+    python "$LocustDir\scenarios\1x.py"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Locust 1x scenario exited with $LASTEXITCODE"
+    }
+    # Snapshot-vs-live reputation reconciliation (S6). Must run BEFORE
+    # aggregate_results.py so the REP_DRIFT count is appended to
+    # assertions.csv in time for aggregate's SLA summary to consume it.
+    & python (Join-Path $PSScriptRoot "reconcile_reputation.py") --scenario 1x_locust
+    & (Join-Path $PSScriptRoot "aggregate_results.py") --scenario 1x_locust
+}
+finally {
+    Pop-Location
+}

--- a/testing/scripts/run-locust-5x.ps1
+++ b/testing/scripts/run-locust-5x.ps1
@@ -1,0 +1,52 @@
+<#
+run-locust-5x.ps1 — 5× burst.
+
+Pre-flight notes
+----------------
+This scenario assumes that MongoDB is a single-node replica set (the
+`_withTransaction` + `/allocated` paths require it). If `rs.status()`
+in mongo shell reports `ok: 0`, abort and run `rs.initiate()` first.
+#>
+[CmdletBinding()]
+param(
+    # Renamed from `$Host` → `$HostUrl` for Windows PowerShell 5.1 compat.
+    [string]$HostUrl     = $(if ($env:LOCUST_HOST) { $env:LOCUST_HOST } else { "http://localhost:3141" }),
+    [string]$LoadProfile = "heavy_allocate",
+    [string]$RunFor      = "30m",
+    [string]$ResultsDir  = "results/5x_locust"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot     = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$LocustDir    = Resolve-Path (Join-Path $RepoRoot "testing\locust")
+$ResultAbsDir = Resolve-Path (Join-Path $RepoRoot $ResultsDir) -ErrorAction SilentlyContinue
+if (-not $ResultAbsDir) {
+    New-Item -ItemType Directory -Force -Path (Join-Path $RepoRoot $ResultsDir) | Out-Null
+    $ResultAbsDir = Resolve-Path (Join-Path $RepoRoot $ResultsDir)
+}
+
+$Env:PYTHONPATH = "$LocustDir;$Env:PYTHONPATH"
+$Env:LOCUST_HOST = $HostUrl
+$Env:LOAD_PROFILE = $LoadProfile
+$Env:RESULTS_DIR = $ResultAbsDir
+# Point reconcile_reputation.py at the same single-node replica set the
+# backend uses. Without these, the S6 drift check silently queries a
+# non-existent DB on port 27017 and reports every snapshot as drifted.
+if (-not $env:DB_URL)  { $env:DB_URL  = 'mongodb://127.0.0.1:27018/?replicaSet=rs0' }
+if (-not $env:DB_NAME) { $env:DB_NAME = 'agriai_loadtest' }
+
+Write-Host "[run-locust-5x] host=$HostUrl profile=$LoadProfile time=$RunFor out=$ResultAbsDir"
+
+Push-Location $RepoRoot
+try {
+    python "$LocustDir\scenarios\5x.py"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Locust 5x scenario exited with $LASTEXITCODE"
+    }
+    & python (Join-Path $PSScriptRoot "reconcile_reputation.py") --scenario 5x_locust
+    & (Join-Path $PSScriptRoot "aggregate_results.py") --scenario 5x_locust
+}
+finally {
+    Pop-Location
+}

--- a/testing/scripts/run.ps1
+++ b/testing/scripts/run.ps1
@@ -1,0 +1,121 @@
+# =============================================================================
+# testing/scripts/run.ps1
+# -----------------------------------------------------------------------------
+# Single entrypoint for the Project 7 load & SLA toolchain on Windows.
+# Cross-platform equivalent: `make` (GNU Make).
+#
+# Subcommands:
+#   up       — docker compose up -d the testbed (mongo + auth-emu + backend)
+#   down     — stop + remove containers (preserves mongo-data volume)
+#   nuke     — down + remove the mongo-data volume
+#   seed     — install Node deps for seed/ + run seed_all.mjs
+#   clear    — drop every loadtest-tagged document
+#   smoke    — run scripts/smoke.mjs against http://localhost:3141
+#   logs     — tail the reviewer-backend container
+#   status   — docker ps + curl /api/health
+#
+# Usage examples:
+#   pwsh -File testing/scripts/run.ps1 up
+#   pwsh -File testing/scripts/run.ps1 seed
+#   pwsh -File testing/scripts/run.ps1 smoke
+# =============================================================================
+
+param(
+  [Parameter(Mandatory = $true)][ValidateSet('up','down','nuke','seed','clear','smoke','logs','status','deps')]
+  [string]$Cmd
+)
+
+$RepoRoot    = Resolve-Path "$PSScriptRoot/../.."
+$Testing     = Resolve-Path "$PSScriptRoot/.."
+$DockerDir   = Join-Path $Testing 'docker'
+$EnvFile     = Join-Path $DockerDir 'backend-loadtest.env'
+
+function Step([string]$m) { Write-Host "`n=== $m ===" -ForegroundColor Cyan }
+function Ok([string]$m)   { Write-Host "  ✓ $m" -ForegroundColor Green }
+function Bad([string]$m)  { Write-Host "  ✗ $m" -ForegroundColor Red }
+
+switch ($Cmd) {
+  'deps' {
+    Step 'install Node deps for testing/seed'
+    Push-Location $Testing
+    if (-not (Test-Path 'node_modules')) {
+      npm install | Out-Host
+    } else { Ok 'node_modules already present' }
+    Pop-Location
+  }
+
+  'up' {
+    Step 'docker compose up -d'
+    Push-Location $DockerDir
+    if (-not (Test-Path $EnvFile)) { Bad "missing $EnvFile"; exit 1 }
+    docker compose up -d --build
+    if ($LASTEXITCODE -ne 0) { Bad 'docker compose up failed'; exit $LASTEXITCODE }
+    Pop-Location
+    Step 'waiting for /api/health'
+    $deadline = (Get-Date).AddMinutes(3)
+    while ((Get-Date) -lt $deadline) {
+      try {
+        $h = Invoke-WebRequest -Uri 'http://localhost:3141/api/health' -UseBasicParsing -TimeoutSec 3
+        if ($h.StatusCode -eq 200) { Ok "backend healthy: $($h.Content)"; return }
+      } catch { Start-Sleep -Seconds 2 }
+    }
+    Bad 'backend never became healthy — run: docker compose logs reviewer-backend'
+    exit 1
+  }
+
+  'down' {
+    Step 'docker compose down'
+    Push-Location $DockerDir
+    docker compose down
+    Pop-Location
+  }
+
+  'nuke' {
+    Step 'docker compose down -v'
+    Push-Location $DockerDir
+    docker compose down -v
+    Pop-Location
+  }
+
+  'seed' {
+    Step 'installing/testing deps'
+    & $PSCommandPath -Cmd deps
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    Step 'seed_all.mjs'
+    Push-Location $Testing
+    $env:FIREBASE_EMULATOR_HOST = 'localhost:9099'
+    node seed/seed_all.mjs
+    if ($LASTEXITCODE -ne 0) { Bad 'seed failed'; exit $LASTEXITCODE }
+    Pop-Location
+  }
+
+  'clear' {
+    Step 'drop loadtest docs'
+    Push-Location $Testing
+    node seed/clear.mjs
+    Pop-Location
+  }
+
+  'smoke' {
+    Step 'smoke.mjs'
+    Push-Location $Testing
+    node scripts/smoke.mjs
+    Pop-Location
+  }
+
+  'logs' {
+    Push-Location $DockerDir
+    docker compose logs -f reviewer-backend
+    Pop-Location
+  }
+
+  'status' {
+    Push-Location $DockerDir
+    docker compose ps
+    Pop-Location
+    try {
+      $h = Invoke-WebRequest -Uri 'http://localhost:3141/api/health' -UseBasicParsing -TimeoutSec 3
+      Ok "/api/health → $($h.StatusCode) $($h.Content)"
+    } catch { Bad '/api/health unreachable' }
+  }
+}

--- a/testing/scripts/smoke.mjs
+++ b/testing/scripts/smoke.mjs
@@ -1,0 +1,112 @@
+// =============================================================================
+// testing/scripts/smoke.mjs
+// -----------------------------------------------------------------------------
+// Phase-1 "is this thing even alive?" check. Pass criteria:
+//   1. GET /api/health                          → 200 {status:"healthy"}
+//   2. POST /api/auth/login (admin from seed)   → returns idToken
+//   3. GET  /api/questions/queue-details (auth) → 200 (admin/moderator queue)
+//
+// Step 3 is `queue-details` rather than `allocated` because `getAllocatedQuestions`
+// is wrapped in `withTransaction(...)` and Phase-1's local Mongo is a STANDALONE
+// (no replica set, no mongos) — multi-doc transactions require one or the other.
+// Phase 2/3 docker compose will stand the proper replica-set mongo, so this smoke
+// is just the host-side inner-loop check.
+//
+// We use the BACKEND's /api/auth/login (not the Auth Emu directly) because the
+// backend runs syncUserWithDb() during login, which links the Auth Emu's localId
+// to the seeded Mongo user record's `firebaseUID`. Without that step the next
+// authenticated call returns 401 "User not found in database".
+//
+// Run *after* `make up` + `make seed`.
+// =============================================================================
+
+import { connect, close } from '../seed/lib/db.mjs';
+
+const BASE = process.env.BACKEND_URL || 'http://localhost:3141';
+const PASSWORD = process.env.LOADTEST_PASSWORD || 'LoadTest#2025!';
+const FIREBASE_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST || 'localhost:9099';
+const API_KEY = process.env.FIREBASE_API_KEY || 'AIzaSyDUMMY_emulator_only_key';
+
+function step(label) {
+  console.log(`\n• ${label}`);
+}
+function ok(msg)   { console.log(`  ✓ ${msg}`); }
+function fail(msg) { console.error(`  ✗ ${msg}`); process.exitCode = 1; }
+
+async function fetchJson(url, opts = {}) {
+  const r = await fetch(url, opts);
+  let body = null;
+  try { body = await r.json(); } catch { /* not JSON */ }
+  return { status: r.status, body };
+}
+
+async function login(email) {
+  // 1. signInWithPassword via Auth Emulator
+  const signIn = await fetch(
+    `http://${FIREBASE_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${API_KEY}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password: PASSWORD, returnSecureToken: true }),
+    },
+  );
+  return signIn.json();
+}
+
+async function loginViaBackend(email) {
+  // 1. POST /api/auth/login (backend) — uses its own emulator-aware identitytoolkit
+  //    URL AND runs syncUserWithDb() to link the Auth Emu UID to the seeded
+  //    Mongo user record. The direct-to-emu login in `login()` above does
+  //    neither, so the next authenticated call would 401.
+  //    AuthController is at /auth (see src/modules/auth/controllers/AuthController.ts:42).
+  const r = await fetch(`${BASE}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: PASSWORD, returnSecureToken: true }),
+  });
+  return r.json();
+}
+
+async function main() {
+  step('1. /api/health');
+  const h = await fetchJson(`${BASE}/api/health`);
+  h.status === 200 && h.body?.status === 'healthy'
+    ? ok(`status=${h.status} body=${JSON.stringify(h.body)}`)
+    : fail(`/api/health → ${h.status} ${JSON.stringify(h.body)}`);
+
+  // Pick the admin we seeded. Look up by `email + role` because the FIRST
+  // login rewrites `firebaseUID` to whatever the Auth Emu issues (via
+  // syncUserWithDb). The email is the only stable anchor across runs.
+  const { client, db } = await connect();
+  const admin = await db.collection('users').findOne(
+    { email: 'admin@loadtest.ajrasakha.invalid', role: 'admin' }
+  );
+  await close(client);
+  if (!admin) { fail('admin not found in DB — run `npm run seed` first'); return; }
+
+  step('2. POST /api/auth/login (admin)');
+  try {
+    const tokens = await loginViaBackend(admin.email);
+    if (!tokens.idToken) {
+      fail('login returned no idToken: ' + JSON.stringify(tokens));
+      return;
+    }
+    ok(`got idToken (${tokens.idToken.length} chars)`);
+
+    step('3. GET /api/questions/queue-details (auth)');
+    const authRes = await fetchJson(`${BASE}/api/questions/queue-details`, {
+      method: 'GET',
+      headers: { 'Authorization': `Bearer ${tokens.idToken}` },
+    });
+    authRes.status < 500
+      ? ok(`status=${authRes.status} body=${JSON.stringify(authRes.body).slice(0, 300)}`)
+      : fail(`status=${authRes.status} ${JSON.stringify(authRes.body)}`);
+  } catch (err) {
+    fail(`login flow error: ${err.message}`);
+  }
+
+  if (process.exitCode) console.error('\n✗ smoke FAILED');
+  else console.log('\n✓ smoke OK');
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/testing/seed/clear.mjs
+++ b/testing/seed/clear.mjs
@@ -1,0 +1,39 @@
+// =============================================================================
+// testing/seed/clear.mjs
+// -----------------------------------------------------------------------------
+// Drops every loadtest-tagged document so a run starts from a clean slate.
+//
+// Targets:
+//   • users                       where firebaseUID matches /^lt-/
+//   • questions, question_submissions where created/updated in this DB within
+//     the last hour (i.e. seeded by the loadtest — keeps prod docs intact)
+//   • reroutes                    similarly bounded
+//
+// Safer than a full DB.dropDatabase() and survives a partial-seed crash.
+// =============================================================================
+
+import { connect, close } from './lib/db.mjs';
+
+async function main() {
+  const { client, db } = await connect();
+  console.log(`[clear] db=${process.env.DB_NAME} on ${process.env.DB_URL}`);
+
+  const u = await db.collection('users').deleteMany({ firebaseUID: { $regex: '^lt-' } });
+  const q = await db.collection('questions').deleteMany({ source: { $exists: true } });
+  const sids = (await db.collection('questions').find({ source: { $exists: true } }, { projection: { _id: 1 } }).toArray()).map((x) => x._id);
+  const s = await db.collection('question_submissions').deleteMany({ questionId: { $in: sids } });
+  const r = await db.collection('reroutes').deleteMany({});
+
+  console.log(`[clear] users -${u.deletedCount}`);
+  console.log(`[clear] questions -${q.deletedCount}`);
+  console.log(`[clear] question_submissions -${s.deletedCount}`);
+  console.log(`[clear] reroutes -${r.deletedCount}`);
+
+  await close(client);
+  console.log('[clear] done');
+}
+
+main().catch((err) => {
+  console.error('[clear] fatal:', err);
+  process.exit(1);
+});

--- a/testing/seed/ensure_indexes.mjs
+++ b/testing/seed/ensure_indexes.mjs
@@ -1,0 +1,23 @@
+// =============================================================================
+// testing/seed/ensure_indexes.mjs
+// -----------------------------------------------------------------------------
+// Creates the indexes required for the load test on the active DB.
+//
+// Run from the testing/ directory:
+//   DB_URL=… DB_NAME=agriai_loadtest node seed/ensure_indexes.mjs
+//
+// The same set is also declared in docker/mongo-init/01-loadtest-indexes.js
+// (which only fires on a brand-new Mongo container).
+// =============================================================================
+
+import { connect, close, ensureIndexes } from './lib/db.mjs';
+
+async function main() {
+  const { client, db } = await connect();
+  console.log('[indexes] creating indexes on', process.env.DB_NAME);
+  await ensureIndexes(db);
+  console.log('[indexes] done');
+  await close(client);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/testing/seed/lib/db.mjs
+++ b/testing/seed/lib/db.mjs
@@ -1,0 +1,84 @@
+// =============================================================================
+// testing/seed/lib/db.mjs
+// -----------------------------------------------------------------------------
+// Mongo connection helper for seed/clear scripts.
+//
+// Mirrors the patterns in ajrasakha/backend/scripts/recalculate-reputation-scores.mjs:
+//   • reads backend/.env via dotenv
+//   • re-uses the mongodb package from backend/node_modules
+//   • exposes both client and db so callers can use collections directly
+// =============================================================================
+
+import { MongoClient } from 'mongodb';
+import { config } from 'dotenv';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// resolve the backend .env from this file: testing/seed/lib → ../../ajrasakha/backend/.env
+export const ENV_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'ajrasakha',
+  'backend',
+  '.env',
+);
+
+export function loadEnv() {
+  config({ path: ENV_PATH });
+  if (!process.env.DB_URL || !process.env.DB_NAME) {
+    throw new Error(
+      `DB_URL / DB_NAME missing — populate ${ENV_PATH} first (copy from .env.example and set DB_NAME=agriai_loadtest).`,
+    );
+  }
+  // hard safety check — never write to a non-loadtest DB
+  if (process.env.DB_NAME !== 'agriai_loadtest') {
+    throw new Error(
+      `refusing to run: DB_NAME=${process.env.DB_NAME} (must be agriai_loadtest). ` +
+      `Set DB_NAME in backend/.env to the load-test DB.`,
+    );
+  }
+}
+
+export async function connect() {
+  loadEnv();
+  const client = new MongoClient(process.env.DB_URL, {
+    // tuned for the seed workload — bulk inserts in 1k batches
+    maxPoolSize: 20,
+    serverSelectionTimeoutMS: 10000,
+  });
+  await client.connect();
+  return { client, db: client.db(process.env.DB_NAME) };
+}
+
+export async function close(client) {
+  if (client) await client.close();
+}
+
+// Mirror of docker/mongo-init/01-loadtest-indexes.js — keeps local mongod and
+// the docker testbed in lock-step. Idempotent: createIndex no-ops on identical
+// keys; differing keys throw.
+export async function ensureIndexes(db) {
+  const tasks = [
+    ['users', { email: 1 }, { unique: true }],
+    ['users', { firebaseUID: 1 }, { unique: true }],
+    ['users', { role: 1, reputation_score: 1 }, {}],
+    ['users', { 'preference.state': 1, 'preference.crop': 1 }, {}],
+    ['questions', { status: 1, autoAllocateModerator: 1 }, {}],
+    ['questions', { 'details.state': 1, 'details.normalised_crop': 1 }, {}],
+    ['questions', { createdAt: 1 }, {}],
+    ['questions', { moderatorId: 1, status: 1 }, {}],
+    ['questions', { userId: 1, status: 1 }, {}],
+    ['question_submissions', { questionId: 1 }, {}],
+    ['question_submissions', { queue: 1 }, {}],
+    ['question_submissions', { 'history.updatedBy': 1, 'history.status': 1 }, {}],
+    ['reroutes', { questionId: 1 }, {}],
+    ['reroutes', { 'reroutes.reroutedTo': 1, 'reroutes.status': 1 }, {}],
+  ];
+  for (const [col, key, opts] of tasks) {
+    await db.collection(col).createIndex(key, opts);
+  }
+}

--- a/testing/seed/lib/fixtures.mjs
+++ b/testing/seed/lib/fixtures.mjs
@@ -1,0 +1,96 @@
+// =============================================================================
+// testing/seed/lib/fixtures.mjs
+// -----------------------------------------------------------------------------
+// Stable enumeration of states, crops, domains, sources, and statuses used by
+// the seed scripts and by the Locust tasks in Phase 3.
+// Kept in one place so seed and load gen stay in lock-step.
+// =============================================================================
+
+// 20 states + UTs keeps us realistic without exploding matrix size.
+export const STATES = [
+  'Andhra Pradesh', 'Assam', 'Bihar', 'Chhattisgarh', 'Gujarat',
+  'Haryana', 'Himachal Pradesh', 'Jharkhand', 'Karnataka', 'Kerala',
+  'Madhya Pradesh', 'Maharashtra', 'Odisha', 'Punjab', 'Rajasthan',
+  'Tamil Nadu', 'Telangana', 'Uttar Pradesh', 'Uttarakhand', 'West Bengal',
+];
+
+// Crops are the same set used by the chatbot dashboard filters.
+export const CROPS = [
+  'wheat', 'rice', 'maize', 'sugarcane', 'cotton', 'soybean',
+  'groundnut', 'mustard', 'pulses', 'millets', 'jowar', 'bajra',
+  'barley', 'turmeric', 'onion', 'potato', 'tomato', 'banana',
+  'mango', 'grapes',
+];
+
+export const SEASONS = ['kharif', 'rabi', 'zaid'];
+
+// Mirrors backend QuestionStatus union
+export const QUESTION_STATUSES = [
+  'open',
+  'in-review',
+  'closed',
+  'delayed',
+  'pae_submitted',
+  'dynamic',
+  'queue_progress',
+  'auditor_review',
+];
+
+// Mirrors backend UserRole union, only what the reviewer system exercises
+export const ROLES = {
+  EXPERT: 'expert',
+  PAE_EXPERT: 'pae_expert',
+  MODERATOR: 'moderator',
+  GATE_KEEPER: 'gate_keeper',
+  AUDITOR: 'auditor',
+  ADMIN: 'admin',
+};
+
+export const PRIORITIES = ['low', 'medium', 'high', 'critical'];
+
+// Mirrors backend QuestionSource
+export const SOURCES = [
+  'AJRASAKHA',
+  'AGRI_EXPERT',
+  'WHATSAPP',
+  'OUTREACH',
+  'CROP_DOCTOR',
+];
+
+// 20 paired crops for the duplicate-detection fixture used by Phase 4's
+// bug-1204 harness.  Each entry is [original, near-duplicate] (cosine ≥ 0.70).
+export const DUPLICATE_PAIRS = [
+  ['What is the best fertilizer for rice cultivation?', 'Which fertilizer works well for rice farming?'],
+  ['How to control aphids in mustard crop?',        'What pesticide controls aphids on mustard plants?'],
+  ['My tomato leaves have yellow spots.',          'Tomato plant leaves are turning yellow with spots.'],
+  ['When to sow wheat in Punjab?',                 'Best sowing time for wheat in Punjab state?'],
+  ['Recommended irrigation for sugarcane',         'How much water does sugarcane need?'],
+];
+
+// 10 templates that, paired with a crop, generate the bulk of synthetic Q&A.
+export const QUESTION_TEMPLATES = [
+  'What is the best fertilizer for {crop} cultivation?',
+  'How to control aphids in {crop}?',
+  'My {crop} leaves have yellow spots — what should I do?',
+  'When is the right time to sow {crop} in {state}?',
+  'Recommended irrigation schedule for {crop}',
+  'Is {crop} suitable for {season} sowing in {state}?',
+  'What pests commonly affect {crop}?',
+  'How to improve yield of {crop}?',
+  'Organic manure options for {crop}',
+  'Symptoms of nitrogen deficiency in {crop}',
+];
+
+// deterministic pseudo-random helper so re-runs produce identical seeds
+// unless SEED_TESTS_RANDOM=1 is exported.
+export function rng(seed = 1337) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+export function pick(rand, arr) {
+  return arr[Math.floor(rand() * arr.length)];
+}

--- a/testing/seed/register_firebase_users.mjs
+++ b/testing/seed/register_firebase_users.mjs
@@ -1,0 +1,103 @@
+// =============================================================================
+// testing/seed/register_firebase_users.mjs
+// -----------------------------------------------------------------------------
+// Creates matching Firebase Auth users in the Auth Emulator so /api/login
+// succeeds end-to-end against the seeded users (firebaseUID + email must exist
+// in both Mongo and Firebase Auth).
+//
+// Endpoint:
+//   POST http://<host>:<port>/identitytoolkit.googleapis.com/v1/accounts:signUp
+//   ?key=<any>  { "email": "...", "password": "...", "returnSecureToken": true }
+//
+// Configured via env:
+//   FIREBASE_EMULATOR_HOST   (default: localhost:9099)
+//   FIREBASE_API_KEY         (default: arbitrary, emulator doesn't validate)
+//
+// Usage:
+//   node testing/seed/register_firebase_users.mjs
+//   node testing/seed/register_firebase_users.mjs           # uses defaults
+// =============================================================================
+
+import { connect, close } from './lib/db.mjs';
+
+const EMULATOR_HOST = process.env.FIREBASE_EMULATOR_HOST || 'localhost:9099';
+const API_KEY       = process.env.FIREBASE_API_KEY       || 'AIzaSyDUMMY_emulator_only_key';
+const PASSWORD      = process.env.LOADTEST_PASSWORD      || 'LoadTest#2025!';
+
+async function signUp(email, password) {
+  const url = `http://${EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=${API_KEY}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, returnSecureToken: true }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    // 400 with EMAIL_EXISTS is fine — the user is already there.
+    if (res.status === 400 && /EMAIL_EXISTS/.test(text)) return { exists: true };
+    throw new Error(`signUp ${email} → HTTP ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+// Mark the freshly-registered emulator user as `emailVerified: true` so the
+// AuthController's emailVerified gate at /api/auth/login doesn't try to send
+// a real email (NODE_ENV != development → SMTP fails) and reject the login
+// with 401. Real Auth Emu users default to `emailVerified: false`.
+//
+// We re-issue the signup to get an idToken, then immediately POST to
+// accounts:update with that idToken to flip the flag. accounts:update keys off
+// the bearer idToken so we don't need to look up localId first.
+async function signUpAndVerify(email, password) {
+  const created = await signUp(email, password);
+  if (created && created.exists) return { exists: true };
+
+  const updateUrl = `http://${EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:update?key=${API_KEY}`;
+  const u = await fetch(updateUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ idToken: created.idToken, emailVerified: true, returnSecureToken: true }),
+  });
+  if (!u.ok) {
+    const text = await u.text();
+    throw new Error(`verify ${email} → HTTP ${u.status} ${text}`);
+  }
+  return { exists: false };
+}
+
+async function main() {
+  const { client, db } = await connect();
+  const users = db.collection('users');
+
+  const cursor = users.find(
+    { firebaseUID: { $regex: '^lt-' } },
+    { projection: { email: 1, firebaseUID: 1, _id: 0 } },
+  );
+
+  let ok = 0, exists = 0, fail = 0;
+  console.log(`[fb_register] emulator = ${EMULATOR_HOST}`);
+  let processed = 0;
+  for await (const u of cursor) {
+    try {
+      const r = await signUpAndVerify(u.email, PASSWORD);
+      if (r && r.exists) exists += 1;
+      else ok += 1;
+    } catch (err) {
+      fail += 1;
+      console.error(`[fb_register] ✗ ${u.email}: ${err.message}`);
+    }
+    processed += 1;
+    if (processed % 50 === 0) {
+      process.stdout.write(`\r[fb_register]   ${processed} processed (ok=${ok} exists=${exists} fail=${fail})`);
+    }
+  }
+  process.stdout.write('\n');
+  console.log(`[fb_register] done: ok=${ok}, existed=${exists}, fail=${fail}`);
+
+  await close(client);
+}
+
+main().catch((err) => {
+  console.error('[fb_register] fatal:', err);
+  process.exit(1);
+});

--- a/testing/seed/seed_all.mjs
+++ b/testing/seed/seed_all.mjs
@@ -1,0 +1,39 @@
+// =============================================================================
+// testing/seed/seed_all.mjs
+// -----------------------------------------------------------------------------
+// Orchestrates the seed in the correct order:
+//   1. seed_users.mjs          (writes to users collection)
+//   2. register_firebase_users (creates matching Auth Emulator users)
+//   3. seed_questions.mjs      (writes to questions + question_submissions)
+//
+// Idempotent: each script wipes loadtest-only docs first.
+//
+// Usage:
+//   node testing/seed/seed_all.mjs
+// =============================================================================
+
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TESTING   = resolve(__dirname, '..');
+
+function run(label, script, env = {}) {
+  console.log(`\n=== ${label} (${script}) ===`);
+  const r = spawnSync('node', [resolve(__dirname, script)], {
+    cwd: TESTING,
+    stdio: 'inherit',
+    env: { ...process.env, ...env },
+  });
+  if (r.status !== 0) {
+    console.error(`✗ ${label} failed (exit ${r.status})`);
+    process.exit(r.status ?? 1);
+  }
+}
+
+run('seed users',     'seed_users.mjs',                    { EXPERTS: '200', PAE_EXPERTS: '50', MODERATORS: '50', GATE_KEEPERS: '20', AUDITORS: '20' });
+run('register Firebase users', 'register_firebase_users.mjs', { FIREBASE_EMULATOR_HOST: 'localhost:9099' });
+run('seed questions', 'seed_questions.mjs',               { QUESTIONS: '5000' });
+
+console.log('\n✓ all seeds complete');

--- a/testing/seed/seed_questions.mjs
+++ b/testing/seed/seed_questions.mjs
@@ -1,0 +1,164 @@
+// =============================================================================
+// testing/seed/seed_questions.mjs
+// -----------------------------------------------------------------------------
+// Seeds `questions` AND matching `question_submissions` so the moderator-queue
+// cron (runModeratorQueueCron) and feedback allocation cron
+// (allocateFeedbackQuestions) actually have work to do under load.
+//
+// Schema sources:
+//   • backend/src/modules/question/classes/transformers/Question.ts
+//   • backend/src/shared/interfaces/models.ts (IQuestion, IQuestionSubmission)
+//
+// Usage:
+//   node testing/seed/seed_questions.mjs                          # default 5000
+//   QUESTIONS=20000 STATUS_MIX=open:0.4,in-review:0.4,closed:0.2 node ...
+// =============================================================================
+
+import { connect, close } from './lib/db.mjs';
+import {
+  STATES, CROPS, SEASONS, SOURCES, PRIORITIES,
+  QUESTION_STATUSES, QUESTION_TEMPLATES, DUPLICATE_PAIRS, rng, pick,
+} from './lib/fixtures.mjs';
+
+const TOTAL = Number(process.env.QUESTIONS) || 5000;
+const DUPLICATE_FRACTION = Number(process.env.DUPLICATE_FRACTION) || 0.1;
+
+function parseStatusMix(env) {
+  if (!env) return { open: 0.6, 'in-review': 0.3, closed: 0.05, delayed: 0.05 };
+  const map = {};
+  for (const part of env.split(',')) {
+    const [s, p] = part.split(':');
+    map[s.trim()] = parseFloat(p);
+  }
+  const sum = Object.values(map).reduce((a, b) => a + b, 0);
+  for (const k of Object.keys(map)) map[k] /= sum;
+  return map;
+}
+
+function pickStatus(rand, mix) {
+  const r = rand();
+  let acc = 0;
+  for (const [s, p] of Object.entries(mix)) { acc += p; if (r < acc) return s; }
+  return Object.keys(mix)[0];
+}
+
+function fakeEmbedding(rand) {
+  const v = new Array(1024);
+  for (let i = 0; i < 1024; i++) v[i] = (rand() - 0.5) * 0.02;
+  let norm = 0;
+  for (const x of v) norm += x * x;
+  norm = Math.sqrt(norm) || 1;
+  return v.map((x) => x / norm);
+}
+
+function nearDuplicateEmbedding(base) {
+  return base.map((x) => x + (Math.random() - 0.5) * 0.001);
+}
+
+function buildRandomQuestion(rand, idx, statusMix) {
+  const template = pick(rand, QUESTION_TEMPLATES);
+  const crop = pick(rand, CROPS);
+  const state = pick(rand, STATES);
+  const season = pick(rand, SEASONS);
+  const status = pickStatus(rand, statusMix);
+  const createdAt = new Date(Date.now() - Math.floor(rand() * 14 * 86400_000));
+
+  const doc = {
+    question: template.replace('{crop}', crop).replace('{state}', state).replace('{season}', season),
+    status, priority: pick(rand, PRIORITIES), totalAnswersCount: 0,
+    isAutoAllocate: status === 'open' || status === 'in-review' || status === 'pae_submitted',
+    autoAllocateModerator: status === 'open' || status === 'in-review' || status === 'pae_submitted',
+    source: pick(rand, SOURCES), embedding: fakeEmbedding(rand), metrics: null,
+    details: { state, district: 'all', crop, season, domain: ['agronomy'], normalised_crop: crop },
+    createdAt, updatedAt: createdAt,
+  };
+  if (status === 'closed') {
+    doc.closedAt = new Date(createdAt.getTime() + Math.floor(rand() * 3 * 86400_000));
+    doc.isClosed = true;
+    doc.closedBy = 'system';
+  }
+  return doc;
+}
+
+function buildDuplicatePair(rand) {
+  const pair = pick(rand, DUPLICATE_PAIRS);
+  const state = pick(rand, STATES);
+  const crop = 'wheat';
+  const emb = fakeEmbedding(rand);
+  const createdAt = new Date(Date.now() - 86400_000);
+  return [
+    { question: pair[0], originalQuestion: pair[1], status: 'queue_duplicate', priority: 'medium',
+      totalAnswersCount: 0, isAutoAllocate: false, autoAllocateModerator: true,
+      source: 'AJRASAKHA', embedding: emb,
+      details: { state, district: 'all', crop, season: 'kharif', domain: ['agronomy'], normalised_crop: crop },
+      metrics: { mean_similarity: 0.92, std_similarity: 0.001 },
+      similarityScore: 92, isDuplicateChecked: true, createdAt, updatedAt: createdAt },
+    { question: pair[1], status: 'queue_duplicate', priority: 'medium',
+      totalAnswersCount: 0, isAutoAllocate: false, autoAllocateModerator: true,
+      source: 'AJRASAKHA', embedding: nearDuplicateEmbedding(emb),
+      details: { state, district: 'all', crop, season: 'kharif', domain: ['agronomy'], normalised_crop: crop },
+      metrics: { mean_similarity: 0.92, std_similarity: 0.001 },
+      similarityScore: 91, isDuplicateChecked: true, createdAt, updatedAt: createdAt },
+  ];
+}
+
+async function main() {
+  const rand = rng(1337);
+  const statusMix = parseStatusMix(process.env.STATUS_MIX);
+  const { client, db } = await connect();
+  const questions = db.collection('questions');
+  const submissions = db.collection('question_submissions');
+
+  console.log(`[seed_questions] connecting → ${process.env.DB_URL} db=${process.env.DB_NAME}`);
+  console.log(`[seed_questions] target ${TOTAL} questions; status mix:`, statusMix);
+
+  // ── Wipe prior loadtest questions + their submissions ─────────────────────
+  const priorIds = (await questions.find({ source: { $exists: true } }).project({ _id: 1 }).toArray()).map((q) => q._id);
+  if (priorIds.length) {
+    await submissions.deleteMany({ questionId: { $in: priorIds } });
+    await questions.deleteMany({ _id: { $in: priorIds } });
+  }
+  console.log(`[seed_questions] cleared ${priorIds.length} prior loadtest questions`);
+
+  // ── 1. Pre-allocate the curated DUPLICATE_PAIRS first ─────────────────────
+  const dupDocs = [];
+  for (let i = 0; i < DUPLICATE_PAIRS.length; i++) dupDocs.push(...buildDuplicatePair(rand));
+  if (dupDocs.length) await questions.insertMany(dupDocs, { ordered: false });
+  console.log(`[seed_questions] inserted ${dupDocs.length} curated duplicate-pair questions`);
+
+  // ── 2. Bulk-insert the synthetic loadtest questions ──────────────────────
+  console.log(`[seed_questions] generating ${TOTAL} random questions…`);
+  const docs = [];
+  for (let i = 0; i < TOTAL; i++) docs.push(buildRandomQuestion(rand, i, statusMix));
+  const BATCH = 1000;
+  for (let i = 0; i < docs.length; i += BATCH) {
+    await questions.insertMany(docs.slice(i, i + BATCH), { ordered: false });
+    process.stdout.write(`\r[seed_questions]   ${Math.min(i + BATCH, docs.length)}/${docs.length}`);
+  }
+  process.stdout.write('\n');
+
+  // ── 3. Build matching question_submissions for every open question ────────
+  const openIds = (await questions.find({ autoAllocateModerator: true }, { projection: { _id: 1 } }).toArray())
+    .map((q) => q._id);
+  const submissionDocs = openIds.map((qid) => ({
+    questionId: qid,
+    queue: [],          // empty ⇒ eligible for moderator allocation by the cron
+    history: [],        // empty ⇒ never reviewed yet
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }));
+  console.log(`[seed_questions] creating ${submissionDocs.length} empty submissions…`);
+  for (let i = 0; i < submissionDocs.length; i += BATCH) {
+    await submissions.insertMany(submissionDocs.slice(i, i + BATCH), { ordered: false });
+    process.stdout.write(`\r[seed_questions]   submissions ${Math.min(i + BATCH, submissionDocs.length)}/${submissionDocs.length}`);
+  }
+  process.stdout.write('\n');
+
+  await close(client);
+  console.log('[seed_questions] done');
+}
+
+main().catch(async (err) => {
+  console.error('[seed_questions] failed:', err);
+  process.exit(1);
+});

--- a/testing/seed/seed_users.mjs
+++ b/testing/seed/seed_users.mjs
@@ -1,0 +1,163 @@
+// =============================================================================
+// testing/seed/seed_users.mjs
+// -----------------------------------------------------------------------------
+// Seeds the `users` collection with:
+//   • 200 experts / pae_experts
+//   • 50 moderators / 20 auditors / 20 gate_keepers
+//   • 1 admin
+// Schema sources: backend/src/modules/auth/classes/transformers/User.ts
+// =============================================================================
+
+import { connect, close } from './lib/db.mjs';
+import {
+  STATES,
+  CROPS,
+  ROLES,
+  rng,
+  pick,
+} from './lib/fixtures.mjs';
+import { faker } from '@faker-js/faker';
+
+const COUNTS = {
+  EXPERT: Number(process.env.EXPERTS) || 200,
+  PAE_EXPERT: Number(process.env.PAE_EXPERTS) || 0,
+  MODERATOR: Number(process.env.MODERATORS) || 50,
+  GATE_KEEPER: Number(process.env.GATE_KEEPERS) || 20,
+  AUDITOR: Number(process.env.AUDITORS) || 20,
+  ADMIN: 1,
+};
+
+function buildExpert(rand, idx) {
+  const state = pick(rand, STATES);
+  const crop = pick(rand, CROPS);
+  const now = new Date();
+  return {
+    firebaseUID: `lt-expert-${String(idx).padStart(5, '0')}`,
+    email: `expert.${String(idx).padStart(5, '0')}@loadtest.ajrasakha.invalid`,
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    role: ROLES.EXPERT,
+    status: 'active',
+    isBlocked: false,
+    isVerified: true,
+    reputation_score: Math.floor(rand() * 50), // 0..49
+    preference: { crop, state, district: 'all', domain: 'all' },
+    mobile: faker.phone.number({ style: 'national' }),
+    notificationRetention: '30',
+    isCallAgentActive: false,
+    agent: 'not_available',
+    isBusy: false,
+    currentCallUuid: null,
+    isTrainingUser: false,
+    Call_centre_manager: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function buildPaeExpert(rand, idx) {
+  const u = buildExpert(rand, idx);
+  u.role = ROLES.PAE_EXPERT;
+  u.firebaseUID = `lt-pae-${String(idx).padStart(5, '0')}`;
+  u.email = `pae.${String(idx).padStart(5, '0')}@loadtest.ajrasakha.invalid`;
+  return u;
+}
+
+function buildModerator(rand, idx) {
+  const now = new Date();
+  return {
+    firebaseUID: `lt-mod-${String(idx).padStart(5, '0')}`,
+    email: `mod.${String(idx).padStart(5, '0')}@loadtest.ajrasakha.invalid`,
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    role: ROLES.MODERATOR,
+    status: 'active',
+    isBlocked: false,
+    isVerified: true,
+    reputation_score: 0,
+    preference: { crop: 'all', state: 'all', district: '', domain: 'all' },
+    mobile: faker.phone.number({ style: 'national' }),
+    notificationRetention: '30',
+    isCallAgentActive: false,
+    agent: 'not_available',
+    isBusy: false,
+    currentCallUuid: null,
+    isTrainingUser: false,
+    Call_centre_manager: false,
+    feedbacksAssigned: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function buildGateKeeper(rand, idx) {
+  const u = buildModerator(rand, idx);
+  u.role = ROLES.GATE_KEEPER;
+  u.firebaseUID = `lt-gk-${String(idx).padStart(5, '0')}`;
+  u.email = `gk.${String(idx).padStart(5, '0')}@loadtest.ajrasakha.invalid`;
+  return u;
+}
+
+function buildAuditor(rand, idx) {
+  const u = buildModerator(rand, idx);
+  u.role = ROLES.AUDITOR;
+  u.firebaseUID = `lt-aud-${String(idx).padStart(5, '0')}`;
+  u.email = `aud.${String(idx).padStart(5, '0')}@loadtest.ajrasakha.invalid`;
+  return u;
+}
+
+function buildAdmin() {
+  const now = new Date();
+  return {
+    firebaseUID: 'lt-admin-00001',
+    email: 'admin@loadtest.ajrasakha.invalid',
+    firstName: 'LoadTest', lastName: 'Admin',
+    role: ROLES.ADMIN, status: 'active', isBlocked: false, isVerified: true,
+    reputation_score: 0,
+    preference: { crop: 'all', state: 'all', district: '', domain: 'all' },
+    mobile: '0000000000', notificationRetention: '30',
+    isCallAgentActive: false, agent: 'not_available', isBusy: false,
+    createdAt: now, updatedAt: now,
+  };
+}
+
+async function main() {
+  const rand = rng(1337);
+  const { client, db } = await connect();
+  const users = db.collection('users');
+
+  console.log(`[seed_users] connecting → ${process.env.DB_URL} db=${process.env.DB_NAME}`);
+
+  const wipeResult = await users.deleteMany({ firebaseUID: { $regex: '^lt-' } });
+  console.log(`[seed_users] wiped ${wipeResult.deletedCount} prior loadtest users`);
+
+  const docs = [];
+  for (let i = 0; i < COUNTS.EXPERT; i++) docs.push(buildExpert(rand, i));
+  for (let i = 0; i < COUNTS.PAE_EXPERT; i++) docs.push(buildPaeExpert(rand, i));
+  for (let i = 0; i < COUNTS.MODERATOR; i++) docs.push(buildModerator(rand, i));
+  for (let i = 0; i < COUNTS.GATE_KEEPER; i++) docs.push(buildGateKeeper(rand, i));
+  for (let i = 0; i < COUNTS.AUDITOR; i++) docs.push(buildAuditor(rand, i));
+  docs.push(buildAdmin());
+
+  console.log(`[seed_users] inserting ${docs.length} users (1k batches)…`);
+  const BATCH = 1000;
+  for (let i = 0; i < docs.length; i += BATCH) {
+    await users.insertMany(docs.slice(i, i + BATCH), { ordered: false });
+    process.stdout.write(`\r[seed_users]   ${Math.min(i + BATCH, docs.length)}/${docs.length}`);
+  }
+  process.stdout.write('\n');
+
+  const grouped = await users
+    .aggregate([{ $match: { firebaseUID: { $regex: '^lt-' } } }, { $group: { _id: '$role', n: { $sum: 1 } } }])
+    .toArray();
+  console.log('[seed_users] by role:');
+  for (const g of grouped) console.log(`  ${g._id.padEnd(14)} ${g.n}`);
+
+  await close(client);
+  console.log('[seed_users] done');
+}
+
+main().catch(async (err) => {
+  console.error('[seed_users] failed:', err);
+  process.exit(1);
+});

--- a/testing/tests/test_aggregator.py
+++ b/testing/tests/test_aggregator.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for `aggregate_results.py` — the per-scenario SLA aggregator.
+
+These tests cover pure logic (CSV in → dict out → SLA gates) and do not
+require Mongo, the backend, or Locust to be running.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+# Make `testing/scripts/` importable.
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "testing" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from aggregate_results import (  # noqa: E402  (path setup above)
+    _percentile,
+    _per_endpoint,
+    _sla_summary,
+    _cosine_p95,
+    _load_budgets,
+    SLA_P95_ALLOCATE_MS,
+    SLA_HTTP_5XX_RATIO,
+    SLA_QUEUE_WAIT_S,
+    SLA_COSINE_P95_MS,
+)
+
+# Use the real YAML-driven budgets so tests cover the same path the
+# aggregator runs in production.
+BUDGETS = _load_budgets()
+
+
+# ---------------- _percentile ---------------------------------------------
+
+class TestPercentile:
+    def test_empty(self) -> None:
+        assert _percentile([], 0.95) == 0.0
+
+    def test_single(self) -> None:
+        assert _percentile([42.0], 0.95) == 42.0
+
+    def test_p50_odd_count(self) -> None:
+        # sorted = [10, 20, 30]; p50 (k=1.0) -> 20
+        assert _percentile([30, 10, 20], 0.50) == 20.0
+
+    def test_p95_linear_interp(self) -> None:
+        # sorted = [10..100] step 10 (n=10); p95 (k = 9*0.95 = 8.55)
+        # -> s[8] + (s[9]-s[8]) * 0.55 = 90 + 10*0.55 = 95.5
+        vals = list(range(10, 110, 10))
+        assert _percentile(vals, 0.95) == pytest.approx(95.5, abs=0.001)
+
+
+# ---------------- _per_endpoint -------------------------------------------
+
+class TestPerEndpoint:
+    def test_groups_by_name(self) -> None:
+        rows = [
+            {"name": "list_allocated", "response_time_ms": "100", "status_code": "200"},
+            {"name": "list_allocated", "response_time_ms": "200", "status_code": "200"},
+            {"name": "submit_review",  "response_time_ms": "300", "status_code": "500"},
+        ]
+        agg = _per_endpoint(rows)
+        assert set(agg.keys()) == {"list_allocated", "submit_review"}
+        assert agg["list_allocated"]["count"] == 2
+        assert agg["submit_review"]["err_count"] == 1
+
+    def test_zero_division_is_safe(self) -> None:
+        # A row with name="" should be ignored, leaving the rest fine.
+        rows = [{"name": "", "response_time_ms": "0", "status_code": "0"}]
+        assert _per_endpoint(rows) == {}
+
+    def test_p95_within_budget(self) -> None:
+        # 100 samples at 100ms; p95 should be well below 800ms.
+        rows = [
+            {"name": "allocate-experts", "response_time_ms": str(100 + i),
+             "status_code": "200"}
+            for i in range(100)
+        ]
+        agg = _per_endpoint(rows)
+        assert agg["allocate-experts"]["p95_ms"] < SLA_P95_ALLOCATE_MS
+
+    def test_5xx_ratio(self) -> None:
+        rows = (
+            [{"name": "queue_details", "response_time_ms": "50",
+              "status_code": "200"}] * 999
+            + [{"name": "queue_details", "response_time_ms": "50",
+                "status_code": "500"}]
+        )
+        agg = _per_endpoint(rows)
+        # 0.1% error rate exactly — at the budget boundary.
+        assert agg["queue_details"]["err_ratio"] == pytest.approx(
+            SLA_HTTP_5XX_RATIO, abs=0.0001
+        )
+
+
+# ---------------- _cosine_p95 ----------------------------------------------
+
+class TestCosineP95:
+    def test_filters_by_endpoint(self) -> None:
+        rows = [
+            {"endpoint": "/api/questions/check-duplicate", "response_time_ms": "100"},
+            {"endpoint": "/api/questions/check-duplicate", "response_time_ms": "200"},
+            {"endpoint": "/api/questions/allocated",        "response_time_ms": "9999"},
+        ]
+        # Only cosine samples should count.
+        assert _cosine_p95(rows) == pytest.approx(195.0, abs=1.0)
+
+    def test_no_samples_returns_zero(self) -> None:
+        rows = [{"endpoint": "/api/questions/allocated", "response_time_ms": "100"}]
+        assert _cosine_p95(rows) == 0.0
+
+
+# ---------------- _sla_summary ---------------------------------------------
+
+def _full_agg(max_ms: float, err_ratio: float = 0.0,
+              p95_ms: float = 100.0) -> Dict[str, Dict[str, float]]:
+    """Helper: produce a fully-populated `agg` row the way `_per_endpoint`
+    would (the real `_sla_summary` reads `err_ratio`, `p95_ms`, `max_ms`)."""
+    return {"q": {
+        "count": 1, "p50_ms": p95_ms, "p95_ms": p95_ms, "p99_ms": p95_ms,
+        "max_ms": max_ms, "err_count": 0, "err_ratio": err_ratio,
+    }}
+
+
+class TestSlaSummary:
+    def _call(self, agg, **kw):
+        return _sla_summary(
+            scenario="1x_locust",
+            agg=agg,
+            rep_drift_count=kw.get("rep_drift_count", 0),
+            cosine_p95_ms=kw.get("cosine_p95_ms", 900.0),
+            end_queue_lengths=kw.get("end_queue_lengths", {}),
+            budgets=BUDGETS,
+        )
+
+    def test_s1_pass_when_max_latency_under_60s(self) -> None:
+        out = self._call(_full_agg(max_ms=30_000.0))
+        s1 = next(r for r in out if r[0] == "S1")
+        assert s1[2] is True
+
+    def test_s1_fail_when_max_latency_over_60s(self) -> None:
+        out = self._call(_full_agg(max_ms=90_000.0))
+        s1 = next(r for r in out if r[0] == "S1")
+        assert s1[2] is False
+
+    def test_s5_pass_when_no_5xx(self) -> None:
+        out = self._call(_full_agg(max_ms=1000.0, err_ratio=0.0))
+        s5 = next(r for r in out if r[0] == "S5")
+        assert s5[2] is True
+
+    def test_s5_fail_when_5xx_over_budget(self) -> None:
+        # At 1× the per-scenario budget is 0.5%; any ratio over that fails.
+        out = self._call(_full_agg(max_ms=1000.0, err_ratio=0.01))
+        s5 = next(r for r in out if r[0] == "S5")
+        assert s5[2] is False
+
+    def test_s6_fail_on_any_drift(self) -> None:
+        out = self._call(_full_agg(max_ms=1000.0), rep_drift_count=1)
+        s6 = next(r for r in out if r[0] == "S6")
+        assert s6[2] is False
+
+    def test_s6_pass_on_zero_drift(self) -> None:
+        out = self._call(_full_agg(max_ms=1000.0), rep_drift_count=0)
+        s6 = next(r for r in out if r[0] == "S6")
+        assert s6[2] is True
+
+    def test_s7_pass_under_budget(self) -> None:
+        out = self._call(_full_agg(max_ms=1000.0),
+                         cosine_p95_ms=SLA_COSINE_P95_MS - 1.0)
+        s7 = next(r for r in out if r[0] == "S7")
+        assert s7[2] is True
+
+    def test_s7_fail_over_budget(self) -> None:
+        out = self._call(_full_agg(max_ms=1000.0),
+                         cosine_p95_ms=SLA_COSINE_P95_MS + 1.0)
+        s7 = next(r for r in out if r[0] == "S7")
+        assert s7[2] is False
+
+    def test_returns_seven_rows(self) -> None:
+        out = self._call(_full_agg(max_ms=1000.0))
+        ids = [r[0] for r in out]
+        assert ids == ["S1", "S2", "S3", "S4", "S5", "S6", "S7"]
+
+    def test_s3_pass_when_queue_drained(self) -> None:
+        # At 1× the threshold is 100; an end-of-run queue length of 50 passes.
+        out = self._call(_full_agg(max_ms=1000.0),
+                         end_queue_lengths={"/api/questions/allocated": 50})
+        s3 = next(r for r in out if r[0] == "S3")
+        assert s3[2] is True
+
+    def test_s3_fail_when_queue_above_threshold(self) -> None:
+        # At 1× the threshold is 100; 400 fails.
+        out = self._call(_full_agg(max_ms=1000.0),
+                         end_queue_lengths={"/api/questions/allocated": 400})
+        s3 = next(r for r in out if r[0] == "S3")
+        assert s3[2] is False
+
+    def test_s4_pass_when_no_breaches(self) -> None:
+        # A single "POST /api/auth/login" row at 100 ms — well under 400.
+        agg = {"POST /api/auth/login": {
+            "count": 1, "p50_ms": 100.0, "p95_ms": 100.0, "p99_ms": 100.0,
+            "max_ms": 100.0, "err_count": 0, "err_ratio": 0.0,
+        }}
+        out = self._call(agg)
+        s4 = next(r for r in out if r[0] == "S4")
+        assert s4[2] is True
+
+    def test_s4_fail_on_endpoint_breach(self) -> None:
+        # Same row but at 500 ms — over the 400 ms budget.
+        agg = {"POST /api/auth/login": {
+            "count": 1, "p50_ms": 500.0, "p95_ms": 500.0, "p99_ms": 500.0,
+            "max_ms": 500.0, "err_count": 0, "err_ratio": 0.0,
+        }}
+        out = self._call(agg)
+        s4 = next(r for r in out if r[0] == "S4")
+        assert s4[2] is False

--- a/testing/tests/test_assertions.py
+++ b/testing/tests/test_assertions.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for `helpers/assertions.py` — the Locust event listener.
+
+These tests focus on the parts that don't need Locust's runner:
+the lock-aware CSV writers and the snapshot/queue-length accumulators.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+import threading
+from pathlib import Path
+from typing import List
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+LOCUST_DIR = ROOT / "testing" / "locust"
+
+# Pre-load the REAL `locust` package from site-packages before any
+# harness module runs. Without this, pytest's sys.path manipulation
+# lets `from locust import events` (inside `assertions.py`) resolve to
+# the empty `testing/locust/__init__.py`, which raises
+# `ImportError: cannot import name 'events'`.
+import locust  # noqa: E402, F401  — must precede harness imports below
+assert locust.__file__ is not None and "site-packages" in locust.__file__, (
+    f"Pre-loaded locust is not the real package: {locust.__file__}"
+)
+
+# Add sub-package dirs only — NOT `testing/locust/` itself, which would
+# shadow the real `locust` package on sys.path.
+for sub in ("helpers", "users", "tasks"):
+    p = str(LOCUST_DIR / sub)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import assertions as A  # noqa: E402  (path setup above)
+
+
+@pytest.fixture
+def clean_listener(tmp_path, monkeypatch):
+    """Reset listener state before each test and point at a tmp dir."""
+    A._results_dir = None
+    A._request_csv = None
+    A._request_csv_writer = None
+    A._assertions_csv_writer = None
+    A._assertions_file = None
+    A._reputation_snapshots = {}
+    A._reputation_snapshot_history = []
+    A._assertion_counts = {}
+    A._failed_request_count = {}
+    A._total_request_count = {}
+    A._queue_lengths = []
+    A._cosine_p95_samples = []
+    A.init(str(tmp_path))
+    yield tmp_path
+    A.close()
+
+
+class TestInit:
+    def test_creates_requests_csv_with_header(self, clean_listener, tmp_path) -> None:
+        p = tmp_path / "requests.csv"
+        assert p.exists()
+        with open(p, newline="", encoding="utf-8") as f:
+            header = next(csv.reader(f))
+        assert header[0] == "timestamp"
+        assert "endpoint" in header
+        assert "status_code" in header
+
+    def test_creates_assertions_csv_with_header(self, clean_listener, tmp_path) -> None:
+        p = tmp_path / "assertions.csv"
+        assert p.exists()
+
+
+class TestRecordRequest:
+    def test_appends_row(self, clean_listener, tmp_path) -> None:
+        A.record_request(
+            endpoint="/x", method="GET", name="n", status_code=200,
+            response_time_ms=12.0, response_length=10,
+            failure=None, assertion="PASS", context={"k": "v"},
+        )
+        with open(tmp_path / "requests.csv", newline="", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        assert len(rows) == 2  # header + 1
+        assert rows[1][3] == "n"
+        assert rows[1][4] == "200"
+
+    def test_5xx_bumps_failure_count(self, clean_listener) -> None:
+        A.record_request(
+            endpoint="/x", method="GET", name="alloc", status_code=503,
+            response_time_ms=5.0, response_length=0,
+            failure="HTTP 503", assertion="FAIL_5XX", context={},
+        )
+        ratio = A.get_failure_ratio()
+        assert ratio["alloc"] == 1.0
+        assert A.get_assertion_counts().get("HTTP_5XX") == 1
+
+
+class TestRaceOnClose:
+    """The known race: `_on_quitting` closes the file while a writer is
+    mid-row. The fix puts `close()` under `_lock`. This test exercises
+    that the lock prevents the ValueError that would otherwise come
+    from writing to a closed file."""
+
+    def test_close_waits_for_record_request(self, clean_listener) -> None:
+        errors: List[Exception] = []
+
+        def writer():
+            try:
+                for _ in range(1000):
+                    A.record_request(
+                        endpoint="/x", method="GET", name="n",
+                        status_code=200, response_time_ms=1.0,
+                        response_length=0, failure=None,
+                        assertion="PASS", context={},
+                    )
+            except Exception as e:  # pragma: no cover
+                errors.append(e)
+
+        t = threading.Thread(target=writer)
+        t.start()
+        A.close()  # should block until writer is done with this batch.
+        t.join(timeout=5.0)
+        assert not errors
+
+
+class TestReputationSnapshots:
+    def test_record_and_read_back(self, clean_listener) -> None:
+        A.record_reputation_snapshot("u1", {"reputation_score": 5, "at": 0.0})
+        snaps = A.get_reputation_snapshots()
+        assert snaps["u1"]["reputation_score"] == 5
+
+    def test_write_csv_with_expected_columns(self, clean_listener, tmp_path) -> None:
+        A.record_reputation_snapshot("u1", {"reputation_score": 5})
+        A.record_reputation_snapshot("u2", {"reputation_score": 7})
+        out = A.write_reputation_snapshot_csv()
+        assert out.exists()
+        assert out == tmp_path / "reputation_snapshots.csv"
+
+    def test_history_appends_every_event(self, clean_listener) -> None:
+        A.record_reputation_snapshot("u1", {"reputation_score": 5, "at": 1.0})
+        A.record_reputation_snapshot("u1", {"reputation_score": 7, "at": 2.0})
+        A.record_reputation_snapshot("u2", {"reputation_score": 3, "at": 3.0})
+        hist = A.get_reputation_snapshot_history()
+        assert len(hist) == 3
+        assert hist[0] == (1.0, "u1", 5.0, "")
+        assert hist[1] == (2.0, "u1", 7.0, "")
+        assert hist[2] == (3.0, "u2", 3.0, "")
+
+    def test_history_csv_writes_with_expected_columns(
+        self, clean_listener, tmp_path,
+    ) -> None:
+        A.record_reputation_snapshot("u1", {"reputation_score": 5, "at": 2.0})
+        A.record_reputation_snapshot("u1", {"reputation_score": 7, "at": 1.0})
+        A.record_reputation_snapshot("u2", {"reputation_score": 3, "at": 3.0})
+        out = A.write_reputation_snapshot_history_csv()
+        assert out == tmp_path / "reputation_snapshot_history.csv"
+        rows = list(csv.reader(open(out, encoding="utf-8")))
+        assert rows[0] == ["at", "user_id", "reputation_score", "context"]
+        # u1 sorted by (user_id, at) → 1.0 then 2.0
+        assert rows[1][1] == "u1" and rows[2][1] == "u1"
+        assert float(rows[1][0]) < float(rows[2][0])
+
+
+class TestQueueLengths:
+    def test_record_and_dump(self, clean_listener, tmp_path) -> None:
+        A.record_queue_length("/queue", 12)
+        A.record_queue_length("/queue", 18)
+        out = A.write_queue_length_csv()
+        assert out is not None
+        assert out.exists()
+        with open(out, newline="", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        assert len(rows) == 3  # header + 2
+        assert rows[1][2] == "12"
+        assert rows[2][2] == "18"
+
+
+class TestCosineSamples:
+    def test_record_and_percentile(self, clean_listener) -> None:
+        for v in [100, 200, 300, 400, 500]:
+            A.record_cosine_sample(float(v))
+        samples = A.get_cosine_samples()
+        assert samples == [100.0, 200.0, 300.0, 400.0, 500.0]

--- a/testing/tests/test_harness_imports.py
+++ b/testing/tests/test_harness_imports.py
@@ -1,0 +1,83 @@
+"""
+Smoke tests: every harness module parses and binds its top-level names.
+
+These tests intentionally do NOT recursively import every dependency —
+they parse-check each file with `py_compile`, which catches syntax
+errors and indentation issues without executing module-level code
+(so the `from locust import …` chain never runs).
+
+Catches:
+* Python syntax errors in any harness file.
+* Bad indentation, missing colons, etc.
+
+Does NOT catch:
+* Circular import loops (those require running the full module graph).
+
+Does not require a live backend, Mongo, or Locust runtime.
+"""
+from __future__ import annotations
+
+import py_compile
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+LOCUST = ROOT / "testing" / "locust"
+
+
+def _list_modules(subdir: str) -> List[Path]:
+    d = LOCUST / subdir
+    return sorted(p for p in d.glob("*.py") if p.name != "__init__.py")
+
+
+def _syntax_check(path: Path) -> None:
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".pyc", delete=True) as tmp:
+        py_compile.compile(str(path), doraise=True, cfile=tmp.name)
+
+
+@pytest.mark.parametrize("path", _list_modules("helpers"),
+                         ids=lambda p: p.name)
+def test_helpers_parse(path: Path) -> None:
+    _syntax_check(path)
+
+
+@pytest.mark.parametrize("path", _list_modules("tasks"),
+                         ids=lambda p: p.name)
+def test_tasks_parse(path: Path) -> None:
+    _syntax_check(path)
+
+
+@pytest.mark.parametrize("path", _list_modules("users"),
+                         ids=lambda p: p.name)
+def test_users_parse(path: Path) -> None:
+    _syntax_check(path)
+
+
+def test_locustfile_reviewer_parses() -> None:
+    _syntax_check(LOCUST / "locustfile_reviewer.py")
+
+
+def test_scenarios_parse() -> None:
+    for p in (LOCUST / "scenarios").glob("*.py"):
+        _syntax_check(p)
+
+
+def test_all_harness_subdirs_present() -> None:
+    for sub in ("helpers", "users", "tasks", "scenarios"):
+        d = LOCUST / sub
+        assert d.is_dir(), f"missing subdir: {d}"
+        assert any(d.glob("*.py")), f"no .py files in {d}"
+
+
+def test_no_stray_init_pyc_in_locust() -> None:
+    """The harness MUST keep its empty `__init__.py` files — pytest
+    collection relies on them NOT being there (otherwise pytest tries
+    to import `testing.locust` as a real package and shadows the real
+    Locust install)."""
+    for sub in ("helpers", "users", "tasks"):
+        init = LOCUST / sub / "__init__.py"
+        assert init.exists(), f"missing harness marker: {init}"

--- a/testing/tests/test_reconcile_reputation.py
+++ b/testing/tests/test_reconcile_reputation.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for `scripts/reconcile_reputation.py` — the post-run reconciliation
+that produces the S6 (`REP_DRIFT`) and `REP_RACE_MONOTONICITY` counts.
+
+We do NOT exercise the live Mongo path here (it would require a replica set).
+Only `_detect_monotonicity_races`, which is the in-memory race detector.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "testing" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import reconcile_reputation as R  # noqa: E402
+
+
+def _write_history(path: Path, rows: list[tuple[str, str, str, str]]) -> None:
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["at", "user_id", "reputation_score", "context"])
+        for r in rows:
+            w.writerow(r)
+
+
+def test_no_history_file_returns_empty(tmp_path: Path) -> None:
+    """Missing history file → zero races (not an error)."""
+    races = R._detect_monotonicity_races(tmp_path / "nope.csv")
+    assert races == []
+
+
+def test_monotonic_run_yields_zero_races(tmp_path: Path) -> None:
+    p = tmp_path / "h.csv"
+    _write_history(p, [
+        ("1.0", "u1", "1", "POST /api/answers"),
+        ("2.0", "u1", "2", "POST /api/answers"),
+        ("3.0", "u1", "5", "POST /api/answers/moderator/approve"),
+    ])
+    assert R._detect_monotonicity_races(p) == []
+
+
+def test_single_race_detected(tmp_path: Path) -> None:
+    p = tmp_path / "h.csv"
+    _write_history(p, [
+        ("1.0", "u1", "5", "POST /api/answers"),
+        ("2.0", "u1", "7", "POST /api/answers"),
+        ("3.0", "u1", "6", "POST /api/answers/moderator/approve"),  # race
+    ])
+    races = R._detect_monotonicity_races(p)
+    assert len(races) == 1
+    uid, prev, curr, prev_ctx, curr_ctx = races[0]
+    assert uid == "u1"
+    assert prev == 7.0 and curr == 6.0
+    assert "POST /api/answers" in prev_ctx
+    assert "moderator/approve" in curr_ctx
+
+
+def test_race_is_per_user_isolated(tmp_path: Path) -> None:
+    p = tmp_path / "h.csv"
+    _write_history(p, [
+        ("1.0", "u1", "5", "ctx"),
+        ("2.0", "u1", "7", "ctx"),  # up, fine
+        ("1.5", "u2", "3", "ctx"),
+        ("2.5", "u2", "2", "ctx"),  # race for u2 only
+    ])
+    races = R._detect_monotonicity_races(p)
+    assert len(races) == 1
+    assert races[0][0] == "u2"
+
+
+def test_malformed_rows_are_skipped(tmp_path: Path) -> None:
+    p = tmp_path / "h.csv"
+    _write_history(p, [
+        ("not_a_number", "u1", "5", "ctx"),
+        ("2.0", "u1", "broken_score", "ctx"),
+        ("3.0", "u1", "7", "ctx"),
+    ])
+    # Two bad rows + one good row → monotonicity check yields nothing.
+    assert R._detect_monotonicity_races(p) == []


### PR DESCRIPTION
## Summary

Adds the Project 7 reviewer-system load & SLA testing toolchain under `testing/`. Covers bug-repro harnesses, seed/clear scripts, Locust scenarios (1x/5x/10x), SLA config, mock backend, docker-compose for local emulators, and pytest unit tests.

## What changes

- **+6,981 lines** across **80 files**, all under `testing/`.
- No other repo paths are touched. `ajrasakha/`, `backend/`, `frontend/`, `ai/`, etc. are untouched.

## Tree

| Path | Purpose |
|---|---|
| `testing/locust/` | Locust harness — reviewer + role-specific users, scenarios `1x/5x/10x`, credential pool from the seed DB, assertions, payloads |
| `testing/seed/` | Firebase user + question seeders, Mongo index bootstrap, register-firebase-users helper |
| `testing/scripts/` | `preflight.ps1`, `diag-{env,ports}.ps1`, `run-locust-{1x,5x,10x}.ps1`, `dashboards.py`, `aggregate_results.py`, `reconcile_reputation.{py,mjs}`, `gen-firebase-sa.cjs` |
| `testing/docker/` | docker-compose for backend + firebase-auth-emulator + mongo replica-set; **synthetic** Firebase SA keypair (locally generated by `gen-firebase-sa.cjs`, not a Google-issued credential) |
| `testing/fixtures/` | post-seed sanity probes (summary, verify_indexes, verify_seed) |
| `testing/tests/` | pytest unit tests (aggregator, assertions, harness imports, reconcile_reputation) |
| `testing/bugs/` | repro scripts + checkout shims for pre-fix SHAs of bugs #1195 + #1204 (per `roadmap.md`) |
| `testing/config/sla.yaml` | single source of truth for SLA gates (p95 / p99 / error rate) across all scenarios |
| `testing/results/_default/` | empty CSV schema placeholders (assertions.csv, requests.csv) — actual run outputs are gitignored under `results/` per run |
| `testing/mock/server.mjs` | tiny mock backend for harness boot tests |
| `testing/Makefile`, `package.json`, `package-lock.json`, `README.md` | entrypoint + lockfile + docs |

## How to run

```
# 1) Boot the local stack (mongo replica-set + firebase auth emulator + backend stub)
cd testing && make preflight && make up

# 2) Seed
node seed/seed_all.mjs

# 3) Run a scenario
pwsh scripts/run-locust-1x.ps1
# or
pwsh scripts/run-locust-5x.ps1
pwsh scripts/run-locust-10x.ps1

# 4) Aggregate + dashboard
python scripts/aggregate_results.py
python scripts/dashboards.py
```
