### PR TITLE
feat: add custom agricultural correctness DeepEval metric

### DIFF
--- a/ai/ajrasakha/evaluation/agri_correctness_metric.py
+++ b/ai/ajrasakha/evaluation/agri_correctness_metric.py
@@ -1,0 +1,192 @@
+"""
+Custom agricultural correctness metric.
+
+The original project brief for the Answer Evaluation Pipeline calls for:
+
+    "Custom agricultural metric: did the answer mention the correct crop,
+    correct treatment, and correct region where applicable?"
+
+That metric never existed in the codebase — only a keyword-based banned
+chemicals check did (validators/banned_chemicals.py), which is a safety
+filter, not a correctness scorer. This module fills that gap using
+DeepEval's GEval (LLM-as-judge) framework, consistent with how the other
+DeepEval-based metrics in deepeval_metrics.py are built.
+
+Ground truth for crop / region is pulled from the existing test case
+fields (case["expected_plan"]["crop"], case["location"]["state"]) so no
+new ground truth needs to be authored for most cases. Treatment ground
+truth is opt-in via a new "expected_treatment" field on a test case,
+since not every case has a prescribed treatment.
+"""
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+
+
+def _judge_model():
+    """
+    Reuse the same judge-model selection logic as deepeval_metrics.py:
+    prefer Claude when ANTHROPIC_API_KEY is present, otherwise fall back
+    to DeepEval's default (OpenAI).
+    """
+    anthropic_key = os.getenv("ANTHROPIC_API_KEY")
+
+    if anthropic_key:
+        try:
+            from deepeval.models import ClaudeModel
+
+            return ClaudeModel(model="claude-3-5-sonnet-20241022")
+        except Exception:
+            return None
+
+    return None
+
+
+def _build_expected_output(expected_crop: str | None, expected_treatment: str | None, expected_region: str | None) -> str:
+    """
+    Turn the ground-truth fields into a short natural-language description
+    that GEval can compare the actual answer against. Only include facts
+    that are actually known for this case.
+    """
+    parts = []
+
+    if expected_crop and str(expected_crop).lower() not in {"all", "none", ""}:
+        parts.append(f"the crop is {expected_crop}")
+
+    if expected_treatment:
+        parts.append(f"the recommended treatment/practice is {expected_treatment}")
+
+    if expected_region:
+        parts.append(f"the advice is applicable to {expected_region}")
+
+    if not parts:
+        return ""
+
+    return "A correct answer should reflect that " + "; ".join(parts) + "."
+
+
+def extract_agri_ground_truth(case: dict) -> dict:
+    """
+    Pull crop / treatment / region ground truth out of an existing test
+    case dict. Crop and region are read from fields that already exist on
+    every case; treatment is opt-in via "expected_treatment".
+    """
+    expected_plan = case.get("expected_plan", {}) or {}
+    location = case.get("location", {}) or {}
+
+    expected_crop = expected_plan.get("crop")
+    expected_region = location.get("state")
+    expected_treatment = case.get("expected_treatment")
+
+    return {
+        "expected_crop": expected_crop,
+        "expected_treatment": expected_treatment,
+        "expected_region": expected_region,
+    }
+
+
+def evaluate_agri_correctness(
+    query: str,
+    answer: str,
+    case: dict,
+    threshold: float = 0.6,
+) -> dict:
+    """
+    Score whether the answer correctly reflects the expected crop,
+    treatment, and region for this case.
+
+    Skips (not required) when the case carries no crop/treatment/region
+    ground truth worth checking, e.g. general/weather/greeting questions
+    where "crop" is "all" and no treatment is expected.
+    """
+    ground_truth = extract_agri_ground_truth(case)
+
+    expected_output = _build_expected_output(
+        ground_truth["expected_crop"],
+        ground_truth["expected_treatment"],
+        ground_truth["expected_region"],
+    )
+
+    if not expected_output:
+        return {
+            "agri_correctness_required": False,
+            "agri_correctness_score": None,
+            "agri_correctness_pass": True,
+            "agri_correctness_reason": "no crop/treatment/region ground truth for this case",
+            "agri_correctness_expected_crop": ground_truth["expected_crop"] or "",
+            "agri_correctness_expected_treatment": ground_truth["expected_treatment"] or "",
+            "agri_correctness_expected_region": ground_truth["expected_region"] or "",
+        }
+
+    if not answer or not str(answer).strip():
+        return {
+            "agri_correctness_required": True,
+            "agri_correctness_score": None,
+            "agri_correctness_pass": False,
+            "agri_correctness_reason": "answer_missing",
+            "agri_correctness_expected_crop": ground_truth["expected_crop"] or "",
+            "agri_correctness_expected_treatment": ground_truth["expected_treatment"] or "",
+            "agri_correctness_expected_region": ground_truth["expected_region"] or "",
+        }
+
+    test_case = LLMTestCase(
+        input=query,
+        actual_output=answer,
+        expected_output=expected_output,
+    )
+
+    metric_kwargs = dict(
+        name="Agricultural Correctness",
+        criteria=(
+            "Determine whether the actual output correctly identifies and "
+            "addresses the crop, treatment/practice, and region described in "
+            "the expected output. Penalize answers that name the wrong crop, "
+            "recommend a mismatched treatment, or give region-inappropriate "
+            "advice. Do not penalize the answer for including additional, "
+            "correct information beyond what the expected output states."
+        ),
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ],
+        threshold=threshold,
+    )
+
+    judge_model = _judge_model()
+    if judge_model is not None:
+        metric_kwargs["model"] = judge_model
+
+    metric = GEval(**metric_kwargs)
+
+    try:
+        metric.measure(test_case)
+
+        passed = bool(metric.score is not None and metric.score >= threshold)
+
+        return {
+            "agri_correctness_required": True,
+            "agri_correctness_score": metric.score,
+            "agri_correctness_pass": passed,
+            "agri_correctness_reason": metric.reason,
+            "agri_correctness_expected_crop": ground_truth["expected_crop"] or "",
+            "agri_correctness_expected_treatment": ground_truth["expected_treatment"] or "",
+            "agri_correctness_expected_region": ground_truth["expected_region"] or "",
+        }
+
+    except Exception as e:
+        return {
+            "agri_correctness_required": True,
+            "agri_correctness_score": None,
+            "agri_correctness_pass": False,
+            "agri_correctness_reason": str(e),
+            "agri_correctness_expected_crop": ground_truth["expected_crop"] or "",
+            "agri_correctness_expected_treatment": ground_truth["expected_treatment"] or "",
+            "agri_correctness_expected_region": ground_truth["expected_region"] or "",
+        }

