### PR TITLE
feat: add GDB Coverage Gap Detector (Project 6)

### DIFF
--- a/tools/gdb-gap-detector/README.md
+++ b/tools/gdb-gap-detector/README.md
@@ -1,0 +1,107 @@
+# GDB Coverage Gap Detector
+
+Project 6 submission - Vicharanashala Summership 2026.
+
+When a farmer asks something the GDB can't answer, the system logs a
+disclaimer event, but there wasn't anything looking across all of those
+logs together to find patterns. This pulls them, groups differently
+worded versions of the same question, and ranks the results so the
+review pipeline can grow the GDB by what actually affects the most
+farmers instead of whatever a reviewer happens to notice first.
+
+## What's here
+
+```
+backend/
+  app/
+    main.py             - FastAPI backend, reads from MongoDB or falls back to demo data
+    clustering.py        - groups questions and ranks gaps, the core logic
+    domain_matching.py   - fixes a domain-name mismatch found in the real data
+    embeddings.py        - computes embeddings locally, no API key needed
+    synthetic_data.py    - fake data for demo mode / tests
+  tests/                - 33 tests
+  discover_database.py  - read-only script used to find the real collection names
+  inspect_candidates.py - same, but pulls full field lists/types
+frontend/
+  index.html             - the dashboard, open directly in a browser
+```
+
+## Running it (demo mode, no DB needed)
+
+```bash
+cd backend
+pip install -r requirements.txt
+python -m pytest tests/ -v      # 33 passed
+python -m uvicorn app.main:app --port 8000
+```
+
+Then open `frontend/index.html` in a browser. It'll say "Demo mode" at
+the top and populate with synthetic data shaped like the real schema.
+
+## Connecting to real data
+
+Two databases, found by reading the schema directly since the public
+Ajrasakha repo's Question model didn't match what's actually here:
+
+- `gdb_gap_detector.raw_queries` - the disclaimer-triggered questions.
+  Has `question`, `crop`, `state`, `domain`, `disclaimer_triggered`. No
+  stored embedding, so we compute one locally at query time.
+- `farmer_feedback.gdb_entries` - the verified answers, for the coverage
+  ratio. Has `domain` and `state`, no `crop`.
+
+Add a `.env` file in `backend/` (don't commit it):
+```
+MONGODB_URI=<connection string>
+```
+Restart uvicorn and the dashboard switches to live data automatically.
+
+Doesn't touch `gdb_gap_detector.clusters` - that looks like it's already
+holding another student's own output in the same shared DB.
+
+## Two things found while testing against real data
+
+**No stored embeddings.** Assumed at first that embeddings would already
+exist on each question (based on reading the public repo), but the real
+collection doesn't have one. Fixed by computing embeddings locally with
+sentence-transformers instead - no API key needed, and it's one of the
+two approaches the brief itself mentions.
+
+**Domain name mismatch.** raw_queries says "Disease", gdb_entries says
+"Crop Disease" - same topic, different wording. Same for "Pest" vs "Pest
+Control", "Fertilizer" vs "Fertilizers". Without handling this the
+coverage heatmap only ever showed 0% or 100%, since exact string
+matching never found an overlap. Added a normalization step
+(`domain_matching.py`) to fix it - it's a heuristic, not a verified
+mapping, worth checking with whoever owns the actual domain list.
+
+Also worth noting: a chunk of real GDB entries have no `state` recorded
+at all, so those can't be matched geographically no matter what. Not
+something the code can fix, just a real gap in the underlying data.
+
+## A clustering bug found during testing
+
+First version grouped by embedding similarity first and guessed
+crop/state/domain from the result. Two genuinely different gaps -
+cotton/Punjab pest questions and tomato/Karnataka pest questions - got
+merged into one cluster because their embeddings happened to land close
+together. Fixed by grouping on the real crop/state/domain metadata
+first, then only using embeddings to separate different phrasings
+within each group. There's a regression test for this specifically
+(`test_never_merges_two_different_crop_state_groups...`).
+
+## How this compares to other Project 6 submissions
+
+A few classmates already built this same project. Checked three PRs
+directly instead of assuming this is automatically different:
+
+- **#1077** - keyword-based clustering, no embeddings (the PR calls this
+  out as a known limitation). Does correctly compute coverage % against
+  real GDB counts, tested on 279 real disclaimer logs.
+- **#1102** - embedding-based clustering with FastAPI + React, closest
+  architecture to this one. Doesn't appear to compute a true coverage
+  ratio against real GDB counts based on the PR description.
+- **#1058, #1016** - also Project 6 (only read titles given time).
+
+This one combines embedding-based clustering (like #1102) with a real
+coverage percentage against actual GDB counts (like #1077) - didn't see
+both together in what's already been submitted.

--- a/tools/gdb-gap-detector/backend/app/clustering.py
+++ b/tools/gdb-gap-detector/backend/app/clustering.py
@@ -1,0 +1,172 @@
+"""
+Groups disclaimer-triggered questions into gap clusters and ranks them.
+"""
+
+from __future__ import annotations
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+from app.domain_matching import normalize_domain
+
+
+@dataclass
+class GapCluster:
+    cluster_id: int
+    crop: str
+    state: str
+    domain: str
+    sample_questions: list[str]
+    total_count: int
+    count_last_7_days: int
+    count_prior_7_days: int
+
+    @property
+    def growth_rate(self) -> float:
+        # last 7 days vs the 7 before that. If prior week was 0, just
+        # return last week's count instead of dividing by zero.
+        if self.count_prior_7_days == 0:
+            return float(self.count_last_7_days) if self.count_last_7_days > 0 else 0.0
+        return self.count_last_7_days / self.count_prior_7_days
+
+    def priority_score(self) -> float:
+        # size matters more than growth, but a fast-growing small gap
+        # should still be able to rank above a big flat one. growth is
+        # capped at 3x so a tiny cluster can't jump to the top just
+        # because it doubled from 1 to 2.
+        return self.total_count * (1.0 + min(self.growth_rate, 3.0))
+
+
+def cluster_gap_questions(
+    questions: list[dict[str, Any]],
+    eps: float = 0.3,
+    min_samples: int = 2,
+) -> list[GapCluster]:
+    """
+    Groups questions first by crop/state/domain (reliable metadata already
+    on each doc), then within each group, sub-clusters by embedding
+    similarity to separate different phrasings of the same question from
+    genuinely different questions.
+
+    Doing it in this order matters - if you cluster on embeddings first and
+    guess crop/state/domain after, two unrelated topics with similar
+    embeddings can get merged into one group and mislabeled. Grouping by
+    the real metadata first avoids that.
+
+    Uses DBSCAN instead of k-means since we don't know how many distinct
+    phrasings exist in a group ahead of time, and DBSCAN handles one-off
+    outlier questions as noise instead of forcing them into a cluster.
+
+    Each question dict needs: question, crop, state, domain, embedding, created_at.
+    """
+    if not questions:
+        return []
+
+    now = datetime.now(timezone.utc)
+    one_week_ago = now - timedelta(days=7)
+    two_weeks_ago = now - timedelta(days=14)
+
+    partitions: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for q in questions:
+        partitions[(q["crop"], q["state"], q["domain"])].append(q)
+
+    clusters: list[GapCluster] = []
+    next_cluster_id = 0
+
+    for (crop, state, domain), members in partitions.items():
+        if len(members) < min_samples:
+            continue  # too few to call this a real pattern yet
+
+        embeddings = np.array([m["embedding"] for m in members])
+        labels = DBSCAN(eps=eps, min_samples=min_samples, metric="cosine").fit_predict(embeddings)
+
+        sub_groups: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        for m, label in zip(members, labels):
+            if label == -1:
+                continue  # noise, not part of a repeated pattern
+            sub_groups[label].append(m)
+
+        for sub_members in sub_groups.values():
+            count_last_7 = sum(1 for m in sub_members if m["created_at"] >= one_week_ago)
+            count_prior_7 = sum(1 for m in sub_members if two_weeks_ago <= m["created_at"] < one_week_ago)
+
+            clusters.append(GapCluster(
+                cluster_id=next_cluster_id,
+                crop=crop,
+                state=state,
+                domain=domain,
+                sample_questions=[m["question"] for m in sub_members[:3]],
+                total_count=len(sub_members),
+                count_last_7_days=count_last_7,
+                count_prior_7_days=count_prior_7,
+            ))
+            next_cluster_id += 1
+
+    return clusters
+
+
+def rank_gap_report(clusters: list[GapCluster], top_n: int = 20) -> list[GapCluster]:
+    """Sorts clusters by priority_score, highest first, capped at top_n."""
+    return sorted(clusters, key=lambda c: c.priority_score(), reverse=True)[:top_n]
+
+
+def build_coverage_heatmap(
+    clusters: list[GapCluster],
+    gdb_entry_counts: dict[tuple[str, str], int],
+) -> list[dict[str, Any]]:
+    """
+    Computes coverage % per domain+state: gdb_entries / (gdb_entries + gaps).
+
+    Grouped by domain+state, not crop+state+domain - the real gdb_entries
+    collection doesn't have a crop field, so that's the finest grain we
+    can actually match against. The ranked gap report above still shows
+    crop-level detail since that comes from a different collection that
+    does have it.
+
+    Domain names don't match exactly between the two collections
+    (raw_queries says "Disease", gdb_entries says "Crop Disease" for the
+    same thing) so we normalize before matching - see domain_matching.py.
+    This is a best-effort fix, not a verified mapping, worth double
+    checking with whoever owns the domain list. Display labels still use
+    the original (non-normalized) wording from the gap side.
+    """
+    gap_counts: dict[tuple[str, str], int] = defaultdict(int)
+    gap_display_domain: dict[tuple[str, str], str] = {}
+    for c in clusters:
+        key = (normalize_domain(c.domain), c.state)
+        gap_counts[key] += c.total_count
+        gap_display_domain.setdefault(key, c.domain)
+
+    gdb_counts: dict[tuple[str, str], int] = defaultdict(int)
+    gdb_display_domain: dict[tuple[str, str], str] = {}
+    for (raw_domain, state), count in gdb_entry_counts.items():
+        key = (normalize_domain(raw_domain), state)
+        gdb_counts[key] += count
+        gdb_display_domain.setdefault(key, raw_domain)
+
+    all_pairs = set(gap_counts.keys()) | set(gdb_counts.keys())
+    if not all_pairs:
+        return []
+
+    rows = []
+    for key in all_pairs:
+        _, state = key
+        gaps = gap_counts.get(key, 0)
+        gdb_entries = gdb_counts.get(key, 0)
+        total = gaps + gdb_entries
+        coverage_pct = round((gdb_entries / total) * 100, 1) if total > 0 else 0.0
+        display_domain = gap_display_domain.get(key) or gdb_display_domain.get(key)
+        rows.append({
+            "domain": display_domain,
+            "state": state,
+            "gap_count": gaps,
+            "gdb_entry_count": gdb_entries,
+            "coverage_pct": coverage_pct,
+            "gap_intensity": round(1 - (coverage_pct / 100), 3),  # for the heatmap color
+        })
+
+    return sorted(rows, key=lambda r: r["coverage_pct"])  # worst covered first

--- a/tools/gdb-gap-detector/backend/app/domain_matching.py
+++ b/tools/gdb-gap-detector/backend/app/domain_matching.py
@@ -1,0 +1,37 @@
+"""
+Normalizes domain names for matching purposes.
+
+Found this issue while testing against the real staging data: raw_queries
+and gdb_entries use different wording for the same topics, e.g.
+"Disease" vs "Crop Disease", "Pest" vs "Pest Control", "Fertilizer" vs
+"Fertilizers". Without this, the coverage heatmap always shows 0% or
+100% since exact string matching never finds an overlap.
+
+This is a quick heuristic, not something verified against an actual
+domain taxonomy doc - worth checking with whoever owns that list.
+"""
+
+from __future__ import annotations
+import re
+
+# words that show up as a modifier in one collection but not the other
+_STRIP_WORDS = {"crop", "control", "management", "general"}
+
+
+def normalize_domain(raw: str) -> str:
+    """
+    Lowercases, drops the words above, and strips a trailing 's' for basic
+    singular/plural handling. Only for matching, not for display.
+
+    "Disease" / "Crop Disease" -> "disease"
+    "Pest" / "Pest Control" -> "pest"
+    "Fertilizer" / "Fertilizers" -> "fertilizer"
+    """
+    if not raw:
+        return ""
+    words = re.findall(r"[a-zA-Z]+", raw.lower())
+    words = [w for w in words if w not in _STRIP_WORDS]
+    normalized = " ".join(words).strip()
+    if normalized.endswith("s") and len(normalized) > 3:
+        normalized = normalized[:-1]
+    return normalized

--- a/tools/gdb-gap-detector/backend/app/embeddings.py
+++ b/tools/gdb-gap-detector/backend/app/embeddings.py
@@ -1,0 +1,27 @@
+"""
+Computes question embeddings locally using sentence-transformers, since
+the real raw_queries collection doesn't have a stored embedding field.
+No API key needed, runs on-device.
+
+Model is loaded lazily so importing this module doesn't trigger a
+download - tests mock get_model() instead of loading the real thing.
+"""
+
+from __future__ import annotations
+from functools import lru_cache
+
+_MODEL_NAME = "all-MiniLM-L6-v2"  # small, fast, decent general quality
+
+
+@lru_cache(maxsize=1)
+def get_model():
+    from sentence_transformers import SentenceTransformer
+    return SentenceTransformer(_MODEL_NAME)
+
+
+def compute_embeddings(texts: list[str]) -> list[list[float]]:
+    if not texts:
+        return []
+    model = get_model()
+    vectors = model.encode(texts, show_progress_bar=False)
+    return [v.tolist() for v in vectors]

--- a/tools/gdb-gap-detector/backend/app/main.py
+++ b/tools/gdb-gap-detector/backend/app/main.py
@@ -1,0 +1,158 @@
+"""
+FastAPI backend for the GDB Coverage Gap Detector.
+
+GET /api/gap-report  - ranked list of top coverage gaps
+GET /api/heatmap     - domain x state coverage %
+
+Reads from MongoDB when MONGODB_URI is set, otherwise falls back to
+synthetic demo data so this works before DB access is set up.
+"""
+
+from __future__ import annotations
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+
+from app.clustering import cluster_gap_questions, rank_gap_report, build_coverage_heatmap
+from app.synthetic_data import generate_synthetic_questions, generate_synthetic_gdb_entry_counts
+
+load_dotenv()
+
+app = FastAPI(title="GDB Coverage Gap Detector")
+
+# open CORS for local dev only, tighten this before any real deployment
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+MONGODB_URI = os.getenv("MONGODB_URI", "").strip()
+USING_REAL_DB = bool(MONGODB_URI)
+
+
+def _fetch_disclaimer_questions() -> list[dict[str, Any]]:
+    """
+    Pulls disclaimer-triggered questions from gdb_gap_detector.raw_queries,
+    filtered on disclaimer_triggered=True. That collection doesn't have a
+    stored embedding field so we compute one locally per question (see
+    embeddings.py).
+
+    Doesn't touch gdb_gap_detector.clusters - that looks like it already
+    has another student's computed output sitting in the same DB.
+    """
+    if not USING_REAL_DB:
+        return generate_synthetic_questions(weeks_of_history=6, growth_topics=(0,))
+
+    from pymongo import MongoClient
+    from app.embeddings import compute_embeddings
+
+    client = MongoClient(MONGODB_URI, serverSelectionTimeoutMS=5000)
+    db = client["gdb_gap_detector"]
+
+    raw = list(db.raw_queries.find(
+        {"disclaimer_triggered": True},
+        {"question": 1, "crop": 1, "state": 1, "domain": 1, "timestamp": 1},
+    ))
+    client.close()
+
+    if not raw:
+        return []
+
+    texts = [doc.get("question", "") for doc in raw]
+    vectors = compute_embeddings(texts)
+
+    questions = []
+    for doc, vector in zip(raw, vectors):
+        timestamp = doc.get("timestamp")
+        if timestamp and timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        questions.append({
+            "question": doc.get("question", ""),
+            "crop": doc.get("crop") or "Unknown",
+            "state": doc.get("state") or "Unknown",
+            "domain": doc.get("domain") or "Unknown",
+            "embedding": vector,
+            "created_at": timestamp or datetime.now(timezone.utc),
+        })
+    return questions
+
+
+def _fetch_gdb_entry_counts() -> dict[tuple[str, str], int]:
+    """
+    Counts verified GDB entries per (domain, state) from
+    farmer_feedback.gdb_entries, for the coverage ratio calculation.
+
+    That collection has domain and state but no crop field, so this is
+    domain+state grouping, not domain+state+crop. The gap report keeps
+    crop detail separately since it comes from raw_queries which does
+    have it.
+    """
+    if not USING_REAL_DB:
+        return generate_synthetic_gdb_entry_counts()
+
+    from pymongo import MongoClient
+    client = MongoClient(MONGODB_URI, serverSelectionTimeoutMS=5000)
+    db = client["farmer_feedback"]
+
+    pipeline = [
+        {"$group": {
+            "_id": {"domain": "$domain", "state": "$state"},
+            "count": {"$sum": 1},
+        }},
+    ]
+    results = list(db.gdb_entries.aggregate(pipeline))
+    client.close()
+
+    counts: dict[tuple[str, str], int] = {}
+    for row in results:
+        domain = row["_id"].get("domain") or "Unknown"
+        state = row["_id"].get("state") or "Unknown"
+        counts[(domain, state)] = row["count"]
+    return counts
+
+
+@app.get("/api/health")
+def health():
+    return {"status": "ok", "using_real_db": USING_REAL_DB}
+
+
+@app.get("/api/gap-report")
+def gap_report(top_n: int = 20):
+    questions = _fetch_disclaimer_questions()
+    clusters = cluster_gap_questions(questions)
+    ranked = rank_gap_report(clusters, top_n=top_n)
+    return {
+        "using_real_db": USING_REAL_DB,
+        "total_disclaimer_questions_analyzed": len(questions),
+        "gaps_found": len(clusters),
+        "report": [
+            {
+                "rank": i + 1,
+                "crop": c.crop,
+                "state": c.state,
+                "domain": c.domain,
+                "farmer_count": c.total_count,
+                "growth_rate": round(c.growth_rate, 2),
+                "priority_score": round(c.priority_score(), 1),
+                "sample_questions": c.sample_questions,
+            }
+            for i, c in enumerate(ranked)
+        ],
+    }
+
+
+@app.get("/api/heatmap")
+def heatmap():
+    questions = _fetch_disclaimer_questions()
+    gdb_entry_counts = _fetch_gdb_entry_counts()
+    clusters = cluster_gap_questions(questions)
+    return {
+        "using_real_db": USING_REAL_DB,
+        "cells": build_coverage_heatmap(clusters, gdb_entry_counts),
+    }

--- a/tools/gdb-gap-detector/backend/app/synthetic_data.py
+++ b/tools/gdb-gap-detector/backend/app/synthetic_data.py
@@ -1,0 +1,153 @@
+"""
+Fake disclaimer-triggered questions shaped like the real
+gdb_gap_detector.raw_queries docs (question, crop, state, domain,
+disclaimer_triggered, timestamp).
+
+Used for demoing without a live DB, and for tests where we need a known
+correct grouping to check the clustering against - can't really do that
+with messy real data.
+
+Embeddings here are just small random vectors clustered by topic, standing
+in for the real sentence-transformer embeddings computed at runtime (see
+embeddings.py) - the real DB has no stored embedding field.
+"""
+
+from __future__ import annotations
+import random
+from datetime import datetime, timedelta, timezone
+from typing import TypedDict
+
+
+class SyntheticQuestion(TypedDict):
+    question: str
+    crop: str
+    state: str
+    domain: str
+    embedding: list[float]
+    created_at: datetime
+
+
+# A handful of "topic clusters" — each represents farmers hitting the same
+# real knowledge gap, phrased slightly differently (mirrors how real farmers
+# would ask the same underlying question in different words).
+_TOPIC_CLUSTERS = [
+    {
+        "crop": "Cotton", "state": "Punjab", "domain": "Pest",
+        "questions": [
+            "Why are my cotton leaves turning yellow?",
+            "Cotton crop leaves yellowing, what is the cause?",
+            "My cotton plants have yellow leaves, please help",
+            "Yellow spots on cotton leaves this season",
+        ],
+        "embedding_center": [0.9, 0.1, 0.1, 0.0],
+    },
+    {
+        "crop": "Rice", "state": "West Bengal", "domain": "Weather",
+        "questions": [
+            "When should I sow rice this monsoon season?",
+            "Best time to plant paddy before the rains",
+            "Rice sowing schedule for this year's monsoon",
+        ],
+        "embedding_center": [0.1, 0.9, 0.1, 0.0],
+    },
+    {
+        "crop": "Wheat", "state": "Haryana", "domain": "Scheme",
+        "questions": [
+            "What government schemes are available for wheat farmers?",
+            "Wheat subsidy scheme details for this year",
+            "How to apply for wheat crop insurance scheme",
+            "Government support for wheat cultivation",
+            "Wheat MSP scheme application process",
+        ],
+        "embedding_center": [0.1, 0.1, 0.9, 0.0],
+    },
+    {
+        "crop": "Tomato", "state": "Karnataka", "domain": "Pest",
+        "questions": [
+            "Tomato plant leaves have small holes, what pest is this?",
+            "Insects eating my tomato leaves",
+        ],
+        "embedding_center": [0.85, 0.15, 0.05, 0.1],
+    },
+    {
+        "crop": "Sugarcane", "state": "Maharashtra", "domain": "Soil",
+        "questions": [
+            "Best fertilizer for sugarcane in black soil",
+            "Soil preparation tips for sugarcane planting",
+        ],
+        "embedding_center": [0.0, 0.1, 0.1, 0.9],
+    },
+]
+
+
+def _jitter(vec: list[float], amount: float = 0.08) -> list[float]:
+    """Adds small random noise to an embedding, simulating that no two
+    real questions have identical embeddings even on the same topic."""
+    return [v + random.uniform(-amount, amount) for v in vec]
+
+
+def generate_synthetic_gdb_entry_counts() -> dict[tuple[str, str], int]:
+    """
+    Synthetic counts of existing, already-answered GDB entries per
+    (domain, state) — mirrors querying `farmer_feedback.gdb_entries` in the
+    real database, grouped by domain+state (that collection has `domain`
+    and `state` fields but no `crop` field, confirmed by inspection — so
+    domain+state is the finest granularity the real coverage-ratio
+    calculation actually supports).
+
+    Deliberately varied relative to the gap volumes in _TOPIC_CLUSTERS
+    above, so the demo shows the coverage-ratio calculation actually
+    mattering: e.g. Pest/Punjab has heavy gap volume AND reasonable
+    existing coverage (a genuinely large-but-partially-served gap), while
+    Pest/Karnataka has lighter gap volume but almost no existing coverage
+    (a small-but-severe gap).
+    """
+    return {
+        ("Pest", "Punjab"): 40,          # decent existing coverage, but gap volume is still high
+        ("Weather", "West Bengal"): 25,
+        ("Scheme", "Haryana"): 60,        # well covered relative to its gap volume
+        ("Pest", "Karnataka"): 2,         # severe: almost nothing in the GDB yet
+        ("Soil", "Maharashtra"): 15,
+    }
+
+
+def generate_synthetic_questions(
+    weeks_of_history: int = 6,
+    growth_topics: tuple[int, ...] = (0,),  # index into _TOPIC_CLUSTERS that should show a growing trend
+    seed: int = 42,
+) -> list[SyntheticQuestion]:
+    """
+    Generates a realistic-looking dataset of disclaimer-triggered questions
+    spread across `weeks_of_history` weeks. Topics listed in `growth_topics`
+    get an increasing number of questions in more recent weeks (simulating a
+    genuinely worsening coverage gap); other topics stay roughly flat.
+    """
+    random.seed(seed)
+    now = datetime.now(timezone.utc)
+    results: list[SyntheticQuestion] = []
+
+    for topic_idx, topic in enumerate(_TOPIC_CLUSTERS):
+        is_growth_topic = topic_idx in growth_topics
+
+        for week in range(weeks_of_history):
+            # Growing topics: more questions in recent weeks (week 0 = most recent).
+            # Flat topics: roughly constant volume with minor random noise.
+            if is_growth_topic:
+                count_this_week = max(1, (weeks_of_history - week) * 2)
+            else:
+                count_this_week = random.randint(1, 3)
+
+            for _ in range(count_this_week):
+                q_text = random.choice(topic["questions"])
+                days_ago = week * 7 + random.randint(0, 6)
+                results.append({
+                    "question": q_text,
+                    "crop": topic["crop"],
+                    "state": topic["state"],
+                    "domain": topic["domain"],
+                    "embedding": _jitter(topic["embedding_center"]),
+                    "created_at": now - timedelta(days=days_ago),
+                })
+
+    random.shuffle(results)
+    return results

--- a/tools/gdb-gap-detector/backend/discover_database.py
+++ b/tools/gdb-gap-detector/backend/discover_database.py
@@ -1,0 +1,87 @@
+"""
+Diagnostic tool: discovers which database(s) and collections your
+MONGODB_URI can actually see, without needing anyone to tell you the exact
+database name in advance.
+
+Usage:
+    python discover_database.py
+
+Reads MONGODB_URI from your .env file (same one the main app uses). Prints
+every database your connection can access, and for each one, every
+collection name plus a sample document's top-level fields — so you can spot
+which database/collection matches what this project needs (a `questions`
+collection with fields like `tag`, `status`, `details`, `embedding`).
+
+This is read-only — it only lists and samples data, it never writes,
+modifies, or deletes anything.
+"""
+
+from __future__ import annotations
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MONGODB_URI = os.getenv("MONGODB_URI", "").strip()
+
+if not MONGODB_URI:
+    print("MONGODB_URI is not set in your .env file. Nothing to inspect.")
+    raise SystemExit(1)
+
+from pymongo import MongoClient
+
+print(f"Connecting using your configured MONGODB_URI...\n")
+client = MongoClient(MONGODB_URI, serverSelectionTimeoutMS=8000)
+
+try:
+    db_names = client.list_database_names()
+except Exception as e:
+    print(f"Could not list databases — connection may have failed: {e}")
+    raise SystemExit(1)
+
+# These are MongoDB's own built-in system databases — not relevant to this project.
+SYSTEM_DBS = {"admin", "local", "config"}
+candidate_dbs = [name for name in db_names if name not in SYSTEM_DBS]
+
+if not candidate_dbs:
+    print("No non-system databases visible with this connection. "
+          "Your connection may only have access to one specific database "
+          "already (try running the main app directly — get_default_database() "
+          "might just work).")
+    raise SystemExit(0)
+
+print(f"Found {len(candidate_dbs)} database(s) this connection can see:\n")
+
+for db_name in candidate_dbs:
+    db = client[db_name]
+    try:
+        collection_names = db.list_collection_names()
+    except Exception as e:
+        print(f"  [{db_name}] — could not list collections: {e}")
+        continue
+
+    print(f"[{db_name}]  ({len(collection_names)} collections)")
+
+    # Specifically flag anything that looks like the questions collection
+    # this project needs, based on the real schema we already confirmed.
+    likely_matches = [c for c in collection_names if "question" in c.lower()]
+    if likely_matches:
+        print(f"    -> Looks promising: {likely_matches}")
+
+    for coll_name in collection_names[:15]:  # cap output for readability
+        coll = db[coll_name]
+        sample = coll.find_one()
+        if sample:
+            fields = list(sample.keys())[:10]
+            print(f"    - {coll_name}: sample fields = {fields}")
+        else:
+            print(f"    - {coll_name}: (empty)")
+    if len(collection_names) > 15:
+        print(f"    ... and {len(collection_names) - 15} more collections")
+    print()
+
+print("---")
+print("What to look for: a collection (likely named 'questions' or similar)")
+print("whose sample fields include things like: question, details, tag,")
+print("status, embedding, createdAt. The database that CONTAINS that")
+print("collection is the one to put in MONGODB_DB_NAME in your .env file.")

--- a/tools/gdb-gap-detector/backend/inspect_candidates.py
+++ b/tools/gdb-gap-detector/backend/inspect_candidates.py
@@ -1,0 +1,62 @@
+"""
+Focused follow-up to discover_database.py — inspects specific candidate
+collections in full detail: every field name (not capped at 10), document
+counts, and field data TYPES (not values) so we can tell, for example,
+whether `embedding` is a real vector or missing, without printing any
+actual farmer data.
+
+Usage:
+    python inspect_candidates.py
+"""
+
+from __future__ import annotations
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MONGODB_URI = os.getenv("MONGODB_URI", "").strip()
+from pymongo import MongoClient
+
+client = MongoClient(MONGODB_URI, serverSelectionTimeoutMS=8000)
+
+TARGETS = [
+    ("gdb_gap_detector", "raw_queries"),
+    ("gdb_gap_detector", "clusters"),
+    ("farmer_feedback", "disclaimer_logs"),
+    ("farmer_feedback", "gdb_entries"),
+]
+
+for db_name, coll_name in TARGETS:
+    db = client[db_name]
+    coll = db[coll_name]
+    count = coll.estimated_document_count()
+    sample = coll.find_one()
+
+    print(f"=== {db_name}.{coll_name} ===")
+    print(f"  document count: ~{count}")
+
+    if not sample:
+        print("  (empty or no sample found)\n")
+        continue
+
+    print("  fields (name: type):")
+    for key, value in sample.items():
+        type_name = type(value).__name__
+        # For lists, show what's inside (e.g. is `embedding` a list of numbers?)
+        if isinstance(value, list) and len(value) > 0:
+            inner_type = type(value[0]).__name__
+            extra = f" of {inner_type} (length {len(value)})"
+        elif isinstance(value, list):
+            extra = " (empty list)"
+        else:
+            extra = ""
+        print(f"    - {key}: {type_name}{extra}")
+    print()
+
+print("---")
+print("Look specifically for:")
+print("  - raw_queries / disclaimer_logs: does either have a field that's a")
+print("    'list of float' — that would be a real embedding vector.")
+print("  - Does either have distinct 'crop' AND 'state' AND 'domain' fields?")
+print("  - gdb_entries: does it have 'domain' and 'state' for the coverage count?")

--- a/tools/gdb-gap-detector/backend/requirements.txt
+++ b/tools/gdb-gap-detector/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.115.0
+uvicorn==0.32.0
+pymongo==4.9.1
+scikit-learn==1.5.2
+numpy==2.1.2
+pytest==8.3.3
+python-dotenv==1.0.1
+sentence-transformers==3.2.1

--- a/tools/gdb-gap-detector/backend/tests/test_clustering.py
+++ b/tools/gdb-gap-detector/backend/tests/test_clustering.py
@@ -1,0 +1,263 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from datetime import datetime, timedelta, timezone
+from app.clustering import cluster_gap_questions, rank_gap_report, build_coverage_heatmap, GapCluster
+from app.synthetic_data import generate_synthetic_questions, generate_synthetic_gdb_entry_counts
+
+
+def _q(question, crop, state, domain, embedding, days_ago=0):
+    return {
+        "question": question,
+        "crop": crop,
+        "state": state,
+        "domain": domain,
+        "embedding": embedding,
+        "created_at": datetime.now(timezone.utc) - timedelta(days=days_ago),
+    }
+
+
+class TestClusterGapQuestions:
+    def test_empty_input_returns_empty_list(self):
+        assert cluster_gap_questions([]) == []
+
+    def test_groups_semantically_similar_questions_into_one_cluster(self):
+        questions = [
+            _q("Why are cotton leaves yellow?", "Cotton", "Punjab", "Pest", [0.9, 0.1, 0.1]),
+            _q("Cotton leaves turning yellow", "Cotton", "Punjab", "Pest", [0.88, 0.12, 0.1]),
+            _q("Yellowing on cotton crop", "Cotton", "Punjab", "Pest", [0.91, 0.09, 0.11]),
+        ]
+        clusters = cluster_gap_questions(questions, eps=0.3, min_samples=2)
+        assert len(clusters) == 1
+        assert clusters[0].total_count == 3
+        assert clusters[0].crop == "Cotton"
+
+    def test_keeps_dissimilar_topics_in_separate_clusters(self):
+        questions = [
+            _q("Cotton leaves yellow", "Cotton", "Punjab", "Pest", [0.9, 0.1, 0.1]),
+            _q("Cotton yellowing issue", "Cotton", "Punjab", "Pest", [0.88, 0.1, 0.1]),
+            _q("When to sow rice", "Rice", "West Bengal", "Weather", [0.1, 0.9, 0.1]),
+            _q("Best rice sowing time", "Rice", "West Bengal", "Weather", [0.1, 0.88, 0.1]),
+        ]
+        clusters = cluster_gap_questions(questions, eps=0.3, min_samples=2)
+        assert len(clusters) == 2
+        crops_found = {c.crop for c in clusters}
+        assert crops_found == {"Cotton", "Rice"}
+
+    def test_single_isolated_question_is_treated_as_noise_not_a_gap_cluster(self):
+        # Only one question on this topic — min_samples=2 means it should
+        # NOT be reported as a systemic gap yet (that would be a false alarm
+        # from a single farmer's one-off phrasing).
+        questions = [
+            _q("Cotton leaves yellow", "Cotton", "Punjab", "Pest", [0.9, 0.1, 0.1]),
+            _q("Cotton yellowing", "Cotton", "Punjab", "Pest", [0.88, 0.1, 0.1]),
+            _q("Completely unrelated one-off question", "Maize", "Bihar", "Soil", [0.0, 0.0, 0.99]),
+        ]
+        clusters = cluster_gap_questions(questions, eps=0.3, min_samples=2)
+        assert len(clusters) == 1
+        assert clusters[0].crop == "Cotton"
+
+    def test_growth_rate_reflects_increasing_recent_volume(self):
+        questions = (
+            [_q(f"Cotton yellow {i}", "Cotton", "Punjab", "Pest", [0.9, 0.1, 0.1], days_ago=3) for i in range(6)]
+            + [_q(f"Cotton yellow old {i}", "Cotton", "Punjab", "Pest", [0.9, 0.1, 0.1], days_ago=10) for i in range(2)]
+        )
+        clusters = cluster_gap_questions(questions, eps=0.3, min_samples=2)
+        assert len(clusters) == 1
+        c = clusters[0]
+        assert c.count_last_7_days == 6
+        assert c.count_prior_7_days == 2
+        assert c.growth_rate == 3.0  # 6 / 2
+
+    def test_growth_rate_handles_zero_prior_week_without_crashing(self):
+        questions = [_q(f"Cotton yellow {i}", "Cotton", "Punjab", "Pest", [0.9, 0.1, 0.1], days_ago=1) for i in range(3)]
+        clusters = cluster_gap_questions(questions, eps=0.3, min_samples=2)
+        c = clusters[0]
+        assert c.count_prior_7_days == 0
+        assert c.growth_rate == 3.0  # treated as "went from nothing to 3", not a division error
+
+    def test_never_merges_two_different_crop_state_groups_even_with_similar_embeddings(self):
+        # Regression test: an earlier version of this pipeline clustered
+        # purely on embeddings first and inferred crop/state/domain via
+        # majority vote afterward. Cotton/Punjab/Pest and Tomato/Karnataka/
+        # Pest questions had embeddings close enough to get merged into one
+        # cluster, silently losing the Tomato/Karnataka signal. Partitioning
+        # by crop/state/domain FIRST (current implementation) must prevent
+        # this regardless of how close the embeddings are.
+        questions = [
+            _q("Cotton leaves yellow", "Cotton", "Punjab", "Pest", [0.9, 0.1, 0.1]),
+            _q("Cotton yellowing issue", "Cotton", "Punjab", "Pest", [0.89, 0.1, 0.1]),
+            _q("Tomato leaves have holes", "Tomato", "Karnataka", "Pest", [0.88, 0.12, 0.1]),  # deliberately close embedding, different crop/state
+            _q("Insects eating tomato", "Tomato", "Karnataka", "Pest", [0.87, 0.11, 0.1]),
+        ]
+        clusters = cluster_gap_questions(questions, eps=0.3, min_samples=2)
+        assert len(clusters) == 2
+        crop_state_pairs = {(c.crop, c.state) for c in clusters}
+        assert crop_state_pairs == {("Cotton", "Punjab"), ("Tomato", "Karnataka")}
+        # Every cluster's sample questions must actually belong to that
+        # cluster's crop — no cross-contamination in either direction.
+        for c in clusters:
+            if c.crop == "Cotton":
+                assert all("cotton" in q.lower() or "yellow" in q.lower() for q in c.sample_questions)
+            if c.crop == "Tomato":
+                assert all("tomato" in q.lower() for q in c.sample_questions)
+
+
+class TestRankGapReport:
+    def test_ranks_larger_clusters_higher_when_growth_is_equal(self):
+        small = GapCluster(0, "A", "S1", "Pest", ["q"], total_count=2, count_last_7_days=1, count_prior_7_days=1)
+        large = GapCluster(1, "B", "S2", "Pest", ["q"], total_count=10, count_last_7_days=5, count_prior_7_days=5)
+        ranked = rank_gap_report([small, large])
+        assert ranked[0].crop == "B"
+
+    def test_growing_cluster_can_outrank_a_larger_but_stable_one(self):
+        # Close enough in size that a strong growth trend should tip the ranking —
+        # unlike a huge size gap (e.g. 20 vs 8), which should stay ranked by size.
+        stable_larger = GapCluster(0, "A", "S1", "Pest", ["q"], total_count=10, count_last_7_days=2, count_prior_7_days=2)
+        growing_smaller = GapCluster(1, "B", "S2", "Pest", ["q"], total_count=8, count_last_7_days=6, count_prior_7_days=1)
+        ranked = rank_gap_report([stable_larger, growing_smaller])
+        assert ranked[0].crop == "B"
+
+    def test_a_much_larger_stable_gap_still_outranks_a_smaller_growing_one(self):
+        # Growth is capped at a 3x multiplier by design (see priority_score
+        # docstring) — it should tip a close call, but not let a small
+        # cluster leapfrog a much larger one just because it's growing fast.
+        stable_much_larger = GapCluster(0, "A", "S1", "Pest", ["q"], total_count=20, count_last_7_days=2, count_prior_7_days=2)
+        growing_small = GapCluster(1, "B", "S2", "Pest", ["q"], total_count=8, count_last_7_days=6, count_prior_7_days=1)
+        ranked = rank_gap_report([stable_much_larger, growing_small])
+        assert ranked[0].crop == "A"
+
+    def test_respects_top_n_limit(self):
+        clusters = [GapCluster(i, "A", "S", "Pest", ["q"], total_count=i + 1, count_last_7_days=1, count_prior_7_days=1) for i in range(30)]
+        ranked = rank_gap_report(clusters, top_n=5)
+        assert len(ranked) == 5
+
+
+class TestCoverageHeatmap:
+    def test_empty_clusters_and_empty_gdb_counts_returns_empty_heatmap(self):
+        assert build_coverage_heatmap([], {}) == []
+
+    def test_aggregates_gap_counts_per_domain_state_pair_across_different_crops(self):
+        # Two different crops, same domain+state — should combine into one
+        # heatmap cell, since the real GDB-entry data only supports
+        # domain+state granularity (no crop field), confirmed against the
+        # actual database schema.
+        clusters = [
+            GapCluster(0, "Cotton", "Punjab", "Pest", ["q"], total_count=5, count_last_7_days=1, count_prior_7_days=1),
+            GapCluster(1, "Wheat", "Punjab", "Pest", ["q"], total_count=3, count_last_7_days=1, count_prior_7_days=1),
+        ]
+        heatmap = build_coverage_heatmap(clusters, {})
+        pest_punjab = next(c for c in heatmap if c["domain"] == "Pest" and c["state"] == "Punjab")
+        assert pest_punjab["gap_count"] == 8  # 5 + 3, combined across the two crops
+
+    def test_coverage_pct_reflects_true_ratio_not_just_gap_volume(self):
+        # Same gap volume (18) but very different real coverage — this is
+        # exactly the distinction gap-volume-alone can't make.
+        clusters = [
+            GapCluster(0, "Cotton", "Punjab", "Pest", ["q"], total_count=18, count_last_7_days=1, count_prior_7_days=1),
+            GapCluster(1, "Tomato", "Karnataka", "Pest", ["q"], total_count=18, count_last_7_days=1, count_prior_7_days=1),
+        ]
+        gdb_counts = {
+            ("Pest", "Punjab"): 200,      # well covered despite the gap volume
+            ("Pest", "Karnataka"): 1,      # severely under-covered
+        }
+        heatmap = build_coverage_heatmap(clusters, gdb_counts)
+        punjab = next(c for c in heatmap if c["state"] == "Punjab")
+        karnataka = next(c for c in heatmap if c["state"] == "Karnataka")
+
+        assert punjab["gap_count"] == karnataka["gap_count"] == 18  # same raw volume
+        assert punjab["coverage_pct"] > 90    # 200 / (200+18) ≈ 91.7%
+        assert karnataka["coverage_pct"] < 10  # 1 / (1+18) ≈ 5.3%
+
+    def test_worst_covered_pair_is_sorted_first(self):
+        clusters = [
+            GapCluster(0, "Cotton", "Punjab", "Pest", ["q"], total_count=5, count_last_7_days=1, count_prior_7_days=1),
+            GapCluster(1, "Tomato", "Karnataka", "Pest", ["q"], total_count=5, count_last_7_days=1, count_prior_7_days=1),
+        ]
+        gdb_counts = {("Pest", "Punjab"): 100, ("Pest", "Karnataka"): 1}
+        heatmap = build_coverage_heatmap(clusters, gdb_counts)
+        assert heatmap[0]["state"] == "Karnataka"  # worse coverage ranks first
+
+    def test_a_pair_with_gdb_entries_but_zero_current_gaps_still_appears(self):
+        # A domain/state that's fully served (no active gaps right now)
+        # should still show up as a fully-covered cell, not be silently
+        # omitted.
+        heatmap = build_coverage_heatmap([], {("Scheme", "Haryana"): 50})
+        assert len(heatmap) == 1
+        assert heatmap[0]["coverage_pct"] == 100.0
+        assert heatmap[0]["gap_count"] == 0
+
+    def test_a_pair_with_gaps_but_zero_gdb_entries_shows_zero_coverage(self):
+        clusters = [GapCluster(0, "Maize", "Bihar", "Soil", ["q"], total_count=7, count_last_7_days=1, count_prior_7_days=1)]
+        heatmap = build_coverage_heatmap(clusters, {})
+        assert heatmap[0]["coverage_pct"] == 0.0
+        assert heatmap[0]["gap_intensity"] == 1.0
+
+    def test_matches_gap_and_gdb_domains_despite_different_real_world_vocabulary(self):
+        # Regression test for a real bug found in live testing: raw_queries
+        # uses "Disease"/"Pest"/"Fertilizer", gdb_entries uses "Crop Disease"/
+        # "Pest Control"/"Fertilizers" for the SAME topics. Before
+        # normalization, every cell showed either 0% or 100% — never a real
+        # ratio — because exact string matching never found an overlap.
+        clusters = [
+            GapCluster(0, "Tomato", "Punjab", "Disease", ["q"], total_count=7, count_last_7_days=1, count_prior_7_days=1),
+            GapCluster(1, "Cotton", "Gujarat", "Pest", ["q"], total_count=4, count_last_7_days=1, count_prior_7_days=1),
+        ]
+        gdb_counts = {
+            ("Crop Disease", "Punjab"): 40,
+            ("Pest Control", "Gujarat"): 2,
+        }
+        heatmap = build_coverage_heatmap(clusters, gdb_counts)
+
+        disease_row = next(r for r in heatmap if r["state"] == "Punjab")
+        pest_row = next(r for r in heatmap if r["state"] == "Gujarat")
+
+        # Must actually match across the vocabulary difference — not stay
+        # stuck at 0% (which is what the bug produced).
+        assert disease_row["gap_count"] == 7
+        assert disease_row["gdb_entry_count"] == 40
+        assert disease_row["coverage_pct"] > 0
+
+        assert pest_row["gap_count"] == 4
+        assert pest_row["gdb_entry_count"] == 2
+        assert pest_row["coverage_pct"] > 0
+
+    def test_display_domain_prefers_gap_side_wording(self):
+        # Even though matching is normalized internally, the displayed
+        # label should stay human-readable and prefer the gap-side wording
+        # (closer to how farmers' questions were actually categorized).
+        clusters = [GapCluster(0, "Tomato", "Punjab", "Disease", ["q"], total_count=5, count_last_7_days=1, count_prior_7_days=1)]
+        gdb_counts = {("Crop Disease", "Punjab"): 10}
+        heatmap = build_coverage_heatmap(clusters, gdb_counts)
+        assert heatmap[0]["domain"] == "Disease"  # not "Crop Disease"
+
+
+class TestSyntheticDataIntegration:
+    """End-to-end sanity check: does the whole pipeline behave sensibly on
+    the synthetic dataset used for demoing, not just on hand-crafted cases?"""
+
+    def test_designated_growth_topic_actually_ranks_first(self):
+        questions = generate_synthetic_questions(weeks_of_history=6, growth_topics=(0,))
+        clusters = cluster_gap_questions(questions, eps=0.35, min_samples=2)
+        report = rank_gap_report(clusters, top_n=5)
+        assert len(report) > 0
+        # Topic 0 in synthetic_data.py is Cotton/Punjab/Pest, configured to grow
+        assert report[0].crop == "Cotton"
+
+    def test_heatmap_has_entries_for_multiple_domain_state_pairs(self):
+        questions = generate_synthetic_questions(weeks_of_history=6)
+        clusters = cluster_gap_questions(questions, eps=0.35, min_samples=2)
+        gdb_counts = generate_synthetic_gdb_entry_counts()
+        heatmap = build_coverage_heatmap(clusters, gdb_counts)
+        pairs = {(row["domain"], row["state"]) for row in heatmap}
+        assert len(pairs) >= 2
+
+    def test_synthetic_pipeline_produces_a_true_coverage_percentage_for_every_cell(self):
+        questions = generate_synthetic_questions(weeks_of_history=6)
+        clusters = cluster_gap_questions(questions, eps=0.35, min_samples=2)
+        gdb_counts = generate_synthetic_gdb_entry_counts()
+        heatmap = build_coverage_heatmap(clusters, gdb_counts)
+        for row in heatmap:
+            assert 0.0 <= row["coverage_pct"] <= 100.0
+            assert "gdb_entry_count" in row

--- a/tools/gdb-gap-detector/backend/tests/test_domain_matching.py
+++ b/tools/gdb-gap-detector/backend/tests/test_domain_matching.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.domain_matching import normalize_domain
+
+
+class TestNormalizeDomain:
+    def test_handles_empty_string(self):
+        assert normalize_domain("") == ""
+
+    def test_lowercases(self):
+        assert normalize_domain("Disease") == "disease"
+
+    def test_strips_crop_modifier_word(self):
+        # Real mismatch found in testing: raw_queries has "Disease",
+        # gdb_entries has "Crop Disease" — same underlying topic.
+        assert normalize_domain("Crop Disease") == "disease"
+        assert normalize_domain("Disease") == "disease"
+
+    def test_strips_control_modifier_word(self):
+        # Real mismatch found in testing: raw_queries has "Pest",
+        # gdb_entries has "Pest Control".
+        assert normalize_domain("Pest Control") == "pest"
+        assert normalize_domain("Pest") == "pest"
+
+    def test_strips_trailing_plural_s(self):
+        # Real mismatch found in testing: raw_queries has "Fertilizer",
+        # gdb_entries has "Fertilizers".
+        assert normalize_domain("Fertilizers") == "fertilizer"
+        assert normalize_domain("Fertilizer") == "fertilizer"
+
+    def test_does_not_over_strip_a_short_word_ending_in_s(self):
+        assert normalize_domain("Seeds") != ""
+        assert len(normalize_domain("Seeds")) >= 3
+
+    def test_genuinely_different_domains_stay_different(self):
+        assert normalize_domain("Weather") != normalize_domain("Soil Health")
+        assert normalize_domain("Irrigation") != normalize_domain("Harvesting")
+
+    def test_collapses_extra_whitespace(self):
+        assert normalize_domain("  Pest   Control  ") == "pest"

--- a/tools/gdb-gap-detector/backend/tests/test_embeddings.py
+++ b/tools/gdb-gap-detector/backend/tests/test_embeddings.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from unittest.mock import patch, MagicMock
+from app.embeddings import compute_embeddings
+
+
+class TestComputeEmbeddings:
+    def test_empty_input_returns_empty_list_without_loading_model(self):
+        with patch("app.embeddings.get_model") as mock_get_model:
+            result = compute_embeddings([])
+            assert result == []
+            mock_get_model.assert_not_called()  # no point loading the model for nothing
+
+    def test_calls_model_encode_and_converts_to_plain_lists(self):
+        fake_model = MagicMock()
+        # Simulate what sentence-transformers actually returns: a numpy
+        # array per input text, which has a .tolist() method.
+        fake_vector_1 = MagicMock()
+        fake_vector_1.tolist.return_value = [0.1, 0.2, 0.3]
+        fake_vector_2 = MagicMock()
+        fake_vector_2.tolist.return_value = [0.4, 0.5, 0.6]
+        fake_model.encode.return_value = [fake_vector_1, fake_vector_2]
+
+        with patch("app.embeddings.get_model", return_value=fake_model):
+            result = compute_embeddings(["question one", "question two"])
+
+        fake_model.encode.assert_called_once_with(
+            ["question one", "question two"], show_progress_bar=False
+        )
+        assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    def test_result_length_matches_input_length(self):
+        fake_model = MagicMock()
+        fake_vectors = [MagicMock(tolist=MagicMock(return_value=[i, i])) for i in range(5)]
+        fake_model.encode.return_value = fake_vectors
+
+        with patch("app.embeddings.get_model", return_value=fake_model):
+            result = compute_embeddings([f"q{i}" for i in range(5)])
+
+        assert len(result) == 5

--- a/tools/gdb-gap-detector/frontend/index.html
+++ b/tools/gdb-gap-detector/frontend/index.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>GDB Coverage Gap Detector</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #1C1917;
+    --panel: #262220;
+    --panel-border: #38332F;
+    --text: #F5F1EA;
+    --text-muted: #A69C8F;
+    --gap-red: #C1440E;
+    --coverage-green: #6B8E4E;
+    --growth-gold: #D4A017;
+    --radius: 10px;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Inter', sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 48px 24px 80px; }
+
+  /* ---- Hero ---- */
+  .hero { margin-bottom: 56px; }
+  .hero-eyebrow {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--growth-gold);
+    margin: 0 0 14px;
+  }
+  .hero-title {
+    font-family: 'Fraunces', serif;
+    font-weight: 500;
+    font-size: clamp(28px, 4.2vw, 44px);
+    line-height: 1.15;
+    margin: 0 0 18px;
+    max-width: 760px;
+  }
+  .hero-title .accent { color: var(--gap-red); font-style: italic; }
+  .hero-sub {
+    color: var(--text-muted);
+    font-size: 15px;
+    line-height: 1.6;
+    max-width: 620px;
+    margin: 0;
+  }
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 20px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--panel-border);
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .status-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text-muted); }
+  .status-pill.live .status-dot { background: var(--coverage-green); }
+  .status-pill.synthetic .status-dot { background: var(--growth-gold); }
+
+  /* ---- Section headers ---- */
+  .section { margin-bottom: 56px; }
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 20px;
+    border-bottom: 1px solid var(--panel-border);
+    padding-bottom: 14px;
+  }
+  .section-title {
+    font-family: 'Fraunces', serif;
+    font-size: 21px;
+    font-weight: 500;
+    margin: 0;
+  }
+  .section-note {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  /* ---- Gap report table ---- */
+  .gap-row {
+    display: grid;
+    grid-template-columns: 40px 1fr auto auto;
+    gap: 16px;
+    align-items: center;
+    padding: 16px 4px;
+    border-bottom: 1px solid var(--panel-border);
+  }
+  .gap-rank {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .gap-main .gap-crop-line {
+    font-size: 15px;
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  .gap-crop-line .domain-tag {
+    font-family: 'IBM Plex Mono', monospace;
+    font-weight: 400;
+    font-size: 11px;
+    color: var(--text-muted);
+    border: 1px solid var(--panel-border);
+    padding: 2px 7px;
+    border-radius: 5px;
+    margin-left: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .gap-sample {
+    font-size: 13px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .gap-count {
+    text-align: right;
+    font-family: 'IBM Plex Mono', monospace;
+  }
+  .gap-count .num { font-size: 20px; font-weight: 500; }
+  .gap-count .label { display: block; font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+  .growth-badge {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 12px;
+    padding: 4px 9px;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .growth-badge.up { background: rgba(212,160,23,0.15); color: var(--growth-gold); }
+  .growth-badge.flat { background: rgba(166,156,143,0.12); color: var(--text-muted); }
+
+  /* ---- Heatmap (signature element: field-grid styling) ---- */
+  .heatmap-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 10px;
+  }
+  .plot {
+    border-radius: 6px;
+    padding: 14px 14px 12px;
+    border: 1px solid var(--panel-border);
+    position: relative;
+    overflow: hidden;
+    min-height: 88px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+  .plot .plot-crop { font-size: 13px; font-weight: 600; z-index: 1; }
+  .plot .plot-state { font-size: 11px; color: var(--text-muted); z-index: 1; }
+  .plot .plot-count {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 20px;
+    z-index: 1;
+    align-self: flex-end;
+  }
+  .heatmap-legend {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 16px;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+  .legend-swatch { width: 60px; height: 8px; border-radius: 4px; background: linear-gradient(90deg, var(--coverage-green), var(--growth-gold), var(--gap-red)); }
+
+  /* ---- Footer note ---- */
+  .footnote {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.6;
+    border-top: 1px solid var(--panel-border);
+    padding-top: 20px;
+    max-width: 700px;
+  }
+  .loading, .error { color: var(--text-muted); font-family: 'IBM Plex Mono', monospace; font-size: 13px; padding: 20px 4px; }
+  .error { color: var(--gap-red); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="hero">
+    <p class="hero-eyebrow">GDB Coverage Gap Detector</p>
+    <h1 class="hero-title" id="heroTitle">Loading today's gap signal&hellip;</h1>
+    <p class="hero-sub">Every disclaimer shown to a farmer is a gap the Golden Database hasn't filled yet. This groups those moments by crop, state, and question, so the review pipeline can grow the GDB where it matters most — not just where someone happened to notice.</p>
+    <div class="status-pill" id="statusPill"><span class="status-dot"></span><span id="statusText">Connecting&hellip;</span></div>
+  </div>
+
+  <div class="section">
+    <div class="section-head">
+      <h2 class="section-title">Weekly Gap Report</h2>
+      <span class="section-note" id="gapMeta"></span>
+    </div>
+    <div id="gapReportBody"><div class="loading">Fetching ranked gaps&hellip;</div></div>
+  </div>
+
+  <div class="section">
+    <div class="section-head">
+      <h2 class="section-title">Coverage Heatmap</h2>
+      <span class="section-note">crop × state, true coverage % (GDB entries vs. open gaps)</span>
+    </div>
+    <div id="heatmapBody"><div class="loading">Fetching heatmap&hellip;</div></div>
+    <div class="heatmap-legend">
+      <span>worst covered</span>
+      <span class="legend-swatch"></span>
+      <span>fully covered</span>
+    </div>
+  </div>
+
+  <p class="footnote">
+    Coverage % = existing GDB entries ÷ (GDB entries + open gap questions) for that crop/state pair —
+    a true ratio, not just raw gap volume. This distinguishes a large-but-partially-served gap
+    (e.g. 42 gap questions against 40 existing entries, ~49% covered) from a small-but-severe one
+    (e.g. 14 gap questions against just 2 entries, ~13% covered) — something gap volume alone can't tell apart.
+  </p>
+
+</div>
+
+<script>
+  const API_BASE = "http://127.0.0.1:8000";
+
+  function escapeHtml(str) {
+    const div = document.createElement("div");
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  function intensityColor(intensity) {
+    // 0 = coverage-green, 0.5 = growth-gold, 1 = gap-red
+    const stops = [
+      { at: 0.0, c: [107, 142, 78] },
+      { at: 0.5, c: [212, 160, 23] },
+      { at: 1.0, c: [193, 68, 14] },
+    ];
+    let a, b;
+    if (intensity <= 0.5) { a = stops[0]; b = stops[1]; }
+    else { a = stops[1]; b = stops[2]; }
+    const span = b.at - a.at;
+    const t = span === 0 ? 0 : (intensity - a.at) / span;
+    const rgb = a.c.map((v, i) => Math.round(v + (b.c[i] - v) * t));
+    return `rgb(${rgb.join(",")})`;
+  }
+
+  async function loadStatus() {
+    try {
+      const res = await fetch(`${API_BASE}/api/health`);
+      const data = await res.json();
+      const pill = document.getElementById("statusPill");
+      const text = document.getElementById("statusText");
+      if (data.using_real_db) {
+        pill.classList.add("live");
+        text.textContent = "Connected — live production data";
+      } else {
+        pill.classList.add("synthetic");
+        text.textContent = "Demo mode — synthetic data (set MONGODB_URI for live data)";
+      }
+    } catch (e) {
+      document.getElementById("statusText").textContent = "Backend unreachable — is uvicorn running?";
+    }
+  }
+
+  async function loadGapReport() {
+    const body = document.getElementById("gapReportBody");
+    try {
+      const res = await fetch(`${API_BASE}/api/gap-report?top_n=20`);
+      const data = await res.json();
+      document.getElementById("gapMeta").textContent =
+        `${data.total_disclaimer_questions_analyzed} questions analyzed · ${data.gaps_found} gaps found`;
+
+      if (data.report.length === 0) {
+        body.innerHTML = `<div class="loading">No coverage gaps detected in the current window.</div>`;
+        document.getElementById("heroTitle").textContent = "No active coverage gaps right now.";
+        return;
+      }
+
+      const top = data.report[0];
+      document.getElementById("heroTitle").innerHTML =
+        `<span class="accent">${top.farmer_count} farmers</span> keep asking about ${escapeHtml(top.crop.toLowerCase())} ${escapeHtml(top.domain.toLowerCase())} in ${escapeHtml(top.state)} — and the GDB still can't answer.`;
+
+      body.innerHTML = data.report.map(row => {
+        const growing = row.growth_rate > 1.15;
+        return `
+          <div class="gap-row">
+            <div class="gap-rank">${String(row.rank).padStart(2, "0")}</div>
+            <div class="gap-main">
+              <div class="gap-crop-line">${escapeHtml(row.crop)} · ${escapeHtml(row.state)}<span class="domain-tag">${escapeHtml(row.domain)}</span></div>
+              <div class="gap-sample">"${escapeHtml(row.sample_questions[0] || "")}"</div>
+            </div>
+            <div class="growth-badge ${growing ? "up" : "flat"}">${growing ? "↑" : "→"} ${row.growth_rate}×</div>
+            <div class="gap-count">
+              <span class="num">${row.farmer_count}</span>
+              <span class="label">farmers</span>
+            </div>
+          </div>
+        `;
+      }).join("");
+    } catch (e) {
+      body.innerHTML = `<div class="error">Could not load the gap report. Is the backend running on ${API_BASE}?</div>`;
+    }
+  }
+
+  async function loadHeatmap() {
+    const body = document.getElementById("heatmapBody");
+    try {
+      const res = await fetch(`${API_BASE}/api/heatmap`);
+      const data = await res.json();
+      if (data.cells.length === 0) {
+        body.innerHTML = `<div class="loading">No heatmap data yet.</div>`;
+        return;
+      }
+      body.innerHTML = `<div class="heatmap-grid">` + data.cells.map(cell => {
+        const color = intensityColor(cell.gap_intensity);
+        return `
+          <div class="plot" style="background: linear-gradient(160deg, ${color}33, ${color}14); border-color: ${color}55;">
+            <div>
+              <div class="plot-crop">${escapeHtml(cell.domain)}</div>
+              <div class="plot-state">${escapeHtml(cell.state)}</div>
+              <div class="plot-state" style="margin-top:4px;">${cell.gap_count} gaps · ${cell.gdb_entry_count} in GDB</div>
+            </div>
+            <div class="plot-count" style="color: ${color};">${cell.coverage_pct}%</div>
+          </div>
+        `;
+      }).join("") + `</div>`;
+    } catch (e) {
+      body.innerHTML = `<div class="error">Could not load the heatmap.</div>`;
+    }
+  }
+
+  loadStatus();
+  loadGapReport();
+  loadHeatmap();
+</script>
+</body>
+</html>


### PR DESCRIPTION
**What this does**

Groups disclaimer-triggered farmer questions (where the GDB had no answer) by crop/state/domain and semantic similarity, computes a true coverage % against existing GDB entries, and ranks the results by farmer impact - so the review pipeline can prioritize gaps by evidence instead of by chance. Includes a working dashboard (`frontend/index.html`).

 **How it works**

- Pulls disclaimer-triggered questions from `gdb_gap_detector.raw_queries`
- Groups by crop/state/domain first, then sub-clusters by embedding similarity within each group (computed locally with sentence-transformers, no API key needed)
- Coverage % = GDB entries ÷ (GDB entries + gaps), using real counts from `farmer_feedback.gdb_entries`
- Ranks by a combined size + growth score

**Two issues found and fixed while testing against real data**

- **No stored embeddings** on the real questions (unlike what the public repo's schema suggested) - computed them locally instead.
- **Domain vocabulary mismatch** between the two collections ("Disease" vs "Crop Disease", etc.) was causing the heatmap to only ever show 0% or 100%. Added a normalization step (`domain_matching.py`) - flagged in the README as a heuristic, not a verified mapping.

Also found a clustering bug during testing: grouping by embeddings first and guessing crop/state/domain afterward could merge two genuinely different gaps together. Fixed by grouping on the real metadata first, embeddings only within each group - there's a regression test for this.

**Testing**

33 tests passing (`cd backend && python -m pytest tests/ -v`). Verified live against the real staging database.
