### PR TITLE
fix(auth): resolve forgot password mail trigger, error handling, and email normalization

### DIFF
--- a/backend/src/modules/auth/controllers/AuthController.ts
+++ b/backend/src/modules/auth/controllers/AuthController.ts
@@ -197,7 +197,8 @@ export class AuthController {
   })
   @Post('/forgot-password')
   async forgotPassword(@Body() body: ForgotPasswordBody) {
-    await this.authService.sendPasswordResetEmail(body.email);
+    const email = body.email.trim().toLowerCase();
+    await this.authService.sendPasswordResetEmail(email);
     return { success: true, message: 'If this email is registered, a password reset link has been sent.' };
   }
 

--- a/backend/src/modules/auth/services/FirebaseAuthService.ts
+++ b/backend/src/modules/auth/services/FirebaseAuthService.ts
@@ -397,12 +397,16 @@ export class FirebaseAuthService extends BaseService implements IAuthService {
   }
 
   async sendVerificationEmail(email: string): Promise<void> {
+    const normalizedEmail = email.trim().toLowerCase();
     try {
-      if (appConfig.isDevelopment) return;
-      const link = await this.auth.generateEmailVerificationLink(email);
+      if (appConfig.isDevelopment) {
+        console.log(`[dev] Skipping verification email to ${normalizedEmail}`);
+        return;
+      }
+      const link = await this.auth.generateEmailVerificationLink(normalizedEmail);
 
       await sendEmailNotification(
-        email,
+        normalizedEmail,
         'Verify your email',
         `Please verify your email by clicking on the link below: ${link}
 
@@ -425,20 +429,24 @@ If you face any issues, please contact the admin.`,
     </p>
   `,
       );
-      console.log(`Verification email sent successfully to ${email}`);
+      console.log(`Verification email sent successfully to ${normalizedEmail}`);
     } catch (err: any) {
-      console.error(`Failed to send verification email to ${email}:`, err);
+      console.error(`Failed to send verification email to ${normalizedEmail}:`, err);
       throw new BadRequestError(`Failed to send verification email: ${err.message || 'Unknown error'}`);
     }
   }
 
   async sendPasswordResetEmail(email: string): Promise<void> {
+    const normalizedEmail = email.trim().toLowerCase();
     try {
-      if (appConfig.isDevelopment) return;
-      const link = await this.auth.generatePasswordResetLink(email);
+      if (appConfig.isDevelopment) {
+        console.log(`[dev] Skipping password reset email to ${normalizedEmail}`);
+        return;
+      }
+      const link = await this.auth.generatePasswordResetLink(normalizedEmail);
 
       await sendEmailNotification(
-        email,
+        normalizedEmail,
         'Reset your password',
         `Reset your password by clicking on the link below: ${link}`,
         `<p>We received a request to reset your password.</p>
@@ -446,10 +454,15 @@ If you face any issues, please contact the admin.`,
          <p><a href="${link}">Reset Password</a></p>
          <p>If you didn't request this, you can safely ignore this email.</p>`,
       );
-      console.log(`Password reset email sent successfully to ${email}`);
+      console.log(`Password reset email sent successfully to ${normalizedEmail}`);
     } catch (err: any) {
-      // Silently fail — don't reveal whether the email exists
-      console.error(`Failed to send password reset email to ${email}:`, err);
+      if (err.code === 'auth/user-not-found') {
+        // Silently fail — don't reveal whether the email exists
+        console.warn(`[auth] Password reset requested for unregistered email: ${normalizedEmail}`);
+        return;
+      }
+      console.error(`Failed to send password reset email to ${normalizedEmail}:`, err);
+      throw err;
     }
   }
 }

--- a/backend/src/utils/mailer.ts
+++ b/backend/src/utils/mailer.ts
@@ -21,11 +21,6 @@ const SMTP_SECURE = env('SMTP_SECURE')
   ? String(env('SMTP_SECURE')).toLowerCase() === 'true'
   : SMTP_PORT === 465;
 
-// const SMTP_SECURE =
-//   env('SMTP_SECURE') !== undefined
-//     ? String(env('SMTP_SECURE')).toLowerCase() === 'true'
-//     : true; // 465 is implicit TLS — preserve legacy behaviour
-
 /**
  * Builds the nodemailer transport options. When neither `EMAIL_USER` nor
  * `EMAIL_PASS` is configured we return `null` so callers can short-circuit
@@ -60,10 +55,10 @@ export async function sendEmailNotification(
 ) {
   const transportOptions = buildTransportOptions();
   if (!transportOptions) {
-    console.warn(
-      '[mailer] EMAIL_USER/EMAIL_PASS not configured — skipping email.',
-    );
-    return;
+    const errorMsg =
+      '[mailer] EMAIL_USER/EMAIL_PASS not configured — skipping email.';
+    console.warn(errorMsg);
+    throw new Error(errorMsg);
   }
 
   const transporter = nodemailer.createTransport(transportOptions);
@@ -104,10 +99,10 @@ export async function sendEmailWithAttachment(
 ) {
   const transportOptions = buildTransportOptions();
   if (!transportOptions) {
-    console.warn(
-      '[mailer] EMAIL_USER/EMAIL_PASS not configured — skipping email.',
-    );
-    return;
+    const errorMsg =
+      '[mailer] EMAIL_USER/EMAIL_PASS not configured — skipping email.';
+    console.warn(errorMsg);
+    throw new Error(errorMsg);
   }
 
   const transporter = nodemailer.createTransport(transportOptions);


### PR DESCRIPTION
## Summary

Fixes the issue in production where the **Forgot Password** flow does not trigger emails. 

While PR #1318 addressed the initial `SMTP_SECURE` port calculation, several critical issues remained that caused password reset emails to fail silently or fail on valid requests:
1. Leftover commented-out code in `mailer.ts`.
2. Silent failure in `sendEmailNotification` when credentials are not configured (it logged a warning and returned without throwing, causing the auth service to falsely log and report success).
3. Email inputs were not sanitized in `AuthController.ts` and `FirebaseAuthService.ts`. Trailing whitespace or uppercase letters from mobile auto-fill caused Firebase Auth lookup errors.
4. Total error swallowing in `FirebaseAuthService.ts` masked transport, socket, and configuration errors, preventing operators and error tracking (Sentry) from diagnosing mail delivery failures.

---

## Changes

### 1. `backend/src/utils/mailer.ts`
- Cleaned up leftover commented-out code from #1318.
- Added explicit error throwing in `sendEmailNotification` and `sendEmailWithAttachment` when `buildTransportOptions()` returns `null` (missing credentials) to prevent false-positive success reporting.

### 2. `backend/src/modules/auth/controllers/AuthController.ts`
- Added `.trim().toLowerCase()` to `body.email` in `/forgot-password` before passing it to `sendPasswordResetEmail`.

### 3. `backend/src/modules/auth/services/FirebaseAuthService.ts`
- Applied `.trim().toLowerCase()` to email inputs in `sendPasswordResetEmail` and `sendVerificationEmail`.
- Added clear development mode logging when emails are skipped (`[dev] Skipping password reset email...`).
- Differentiated `auth/user-not-found` (expected for non-existent users; safely logged at `warn` level to prevent email enumeration) from genuine infrastructure/transport errors (logged at `error` level and re-thrown).

---

## Verification

- **TypeScript Compilation**: `pnpm run build` ran and completed with exit code `0`.
- **Rebase**: Cleanly rebased on top of `origin/main` (including commit `973de9ee7`).