--- a/ai/ajrasakha/evaluation/answer_eval.py
+++ b/ai/ajrasakha/evaluation/answer_eval.py
@@ -1,7 +1,66 @@
-def evaluate_response_quality(result: dict, enabled: bool = False) -> dict:
-    return {
-        "answer_quality_enabled": False,
-        "answerrelevancymetric_score": "",
-        "answerrelevancymetric_passed": "",
-        "answerrelevancymetric_reason": "disabled",
-    }
+from ajrasakha.evaluation.deepeval_metrics import evaluate_answer_with_deepeval
+from ajrasakha.evaluation.agri_correctness_metric import evaluate_agri_correctness
+
+
+def evaluate_response_quality(result: dict, case: dict, enabled: bool = False) -> dict:
+    """
+    Run answer-quality scoring for a test case.
+
+    When disabled (mock mode, or DeepEval/API keys unavailable), returns
+    the same disabled shape as before so downstream code (CSV columns,
+    dashboard ingestion) doesn't break.
+
+    When enabled (live mode), runs:
+      - DeepEval's AnswerRelevancyMetric / FaithfulnessMetric / ContextualRelevancyMetric
+      - the custom AgriculturalCorrectnessMetric (crop / treatment / region)
+    """
+    if not enabled:
+        return {
+            "answer_quality_enabled": False,
+            "answerrelevancymetric_score": "",
+            "answerrelevancymetric_passed": "",
+            "answerrelevancymetric_reason": "disabled",
+            "faithfulnessmetric_score": "",
+            "faithfulnessmetric_passed": "",
+            "faithfulnessmetric_reason": "disabled",
+            "contextualrelevancymetric_score": "",
+            "contextualrelevancymetric_passed": "",
+            "contextualrelevancymetric_reason": "disabled",
+            "agri_correctness_required": False,
+            "agri_correctness_score": "",
+            "agri_correctness_pass": "",
+            "agri_correctness_reason": "disabled",
+            "agri_correctness_expected_crop": "",
+            "agri_correctness_expected_treatment": "",
+            "agri_correctness_expected_region": "",
+        }
+
+    query = result.get("query", "")
+    answer = result.get("response_text", "")
+
+    output = {"answer_quality_enabled": True}
+
+    try:
+        deepeval_results = evaluate_answer_with_deepeval(query=query, answer=answer)
+
+        for metric_name, metric_result in deepeval_results.items():
+            prefix = metric_name.lower()
+            output[f"{prefix}_score"] = metric_result.get("score")
+            output[f"{prefix}_passed"] = metric_result.get("passed")
+            output[f"{prefix}_reason"] = metric_result.get("reason")
+
+    except Exception as e:
+        output["answerrelevancymetric_score"] = ""
+        output["answerrelevancymetric_passed"] = False
+        output["answerrelevancymetric_reason"] = f"deepeval_error: {e}"
+        output["faithfulnessmetric_score"] = ""
+        output["faithfulnessmetric_passed"] = False
+        output["faithfulnessmetric_reason"] = f"deepeval_error: {e}"
+        output["contextualrelevancymetric_score"] = ""
+        output["contextualrelevancymetric_passed"] = False
+        output["contextualrelevancymetric_reason"] = f"deepeval_error: {e}"
+
+    agri_result = evaluate_agri_correctness(query=query, answer=answer, case=case)
+    output.update(agri_result)
+
+    return output

--- a/ai/ajrasakha/evaluation/questions.py
+++ b/ai/ajrasakha/evaluation/questions.py
@@ -110,6 +110,7 @@ TEST_CASES = [
         "stable": False,
         "expected_nodes": ["planner", "execute_plan", "assemble_answer_body", "translate_answer"],
         "expected_tools": ["upload_question_to_reviewer_system", "gdb"],
+        "expected_treatment": "a fertilizer dosage recommendation (N-P-K quantities) for Rice",
         "expected_plan": {
             "soil": False,
             "state": "Punjab",
@@ -158,6 +159,7 @@ TEST_CASES = [
         "stable": True,
         "expected_nodes": ["planner", "execute_plan", "retrieval_sanitizer", "assemble_answer_body", "translate_answer"],
         "expected_tools": ["upload_question_to_reviewer_system", "gdb"],
+        "expected_treatment": "standard paddy cultivation practices suited to Punjab",
         "expected_plan": {
             "knowledge_base": True,
             "state": "Punjab",
@@ -215,6 +217,7 @@ TEST_CASES = [
         "stable": False,
         "expected_nodes": ["planner", "execute_plan", "retrieval_sanitizer", "assemble_answer_body", "translate_answer"],
         "expected_tools": ["upload_question_to_reviewer_system", "weather", "gdb"],
+        "expected_treatment": "fungicide/management guidance for yellow rust in wheat",
         "expected_plan": {
             "weather": True,
             "knowledge_base": True,

--- a/ai/ajrasakha/evaluation/run.py
+++ b/ai/ajrasakha/evaluation/run.py
@@ -15,6 +15,7 @@ from ajrasakha.evaluation.plan import evaluate_plan
 from ajrasakha.evaluation.answer_eval import evaluate_response_quality
 from ajrasakha.evaluation.validators.source_check import evaluate_source_attribution
 from ajrasakha.evaluation.validators.disclaimer_language import evaluate_disclaimer_language
+from ajrasakha.evaluation.validators.banned_chemicals import evaluate_banned_chemicals
 from ajrasakha.evaluation.langsmith_trace import build_langsmith_trace_url
 
 
@@ -35,9 +36,11 @@ def run_case(case: dict, mode: str) -> dict:
     plan_result = evaluate_plan(result, case)
     trace_result = build_langsmith_trace_url(result)
     disclaimer_language_result = evaluate_disclaimer_language(result, case)
+    banned_chemicals_result = evaluate_banned_chemicals(result)
 
     quality_result = evaluate_response_quality(
         result,
+        case,
         enabled=(mode == "live"),
     )
 
@@ -53,6 +56,7 @@ def run_case(case: dict, mode: str) -> dict:
         **source_result,
         **trace_result,
         **disclaimer_language_result,
+        **banned_chemicals_result,
     }
 
     failure_result = classify_failure(combined)

--- a/ai/pyproject.toml
+++ b/ai/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "motor>=3.7.1",
     "rapidfuzz>=3.0.0",
     "unicodedataplus>=16.0.0",
+    "deepeval>=2.0.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## What this adds

The intern project brief for the Answer Evaluation Pipeline calls for a
"Custom agricultural metric: did the answer mention the correct crop,
correct treatment, and correct region where applicable?" — this metric
did not exist anywhere in the codebase before this PR.

This adds `ai/ajrasakha/evaluation/agri_correctness_metric.py`, a DeepEval
`GEval` (LLM-as-judge) metric that scores whether an answer correctly
reflects the expected crop, treatment, and region for a test case, using
the same Claude judge-model pattern as the existing DeepEval metrics.

## Bugs fixed along the way

While wiring this in, I found two pieces of existing evaluation code that
were never actually connected:

- `answer_eval.py`'s `evaluate_response_quality()` was a disabled stub —
  it always returned `answer_quality_enabled: False` and never called
  `deepeval_metrics.py`, even in `--mode live`. It now actually runs the
  DeepEval metrics plus the new agri correctness metric.
- `validators/banned_chemicals.py`'s `evaluate_banned_chemicals()` was
  defined but never imported or called in `run.py`. It's now wired in.
- `deepeval` was missing from `pyproject.toml`/`uv.lock` entirely despite
  being used by `deepeval_metrics.py`. Added as a dependency.

## Ground truth

Crop and region ground truth is read from fields that already exist on
every test case (`expected_plan.crop`, `location.state`) — no new
authoring needed for most cases. Treatment ground truth is opt-in via a
new `expected_treatment` field, added to 3 relevant test cases
(soil/fertilizer dosage, GDB cultivation practices, and the
wheat/yellow-rust multi-tool case).

Cases with no crop/treatment/region ground truth (weather, schemes,
greetings, etc.) skip cleanly and are not penalized.

## Output

New columns land in `evaluation_report_live.csv` alongside the existing
metrics, so they flow into the existing dashboard/Layer 3 ingestion with
no changes needed on that side:
`agri_correctness_required`, `agri_correctness_score`,
`agri_correctness_pass`, `agri_correctness_reason`,
`agri_correctness_expected_crop`, `agri_correctness_expected_treatment`,
`agri_correctness_expected_region`.

## Testing

Verified end-to-end locally with mocked LLM judge calls: both `--mode mock`
(safe disabled defaults, no crash) and `--mode live` (real scoring path,
correct skip-when-no-ground-truth behavior) run cleanly and the new
columns appear in the CSV output.